### PR TITLE
feat: Add lexer and parser implementation

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,389 @@
+use std::fmt;
+
+/// Represents a location in the source code
+#[derive(Debug, Clone, PartialEq)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+    pub line: usize,
+    pub column: usize,
+}
+
+/// Represents a node in the AST with location information
+#[derive(Debug, Clone)]
+pub struct Node<T> {
+    pub span: Span,
+    pub node: T,
+}
+
+/// Represents a type in WFL
+#[derive(Debug, Clone, PartialEq)]
+pub enum Type {
+    Number,
+    Text,
+    Truth,
+    List(Box<Type>),
+    Map(Box<Type>, Box<Type>),
+    Set(Box<Type>),
+    Record(Vec<(String, Type)>),
+    Action(Vec<Type>, Box<Type>), // Parameter types and return type
+    Any,
+    Generic(String),              // For generic type parameters
+}
+
+/// Represents a literal value
+#[derive(Debug, Clone, PartialEq)]
+pub enum Literal {
+    Number(f64),
+    Text(String),
+    Truth(bool),
+    Nothing,
+    Missing,
+    Undefined,
+    Empty,
+}
+
+/// Represents an operator
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operator {
+    // Arithmetic
+    Plus,
+    Minus,
+    Multiply,
+    Divide,
+    Modulo,
+
+    // Comparison
+    Equals,
+    NotEquals,
+    Greater,
+    Less,
+    GreaterEquals,
+    LessEquals,
+    Between,
+    OneOf,
+
+    // Logical
+    And,
+    Or,
+    Not,
+
+    // Collection
+    Join,
+    Contains,
+    At,
+}
+
+/// Represents an expression
+#[derive(Debug, Clone)]
+pub enum Expression {
+    Literal(Literal),
+    Variable(String),
+    BinaryOp {
+        left: Box<Node<Expression>>,
+        op: Operator,
+        right: Box<Node<Expression>>,
+    },
+    UnaryOp {
+        op: Operator,
+        expr: Box<Node<Expression>>,
+    },
+    Call {
+        action: Box<Node<Expression>>,
+        args: Vec<Node<Expression>>,
+        named_args: Vec<(String, Node<Expression>)>,
+    },
+    Access {
+        object: Box<Node<Expression>>,
+        field: String,
+    },
+    List(Vec<Node<Expression>>),
+    Map(Vec<(Node<Expression>, Node<Expression>)>),
+    Set(Vec<Node<Expression>>),
+    Record(Vec<(String, Node<Expression>)>),
+}
+
+/// Represents a pattern in pattern matching
+#[derive(Debug, Clone)]
+pub enum Pattern {
+    Literal(Literal),
+    Variable(String),
+    List(Vec<Node<Pattern>>),
+    Record(Vec<(String, Node<Pattern>)>),
+    TypePattern {
+        type_name: Type,
+        constraints: Vec<Node<Expression>>,
+    },
+}
+
+/// Represents a statement
+#[derive(Debug, Clone)]
+pub enum Statement {
+    Store {
+        name: String,
+        value: Node<Expression>,
+        type_annotation: Option<Type>,
+    },
+    Assign {
+        target: Node<Expression>,
+        value: Node<Expression>,
+    },
+    If {
+        condition: Node<Expression>,
+        then_block: Vec<Node<Statement>>,
+        else_block: Option<Vec<Node<Statement>>>,
+    },
+    Check {
+        value: Node<Expression>,
+        patterns: Vec<(Node<Pattern>, Vec<Node<Statement>>)>,
+        else_block: Option<Vec<Node<Statement>>>,
+    },
+    ForEach {
+        item: String,
+        collection: Node<Expression>,
+        body: Vec<Node<Statement>>,
+    },
+    While {
+        condition: Node<Expression>,
+        body: Vec<Node<Statement>>,
+    },
+    Until {
+        condition: Node<Expression>,
+        body: Vec<Node<Statement>>,
+    },
+    Try {
+        body: Vec<Node<Statement>>,
+        catch_blocks: Vec<(Pattern, Vec<Node<Statement>>)>,
+        finally_block: Option<Vec<Node<Statement>>>,
+    },
+    Return(Node<Expression>),
+    Break(Option<String>),        // Optional label
+    Continue(Option<String>),     // Optional label
+    Expression(Node<Expression>), // For expression statements
+}
+
+/// Represents a parameter in an action declaration
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    pub name: String,
+    pub type_annotation: Option<Type>,
+    pub default_value: Option<Node<Expression>>,
+}
+
+/// Represents visibility level
+#[derive(Debug, Clone, PartialEq)]
+pub enum Visibility {
+    Public,
+    Private,
+    Protected,
+}
+
+/// Represents a declaration
+#[derive(Debug, Clone)]
+pub enum Declaration {
+    Action {
+        name: String,
+        visibility: Visibility,
+        generic_params: Vec<String>,
+        params: Vec<Parameter>,
+        return_type: Option<Type>,
+        body: Vec<Node<Statement>>,
+    },
+    Container {
+        name: String,
+        visibility: Visibility,
+        generic_params: Vec<String>,
+        extends: Option<Type>,
+        implements: Vec<Type>,
+        fields: Vec<(String, Type, Visibility)>,
+        methods: Vec<Node<Declaration>>,
+    },
+    Interface {
+        name: String,
+        visibility: Visibility,
+        generic_params: Vec<String>,
+        extends: Vec<Type>,
+        methods: Vec<(String, Vec<Parameter>, Option<Type>)>,
+    },
+}
+
+/// Represents a complete WFL program
+#[derive(Debug)]
+pub struct Program {
+    pub declarations: Vec<Node<Declaration>>,
+}
+
+// Implement Display for better error messages
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Type::Number => write!(f, "number"),
+            Type::Text => write!(f, "text"),
+            Type::Truth => write!(f, "truth"),
+            Type::List(t) => write!(f, "list of {}", t),
+            Type::Map(k, v) => write!(f, "map from {} to {}", k, v),
+            Type::Set(t) => write!(f, "set of {}", t),
+            Type::Record(fields) => {
+                write!(f, "record {{")?;
+                for (i, (name, typ)) in fields.iter().enumerate() {
+                    if i > 0 { write!(f, ", ")? }
+                    write!(f, "{}: {}", name, typ)?;
+                }
+                write!(f, "}}")
+            }
+            Type::Action(params, ret) => {
+                write!(f, "action(")?;
+                for (i, param) in params.iter().enumerate() {
+                    if i > 0 { write!(f, ", ")? }
+                    write!(f, "{}", param)?;
+                }
+                write!(f, ") giving {}", ret)
+            }
+            Type::Any => write!(f, "any"),
+            Type::Generic(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_type_display() {
+        assert_eq!(Type::Number.to_string(), "number");
+        assert_eq!(Type::Text.to_string(), "text");
+        assert_eq!(Type::Truth.to_string(), "truth");
+        assert_eq!(Type::List(Box::new(Type::Number)).to_string(), "list of number");
+        assert_eq!(
+            Type::Map(Box::new(Type::Text), Box::new(Type::Number)).to_string(),
+            "map from text to number"
+        );
+        assert_eq!(Type::Set(Box::new(Type::Text)).to_string(), "set of text");
+        assert_eq!(
+            Type::Record(vec![
+                ("name".to_string(), Type::Text),
+                ("age".to_string(), Type::Number)
+            ]).to_string(),
+            "record {name: text, age: number}"
+        );
+        assert_eq!(
+            Type::Action(
+                vec![Type::Text, Type::Number],
+                Box::new(Type::Truth)
+            ).to_string(),
+            "action(text, number) giving truth"
+        );
+        assert_eq!(Type::Any.to_string(), "any");
+        assert_eq!(Type::Generic("T".to_string()).to_string(), "T");
+    }
+
+    #[test]
+    fn test_ast_node_creation() {
+        let span = Span {
+            start: 0,
+            end: 5,
+            line: 1,
+            column: 1,
+        };
+
+        // Test literal expression
+        let literal_expr = Node {
+            span: span.clone(),
+            node: Expression::Literal(Literal::Number(42.0)),
+        };
+
+        // Test binary operation
+        let binary_op = Node {
+            span: span.clone(),
+            node: Expression::BinaryOp {
+                left: Box::new(literal_expr.clone()),
+                op: Operator::Plus,
+                right: Box::new(Node {
+                    span: span.clone(),
+                    node: Expression::Literal(Literal::Number(1.0)),
+                }),
+            },
+        };
+
+        // Test statement
+        let store_stmt = Node {
+            span: span.clone(),
+            node: Statement::Store {
+                name: "x".to_string(),
+                value: binary_op.clone(),
+                type_annotation: Some(Type::Number),
+            },
+        };
+
+        // Verify the AST structure
+        if let Statement::Store { name, value, type_annotation } = &store_stmt.node {
+            assert_eq!(name, "x");
+            assert_eq!(type_annotation, &Some(Type::Number));
+            
+            if let Expression::BinaryOp { left, op, right } = &value.node {
+                assert!(matches!(op, Operator::Plus));
+                
+                if let Expression::Literal(Literal::Number(n)) = &left.node {
+                    assert_eq!(*n, 42.0);
+                } else {
+                    panic!("Expected number literal");
+                }
+                
+                if let Expression::Literal(Literal::Number(n)) = &right.node {
+                    assert_eq!(*n, 1.0);
+                } else {
+                    panic!("Expected number literal");
+                }
+            } else {
+                panic!("Expected binary operation");
+            }
+        } else {
+            panic!("Expected store statement");
+        }
+    }
+
+    #[test]
+    fn test_container_declaration() {
+        let span = Span {
+            start: 0,
+            end: 10,
+            line: 1,
+            column: 1,
+        };
+
+        let container = Node {
+            span: span.clone(),
+            node: Declaration::Container {
+                name: "Person".to_string(),
+                visibility: Visibility::Public,
+                generic_params: vec!["T".to_string()],
+                extends: None,
+                implements: vec![],
+                fields: vec![
+                    ("name".to_string(), Type::Text, Visibility::Private),
+                    ("age".to_string(), Type::Number, Visibility::Private),
+                ],
+                methods: vec![],
+            },
+        };
+
+        if let Declaration::Container {
+            name,
+            visibility,
+            generic_params,
+            fields,
+            ..
+        } = &container.node {
+            assert_eq!(name, "Person");
+            assert_eq!(visibility, &Visibility::Public);
+            assert_eq!(generic_params, &vec!["T".to_string()]);
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].0, "name");
+            assert_eq!(fields[0].1, Type::Text);
+            assert_eq!(fields[0].2, Visibility::Private);
+        } else {
+            panic!("Expected container declaration");
+        }
+    }
+}

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -10,6 +10,7 @@ pub struct Lexer {
     column: usize,
     indent_stack: Vec<usize>,
     keywords: HashMap<String, TokenType>,
+    start_position: usize,  // Track start of current token
 }
 
 impl Lexer {
@@ -40,6 +41,38 @@ impl Lexer {
         keywords.insert("missing".to_string(), TokenType::Missing);
         keywords.insert("undefined".to_string(), TokenType::Undefined);
         keywords.insert("empty".to_string(), TokenType::Empty);
+        
+        // Access modifiers
+        keywords.insert("public".to_string(), TokenType::Public);
+        keywords.insert("private".to_string(), TokenType::Private);
+        keywords.insert("protected".to_string(), TokenType::Protected);
+        
+        // Container-related
+        keywords.insert("container".to_string(), TokenType::Container);
+        keywords.insert("from".to_string(), TokenType::From);
+        keywords.insert("interface".to_string(), TokenType::Interface);
+        keywords.insert("implements".to_string(), TokenType::Implements);
+        
+        // Type-related
+        keywords.insert("any".to_string(), TokenType::Any);
+        keywords.insert("of".to_string(), TokenType::Of);
+        keywords.insert("type".to_string(), TokenType::Type);
+        
+        // Operators
+        keywords.insert("join".to_string(), TokenType::Join);
+        keywords.insert("to".to_string(), TokenType::To);
+        keywords.insert("into".to_string(), TokenType::Into);
+        keywords.insert("at".to_string(), TokenType::At);
+        keywords.insert("where".to_string(), TokenType::Where);
+        keywords.insert("contains".to_string(), TokenType::Contains);
+        keywords.insert("matches".to_string(), TokenType::Matches);
+        keywords.insert("between".to_string(), TokenType::Between);
+        keywords.insert("one".to_string(), TokenType::OneOf); // "one of" is handled specially
+        
+        // Logical operators
+        keywords.insert("and".to_string(), TokenType::And);
+        keywords.insert("or".to_string(), TokenType::Or);
+        keywords.insert("not".to_string(), TokenType::Not);
 
         let source_chars: Vec<char> = source.chars().collect();
 
@@ -50,16 +83,13 @@ impl Lexer {
             column: 1,
             indent_stack: vec![0],
             keywords,
+            start_position: 0,
         }
     }
 
     // Helper methods
     fn is_whitespace(c: char) -> bool {
         c.is_whitespace()
-    }
-
-    fn is_alpha(c: char) -> bool {
-        c.is_alphabetic()
     }
 
     fn is_digit(c: char) -> bool {
@@ -141,16 +171,26 @@ impl Lexer {
             self.column
         };
 
-        Token {
+        Token::new(
             token_type,
-            value: value.clone(),
-            line: self.line,
+            value.clone(),
+            self.line,
             column,
-        }
+            self.start_position..self.position,
+        )
+    }
+
+    fn create_error(&self, message: String) -> Token {
+        Token::error(
+            message,
+            self.line,
+            self.column,
+            self.start_position..self.position,
+        )
     }
 
     fn scan_identifier(&mut self) -> Token {
-        let start_position = self.position;
+        self.start_position = self.position;
         while let Some(c) = self.peek() {
             if Self::is_identifier_part(c) {
                 self.advance();
@@ -159,15 +199,70 @@ impl Lexer {
             }
         }
 
-        let value: String = self.source[start_position..self.position].iter().collect();
+        let value: String = self.source[self.start_position..self.position].iter().collect();
         let lower_value = value.to_lowercase();
+
+        // Check for compound tokens
+        if lower_value == "one" {
+            self.skip_whitespace();
+            if let Some(next_word) = self.peek_word() {
+                if next_word.to_lowercase() == "of" {
+                    // Consume "of"
+                    for _ in 0..next_word.len() {
+                        self.advance();
+                    }
+                    return self.create_token(TokenType::OneOf, "one of".to_string());
+                }
+            }
+        } else if lower_value == "is" {
+            self.skip_whitespace();
+            if let Some(next_word) = self.peek_word() {
+                let next_lower = next_word.to_lowercase();
+                if next_lower == "not" {
+                    // Consume "not"
+                    for _ in 0..next_word.len() {
+                        self.advance();
+                    }
+                    return self.create_token(TokenType::NotEquals, "is not".to_string());
+                } else if next_lower == "between" {
+                    // Consume "between"
+                    for _ in 0..next_word.len() {
+                        self.advance();
+                    }
+                    return self.create_token(TokenType::Between, "is between".to_string());
+                }
+            }
+            return self.create_token(TokenType::Equals, "is".to_string());
+        }
 
         let token_type = self.keywords.get(&lower_value).cloned().unwrap_or(TokenType::Identifier);
         self.create_token(token_type, value)
     }
 
+    fn peek_word(&mut self) -> Option<String> {
+        let mut pos = self.position;
+        let mut word = String::new();
+        
+        // Skip any whitespace
+        while pos < self.source.len() && Self::is_whitespace(self.source[pos]) {
+            pos += 1;
+        }
+        
+        // Collect word characters
+        while pos < self.source.len() && Self::is_identifier_part(self.source[pos]) {
+            word.push(self.source[pos]);
+            pos += 1;
+        }
+        
+        if word.is_empty() {
+            None
+        } else {
+            Some(word)
+        }
+    }
+
     fn scan_number(&mut self) -> Token {
-        let start_position = self.position;
+        self.start_position = self.position;
         let mut has_decimal_point = false;
 
         while let Some(c) = self.peek() {
@@ -183,31 +278,88 @@ impl Lexer {
             self.advance();
         }
 
-        let value: String = self.source[start_position..self.position].iter().collect();
+        let value: String = self.source[self.start_position..self.position].iter().collect();
         self.create_token(TokenType::NumberLiteral, value)
     }
 
     fn scan_string(&mut self) -> Token {
+        self.start_position = self.position;
         self.advance(); // Skip opening quote
-        let start_position = self.position;
-        while let Some(c) = self.peek() {
-            if c == '"' {
-                break;
-            } else {
-                self.advance();
+        let mut value = String::new();
+        let mut escaped = false;
+
+        loop {
+            match self.peek() {
+                None => {
+                    return self.create_error("Unterminated string literal".to_string());
+                }
+                Some('\\') if !escaped => {
+                    escaped = true;
+                    self.advance();
+                }
+                Some('"') if !escaped => {
+                    self.advance(); // Skip closing quote
+                    break;
+                }
+                Some('n') if escaped => {
+                    value.push('\n');
+                    escaped = false;
+                    self.advance();
+                }
+                Some('t') if escaped => {
+                    value.push('\t');
+                    escaped = false;
+                    self.advance();
+                }
+                Some('r') if escaped => {
+                    value.push('\r');
+                    escaped = false;
+                    self.advance();
+                }
+                Some('\\') if escaped => {
+                    value.push('\\');
+                    escaped = false;
+                    self.advance();
+                }
+                Some('"') if escaped => {
+                    value.push('"');
+                    escaped = false;
+                    self.advance();
+                }
+                Some('_') if escaped => {
+                    // Line continuation
+                    escaped = false;
+                    self.advance();
+                    // Skip whitespace until newline
+                    while let Some(c) = self.peek() {
+                        if c == '\n' {
+                            self.advance();
+                            break;
+                        } else if !Self::is_whitespace(c) {
+                            return self.create_error("Only whitespace allowed after line continuation".to_string());
+                        }
+                        self.advance();
+                    }
+                    // Skip whitespace after newline
+                    self.skip_whitespace();
+                }
+                Some(c) if escaped => {
+                    return self.create_error(format!("Invalid escape sequence: \\{}", c));
+                }
+                Some(c) => {
+                    value.push(c);
+                    self.advance();
+                }
             }
         }
-        let value: String = self.source[start_position..self.position].iter().collect();
-        if self.peek() == Some('"') {
-            self.advance(); // Skip closing quote
-        }
+
         self.create_token(TokenType::StringLiteral, value)
     }
 
     fn scan_comment(&mut self) -> Token {
+        self.start_position = self.position;
         self.advance(); // Skip first '/'
         self.advance(); // Skip second '/'
-        let start_position = self.position;
         while let Some(c) = self.peek() {
             if c == '\n' {
                 break;
@@ -215,7 +367,7 @@ impl Lexer {
                 self.advance();
             }
         }
-        let value: String = self.source[start_position..self.position].iter().collect();
+        let value: String = self.source[self.start_position..self.position].iter().collect();
         self.create_token(TokenType::Comment, value.trim().to_string())
     }
 
@@ -236,7 +388,7 @@ impl Lexer {
             Some(c) if Self::is_identifier_start(c) => self.scan_identifier(),
             Some('/') if self.peek_next() == Some('/') => self.scan_comment(),
             Some(c) => {
-                // Handle single-character tokens
+                // Handle single-character tokens and brackets
                 let token_type = match c {
                     ':' => TokenType::Colon,
                     ',' => TokenType::Comma,
@@ -246,9 +398,17 @@ impl Lexer {
                     '*' => TokenType::Multiply,
                     '/' => TokenType::Divide,
                     '%' => TokenType::Modulo,
+                    '{' => TokenType::LeftBrace,
+                    '}' => TokenType::RightBrace,
+                    '[' => TokenType::LeftBracket,
+                    ']' => TokenType::RightBracket,
+                    '(' => TokenType::LeftParen,
+                    ')' => TokenType::RightParen,
                     _ => {
-                        self.advance(); // Skip unknown character
-                        return self.next_token();
+                        // Handle unknown character
+                        let message = format!("Unexpected character: {}", c);
+                        self.advance();
+                        return self.create_error(message);
                     }
                 };
                 self.advance();
@@ -283,5 +443,119 @@ impl Lexer {
         }
         
         tokens
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn get_token_types(tokens: Vec<Token>) -> Vec<TokenType> {
+        tokens.iter()
+            .filter(|t| t.token_type != TokenType::EOF)
+            .map(|t| t.token_type.clone())
+            .collect()
+    }
+
+    #[test]
+    fn test_basic_tokens() {
+        let source = "define action called test";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        assert_eq!(tokens[0].token_type, TokenType::Define);
+        assert_eq!(tokens[1].token_type, TokenType::Action);
+        assert_eq!(tokens[2].token_type, TokenType::Called);
+        assert_eq!(tokens[3].token_type, TokenType::Identifier);
+    }
+
+    #[test]
+    fn test_string_literals() {
+        let source = r#"store message as "Hello\nWorld\t\"quoted\"\\_continued""#;
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        assert_eq!(tokens[0].token_type, TokenType::Store);
+        assert_eq!(tokens[1].token_type, TokenType::Identifier);
+        assert_eq!(tokens[2].token_type, TokenType::As);
+        assert_eq!(tokens[3].token_type, TokenType::StringLiteral);
+        assert_eq!(tokens[3].value, "Hello\nWorld\t\"quoted\"\\_continued");
+    }
+
+    #[test]
+    fn test_compound_tokens() {
+        let source = "check if value is not between 1 and 10 or is one of options";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        let types = get_token_types(tokens);
+        assert_eq!(types, vec![
+            TokenType::Check,
+            TokenType::If,
+            TokenType::Identifier,
+            TokenType::NotEquals,
+            TokenType::Between,
+            TokenType::NumberLiteral,
+            TokenType::And,
+            TokenType::NumberLiteral,
+            TokenType::Or,
+            TokenType::Equals,
+            TokenType::OneOf,
+            TokenType::Identifier,
+        ]);
+    }
+
+    #[test]
+    fn test_indentation() {
+        let source = "if true:\n    action\n        nested\n    back\nend if";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        let types = get_token_types(tokens);
+        assert!(types.contains(&TokenType::Indent));
+        assert!(types.contains(&TokenType::Dedent));
+        
+        // Count indents and dedents
+        let indent_count = types.iter().filter(|&t| *t == TokenType::Indent).count();
+        let dedent_count = types.iter().filter(|&t| *t == TokenType::Dedent).count();
+        assert_eq!(indent_count, dedent_count);
+    }
+
+    #[test]
+    fn test_error_handling() {
+        let source = "\"unterminated string";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        assert_eq!(tokens[0].token_type, TokenType::Error);
+        assert!(tokens[0].error.is_some());
+        assert_eq!(tokens[0].error.as_ref().unwrap(), "Unterminated string literal");
+    }
+
+    #[test]
+    fn test_numbers() {
+        let source = "42 3.14 1000000";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        let types = get_token_types(tokens);
+        
+        assert_eq!(types[0], TokenType::NumberLiteral);
+        assert_eq!(types[1], TokenType::NumberLiteral);
+        assert_eq!(types[2], TokenType::NumberLiteral);
+    }
+
+    #[test]
+    fn test_comments() {
+        let source = "action // This is a comment\ncode // Another comment";
+        let mut lexer = Lexer::new(source.to_string());
+        let tokens = lexer.tokenize();
+        
+        let types = get_token_types(tokens);
+        assert_eq!(types[0], TokenType::Action);
+        assert_eq!(types[1], TokenType::Comment);
+        assert_eq!(types[2], TokenType::Newline);
+        assert_eq!(types[3], TokenType::Identifier);
+        assert_eq!(types[4], TokenType::Comment);
     }
 }

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -26,6 +26,13 @@ pub enum TokenType {
     Try,
     Catch,
     Finally,
+    Public,
+    Private,
+    Protected,
+    Container,
+    From,
+    Interface,
+    Implements,
 
     // Data Types
     Number,
@@ -35,6 +42,9 @@ pub enum TokenType {
     Map,
     Set,
     Record,
+    Any,
+    Of,
+    Type,
 
     // Literals
     StringLiteral,     // "hello"
@@ -54,6 +64,13 @@ pub enum TokenType {
     Multiply,          // times, *
     Divide,            // divided by, /
     Modulo,            // modulo, %
+    Join,              // join
+    To,               // to
+    Into,             // into
+    At,               // at
+    Where,            // where
+    Contains,         // contains
+    Matches,          // matches
 
     // Comparison Operators
     Equals,            // is, =
@@ -62,6 +79,8 @@ pub enum TokenType {
     Less,              // is less than, <
     GreaterEquals,     // is at least, ≥
     LessEquals,        // is at most, ≤
+    Between,           // is between
+    OneOf,            // is one of
 
     // Logical Operators
     And,
@@ -73,6 +92,12 @@ pub enum TokenType {
     Comma,             // ,
     Dot,               // .
     Quotes,            // "
+    LeftBrace,         // {
+    RightBrace,        // }
+    LeftBracket,       // [
+    RightBracket,      // ]
+    LeftParen,         // (
+    RightParen,        // )
 
     // Special
     Comment,           // // Single line comment
@@ -80,12 +105,51 @@ pub enum TokenType {
     Indent,
     Dedent,
     EOF,
+    Error,            // For lexical errors
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Token {
     pub token_type: TokenType,
     pub value: String,
     pub line: usize,
     pub column: usize,
+    pub span: std::ops::Range<usize>,
+    pub error: Option<String>,  // For storing error messages
+}
+
+impl Token {
+    pub fn new(token_type: TokenType, value: String, line: usize, column: usize, span: std::ops::Range<usize>) -> Self {
+        Self {
+            token_type,
+            value,
+            line,
+            column,
+            span,
+            error: None,
+        }
+    }
+
+    pub fn error(message: String, line: usize, column: usize, span: std::ops::Range<usize>) -> Self {
+        Self {
+            token_type: TokenType::Error,
+            value: String::new(),
+            line,
+            column,
+            span,
+            error: Some(message),
+        }
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.token_type == TokenType::Error
+    }
+
+    pub fn location(&self) -> String {
+        format!("line {}, column {}", self.line, self.column)
+    }
+
+    pub fn span(&self) -> std::ops::Range<usize> {
+        self.span.clone()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,7 @@
 pub mod lexer;
+pub mod ast;
+pub mod parser;
+
 pub use lexer::Lexer;
+pub use ast::{Node, Span, Type, Expression, Statement, Declaration, Program};
+pub use parser::{WflParser, ParseError, ParseResult};

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,0 +1,1058 @@
+use chumsky::{prelude::*, Parser};
+use crate::ast::*;
+use crate::lexer::{Token, TokenType};
+
+/// Parser error type
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub span: Span,
+    pub message: String,
+}
+
+/// Parser result type
+pub type ParseResult<T> = Result<T, Vec<ParseError>>;
+
+/// Main parser struct
+pub struct WflParser {
+    // Configuration options can be added here
+}
+
+impl WflParser {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Parse a sequence of tokens into an AST
+    pub fn parse(&self, tokens: Vec<Token>) -> ParseResult<Program> {
+        let parser = program();
+        parser.parse(tokens)
+            .map_err(|errors| {
+                errors.into_iter()
+                    .map(|e| ParseError {
+                        span: Span {
+                            start: e.span().start,
+                            end: e.span().end,
+                            line: 0, // TODO: Calculate from token
+                            column: 0,
+                        },
+                        message: e.to_string(),
+                    })
+                    .collect()
+            })
+    }
+}
+
+/// Convert token span to AST span
+fn token_span(token: &Token) -> Span {
+    Span {
+        start: 0, // TODO: Track actual positions in lexer
+        end: 0,
+        line: token.line,
+        column: token.column,
+    }
+}
+
+/// Create a node with span information
+fn spanned<T>(span: Span, node: T) -> Node<T> {
+    Node { span, node }
+}
+
+/// Parse a literal value
+fn literal() -> impl Parser<Token, Node<Expression>, Error = Simple<Token>> {
+    filter_map(|span, token: Token| {
+        let literal = match token.token_type {
+            TokenType::NumberLiteral => {
+                Some(Literal::Number(token.value.parse().unwrap_or(0.0)))
+            }
+            TokenType::StringLiteral => {
+                Some(Literal::Text(token.value))
+            }
+            TokenType::TruthLiteral => {
+                let value = match token.value.to_lowercase().as_str() {
+                    "yes" | "true" => true,
+                    "no" | "false" => false,
+                    _ => false,
+                };
+                Some(Literal::Truth(value))
+            }
+            TokenType::Nothing => Some(Literal::Nothing),
+            TokenType::Missing => Some(Literal::Missing),
+            TokenType::Undefined => Some(Literal::Undefined),
+            TokenType::Empty => Some(Literal::Empty),
+            _ => None,
+        };
+        
+        literal.map(|lit| {
+            spanned(
+                token_span(&span),
+                Expression::Literal(lit)
+            )
+        })
+    })
+}
+
+/// Parse a type expression
+fn type_expr() -> impl Parser<Token, Type, Error = Simple<Token>> {
+    recursive(|type_expr| {
+        let simple_type = select! {
+            TokenType::Number => Type::Number,
+            TokenType::Text => Type::Text,
+            TokenType::Truth => Type::Truth,
+            TokenType::Any => Type::Any,
+        };
+
+        let generic_type = just(TokenType::Identifier)
+            .map(|token| Type::Generic(token.value));
+
+        let list_type = just(TokenType::List)
+            .ignore_then(just(TokenType::Of))
+            .ignore_then(type_expr.clone())
+            .map(|elem_type| Type::List(Box::new(elem_type)));
+
+        let map_type = just(TokenType::Map)
+            .ignore_then(just(TokenType::From))
+            .ignore_then(type_expr.clone())
+            .then_ignore(just(TokenType::To))
+            .then(type_expr.clone())
+            .map(|(key_type, value_type)| {
+                Type::Map(Box::new(key_type), Box::new(value_type))
+            });
+
+        let set_type = just(TokenType::Set)
+            .ignore_then(just(TokenType::Of))
+            .ignore_then(type_expr.clone())
+            .map(|elem_type| Type::Set(Box::new(elem_type)));
+
+        let record_type = just(TokenType::Record)
+            .ignore_then(just(TokenType::LeftBrace))
+            .ignore_then(
+                just(TokenType::Identifier)
+                    .then_ignore(just(TokenType::Colon))
+                    .then(type_expr.clone())
+                    .separated_by(just(TokenType::Comma))
+            )
+            .then_ignore(just(TokenType::RightBrace))
+            .map(|fields| {
+                Type::Record(
+                    fields
+                        .into_iter()
+                        .map(|(name, typ)| (name.value, typ))
+                        .collect()
+                )
+            });
+
+        let action_type = just(TokenType::Action)
+            .ignore_then(just(TokenType::LeftParen))
+            .ignore_then(
+                type_expr
+                    .clone()
+                    .separated_by(just(TokenType::Comma))
+            )
+            .then_ignore(just(TokenType::RightParen))
+            .then_ignore(just(TokenType::Give))
+            .then_ignore(just(TokenType::Back))
+            .then(type_expr)
+            .map(|(params, ret)| Type::Action(params, Box::new(ret)));
+
+        choice((
+            simple_type,
+            generic_type,
+            list_type,
+            map_type,
+            set_type,
+            record_type,
+            action_type,
+        ))
+    })
+}
+
+/// Parse an expression
+fn expression() -> impl Parser<Token, Node<Expression>, Error = Simple<Token>> {
+    recursive(|expr| {
+        let atom = literal()
+            .or(just(TokenType::Identifier).map_with_span(|token, span| {
+                spanned(
+                    token_span(&span),
+                    Expression::Variable(token.value)
+                )
+            }));
+
+        let list = just(TokenType::LeftBracket)
+            .ignore_then(expr.clone().separated_by(just(TokenType::Comma)))
+            .then_ignore(just(TokenType::RightBracket))
+            .map_with_span(|items, span| {
+                spanned(token_span(&span), Expression::List(items))
+            });
+
+        let map = just(TokenType::LeftBrace)
+            .ignore_then(
+                expr.clone()
+                    .then_ignore(just(TokenType::Colon))
+                    .then(expr.clone())
+                    .separated_by(just(TokenType::Comma))
+            )
+            .then_ignore(just(TokenType::RightBrace))
+            .map_with_span(|pairs, span| {
+                spanned(token_span(&span), Expression::Map(pairs))
+            });
+
+        let set = just(TokenType::Set)
+            .ignore_then(just(TokenType::LeftBrace))
+            .ignore_then(expr.clone().separated_by(just(TokenType::Comma)))
+            .then_ignore(just(TokenType::RightBrace))
+            .map_with_span(|items, span| {
+                spanned(token_span(&span), Expression::Set(items))
+            });
+
+        let record = just(TokenType::Record)
+            .ignore_then(just(TokenType::LeftBrace))
+            .ignore_then(
+                just(TokenType::Identifier)
+                    .then_ignore(just(TokenType::Is))
+                    .then(expr.clone())
+                    .separated_by(just(TokenType::Comma))
+            )
+            .then_ignore(just(TokenType::RightBrace))
+            .map_with_span(|fields, span| {
+                spanned(
+                    token_span(&span),
+                    Expression::Record(
+                        fields
+                            .into_iter()
+                            .map(|(name, value)| (name.value, value))
+                            .collect()
+                    )
+                )
+            });
+
+        let call = atom
+            .clone()
+            .then(
+                expr.clone()
+                    .or(
+                        just(TokenType::Identifier)
+                            .then_ignore(just(TokenType::Is))
+                            .then(expr.clone())
+                            .map(|(name, value)| {
+                                (name.value, value)
+                            })
+                    )
+                    .repeated()
+            )
+            .map_with_span(|(func, args), span| {
+                let (positional, named): (Vec<_>, Vec<_>) = args
+                    .into_iter()
+                    .partition(|arg| matches!(arg, Node { .. }));
+                
+                spanned(
+                    token_span(&span),
+                    Expression::Call {
+                        action: Box::new(func),
+                        args: positional,
+                        named_args: named,
+                    }
+                )
+            });
+
+        let access = atom
+            .clone()
+            .then(
+                just(TokenType::Dot)
+                    .ignore_then(just(TokenType::Identifier))
+                    .repeated()
+            )
+            .map_with_span(|(obj, fields), span| {
+                fields.into_iter().fold(obj, |acc, field| {
+                    spanned(
+                        token_span(&span),
+                        Expression::Access {
+                            object: Box::new(acc),
+                            field: field.value,
+                        }
+                    )
+                })
+            });
+
+        // Define operator precedence
+        let op = choice((
+            just(TokenType::Plus).to(Operator::Plus),
+            just(TokenType::Minus).to(Operator::Minus),
+            just(TokenType::Multiply).to(Operator::Multiply),
+            just(TokenType::Divide).to(Operator::Divide),
+            just(TokenType::Modulo).to(Operator::Modulo),
+            just(TokenType::Equals).to(Operator::Equals),
+            just(TokenType::NotEquals).to(Operator::NotEquals),
+            just(TokenType::Greater).to(Operator::Greater),
+            just(TokenType::Less).to(Operator::Less),
+            just(TokenType::GreaterEquals).to(Operator::GreaterEquals),
+            just(TokenType::LessEquals).to(Operator::LessEquals),
+            just(TokenType::And).to(Operator::And),
+            just(TokenType::Or).to(Operator::Or),
+        ));
+
+        let unary = just(TokenType::Not)
+            .map(|_| Operator::Not)
+            .then(atom.clone())
+            .map_with_span(|(op, expr), span| {
+                spanned(
+                    token_span(&span),
+                    Expression::UnaryOp {
+                        op,
+                        expr: Box::new(expr),
+                    }
+                )
+            });
+
+        let binary = unary
+            .clone()
+            .then(op.then(unary).repeated())
+            .map_with_span(|(first, rest), span| {
+                rest.into_iter().fold(first, |acc, (op, right)| {
+                    spanned(
+                        token_span(&span),
+                        Expression::BinaryOp {
+                            left: Box::new(acc),
+                            op,
+                            right: Box::new(right),
+                        }
+                    )
+                })
+            });
+
+        choice((
+            binary,
+            unary,
+            call,
+            access,
+            list,
+            map,
+            set,
+            record,
+            atom,
+        ))
+    })
+}
+
+/// Parse a pattern
+fn pattern() -> impl Parser<Token, Node<Pattern>, Error = Simple<Token>> {
+    recursive(|pattern| {
+        let literal_pattern = literal().map_with_span(|expr, span| {
+            if let Expression::Literal(lit) = expr.node {
+                spanned(token_span(&span), Pattern::Literal(lit))
+            } else {
+                unreachable!()
+            }
+        });
+
+        let variable_pattern = just(TokenType::Identifier)
+            .map_with_span(|token, span| {
+                spanned(
+                    token_span(&span),
+                    Pattern::Variable(token.value)
+                )
+            });
+
+        let list_pattern = just(TokenType::LeftBracket)
+            .ignore_then(pattern.clone().separated_by(just(TokenType::Comma)))
+            .then_ignore(just(TokenType::RightBracket))
+            .map_with_span(|items, span| {
+                spanned(token_span(&span), Pattern::List(items))
+            });
+
+        let record_pattern = just(TokenType::LeftBrace)
+            .ignore_then(
+                just(TokenType::Identifier)
+                    .then_ignore(just(TokenType::Colon))
+                    .then(pattern.clone())
+                    .separated_by(just(TokenType::Comma))
+            )
+            .then_ignore(just(TokenType::RightBrace))
+            .map_with_span(|fields, span| {
+                spanned(
+                    token_span(&span),
+                    Pattern::Record(
+                        fields
+                            .into_iter()
+                            .map(|(name, pat)| (name.value, pat))
+                            .collect()
+                    )
+                )
+            });
+
+        let type_pattern = type_expr()
+            .then(
+                just(TokenType::Where)
+                    .ignore_then(expression())
+                    .repeated()
+            )
+            .map_with_span(|(typ, constraints), span| {
+                spanned(
+                    token_span(&span),
+                    Pattern::TypePattern {
+                        type_name: typ,
+                        constraints,
+                    }
+                )
+            });
+
+        choice((
+            literal_pattern,
+            variable_pattern,
+            list_pattern,
+            record_pattern,
+            type_pattern,
+        ))
+    })
+}
+
+/// Parse a statement
+fn statement() -> impl Parser<Token, Node<Statement>, Error = Simple<Token>> {
+    recursive(|stmt| {
+        let store = just(TokenType::Store)
+            .ignore_then(just(TokenType::Identifier))
+            .then_ignore(just(TokenType::As))
+            .then(expression())
+            .then(
+                just(TokenType::With)
+                    .ignore_then(just(TokenType::Type))
+                    .ignore_then(type_expr())
+                    .or_not()
+            )
+            .map_with_span(|((name, value), type_annotation), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Store {
+                        name: name.value,
+                        value,
+                        type_annotation,
+                    }
+                )
+            });
+
+        let assign = expression()
+            .then_ignore(just(TokenType::Equals))
+            .then(expression())
+            .map_with_span(|(target, value), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Assign { target, value }
+                )
+            });
+
+        let if_stmt = just(TokenType::If)
+            .ignore_then(expression())
+            .then_ignore(just(TokenType::Colon))
+            .then(stmt.clone().repeated())
+            .then(
+                just(TokenType::Otherwise)
+                    .ignore_then(just(TokenType::Colon))
+                    .ignore_then(stmt.clone().repeated())
+                    .or_not()
+            )
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::If))
+            .map_with_span(|((condition, then_block), else_block), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::If {
+                        condition,
+                        then_block,
+                        else_block,
+                    }
+                )
+            });
+
+        let check = just(TokenType::Check)
+            .ignore_then(expression())
+            .then_ignore(just(TokenType::Colon))
+            .then(
+                pattern()
+                    .then_ignore(just(TokenType::Then))
+                    .then(stmt.clone().repeated())
+                    .repeated()
+            )
+            .then(
+                just(TokenType::Otherwise)
+                    .ignore_then(just(TokenType::Colon))
+                    .ignore_then(stmt.clone().repeated())
+                    .or_not()
+            )
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::Check))
+            .map_with_span(|((value, patterns), else_block), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Check {
+                        value,
+                        patterns,
+                        else_block,
+                    }
+                )
+            });
+
+        let for_each = just(TokenType::For)
+            .ignore_then(just(TokenType::Each))
+            .ignore_then(just(TokenType::Identifier))
+            .then_ignore(just(TokenType::In))
+            .then(expression())
+            .then_ignore(just(TokenType::Colon))
+            .then(stmt.clone().repeated())
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::For))
+            .map_with_span(|((item, collection), body), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::ForEach {
+                        item: item.value,
+                        collection,
+                        body,
+                    }
+                )
+            });
+
+        let while_stmt = just(TokenType::While)
+            .ignore_then(expression())
+            .then_ignore(just(TokenType::Colon))
+            .then(stmt.clone().repeated())
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::While))
+            .map_with_span(|(condition, body), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::While { condition, body }
+                )
+            });
+
+        let until = just(TokenType::Until)
+            .ignore_then(expression())
+            .then_ignore(just(TokenType::Colon))
+            .then(stmt.clone().repeated())
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::Until))
+            .map_with_span(|(condition, body), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Until { condition, body }
+                )
+            });
+
+        let try_stmt = just(TokenType::Try)
+            .ignore_then(stmt.clone().repeated())
+            .then(
+                just(TokenType::Catch)
+                    .ignore_then(pattern())
+                    .then_ignore(just(TokenType::Colon))
+                    .then(stmt.clone().repeated())
+                    .repeated()
+            )
+            .then(
+                just(TokenType::Finally)
+                    .ignore_then(just(TokenType::Colon))
+                    .ignore_then(stmt.clone().repeated())
+                    .or_not()
+            )
+            .then_ignore(just(TokenType::End))
+            .then_ignore(just(TokenType::Try))
+            .map_with_span(|((body, catch_blocks), finally_block), span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Try {
+                        body,
+                        catch_blocks,
+                        finally_block,
+                    }
+                )
+            });
+
+        let return_stmt = just(TokenType::Give)
+            .ignore_then(just(TokenType::Back))
+            .ignore_then(expression())
+            .map_with_span(|value, span| {
+                spanned(token_span(&span), Statement::Return(value))
+            });
+
+        let break_stmt = just(TokenType::Break)
+            .ignore_then(just(TokenType::Identifier).or_not())
+            .map_with_span(|label, span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Break(label.map(|t| t.value))
+                )
+            });
+
+        let continue_stmt = just(TokenType::Continue)
+            .ignore_then(just(TokenType::Identifier).or_not())
+            .map_with_span(|label, span| {
+                spanned(
+                    token_span(&span),
+                    Statement::Continue(label.map(|t| t.value))
+                )
+            });
+
+        let expr_stmt = expression().map_with_span(|expr, span| {
+            spanned(token_span(&span), Statement::Expression(expr))
+        });
+
+        choice((
+            store,
+            assign,
+            if_stmt,
+            check,
+            for_each,
+            while_stmt,
+            until,
+            try_stmt,
+            return_stmt,
+            break_stmt,
+            continue_stmt,
+            expr_stmt,
+        ))
+    })
+}
+
+/// Parse a parameter list
+fn parameters() -> impl Parser<Token, Vec<Parameter>, Error = Simple<Token>> {
+    just(TokenType::LeftParen)
+        .ignore_then(
+            just(TokenType::Identifier)
+                .then(
+                    just(TokenType::With)
+                        .ignore_then(just(TokenType::Type))
+                        .ignore_then(type_expr())
+                        .or_not()
+                )
+                .then(
+                    just(TokenType::With)
+                        .ignore_then(just(TokenType::Default))
+                        .ignore_then(expression())
+                        .or_not()
+                )
+                .map(|((name, type_annotation), default_value)| Parameter {
+                    name: name.value,
+                    type_annotation,
+                    default_value: default_value.map(|e| Node {
+                        span: token_span(&e),
+                        node: e.node,
+                    }),
+                })
+                .separated_by(just(TokenType::Comma))
+        )
+        .then_ignore(just(TokenType::RightParen))
+}
+
+/// Parse a declaration
+fn declaration() -> impl Parser<Token, Node<Declaration>, Error = Simple<Token>> {
+    let visibility = choice((
+        just(TokenType::Public).to(Visibility::Public),
+        just(TokenType::Private).to(Visibility::Private),
+        just(TokenType::Protected).to(Visibility::Protected),
+    )).or_not().map(|v| v.unwrap_or(Visibility::Private));
+
+    let generic_params = just(TokenType::Of)
+        .ignore_then(just(TokenType::Type))
+        .ignore_then(just(TokenType::Identifier))
+        .map(|t| t.value)
+        .separated_by(just(TokenType::Comma))
+        .or_not()
+        .map(|v| v.unwrap_or_default());
+
+    let action = visibility
+        .then(just(TokenType::Define))
+        .ignore_then(just(TokenType::Action))
+        .ignore_then(just(TokenType::Called))
+        .ignore_then(just(TokenType::Identifier))
+        .then(generic_params.clone())
+        .then(parameters())
+        .then(
+            just(TokenType::Gives)
+                .ignore_then(just(TokenType::Back))
+                .ignore_then(type_expr())
+                .or_not()
+        )
+        .then_ignore(just(TokenType::Colon))
+        .then(statement().repeated())
+        .then_ignore(just(TokenType::End))
+        .then_ignore(just(TokenType::Action))
+        .map_with_span(
+            |((((((visibility, name), generic_params), params), return_type), body), span)| {
+                spanned(
+                    token_span(&span),
+                    Declaration::Action {
+                        name: name.value,
+                        visibility,
+                        generic_params,
+                        params,
+                        return_type,
+                        body,
+                    }
+                )
+            }
+        );
+
+    let container = visibility
+        .then(just(TokenType::Create))
+        .ignore_then(just(TokenType::Container))
+        .ignore_then(just(TokenType::Called))
+        .ignore_then(just(TokenType::Identifier))
+        .then(generic_params.clone())
+        .then(
+            just(TokenType::From)
+                .ignore_then(type_expr())
+                .or_not()
+        )
+        .then(
+            just(TokenType::Implements)
+                .ignore_then(type_expr())
+                .separated_by(just(TokenType::Comma))
+                .or_not()
+                .map(|v| v.unwrap_or_default())
+        )
+        .then_ignore(just(TokenType::Colon))
+        .then(
+            visibility
+                .then(just(TokenType::Identifier))
+                .then_ignore(just(TokenType::Is))
+                .then(type_expr())
+                .map(|((vis, name), typ)| (name.value, typ, vis))
+                .repeated()
+        )
+        .then(declaration().repeated())
+        .then_ignore(just(TokenType::End))
+        .then_ignore(just(TokenType::Container))
+        .map_with_span(
+            |(((((((visibility, name), generic_params), extends), implements), fields), methods), span)| {
+                spanned(
+                    token_span(&span),
+                    Declaration::Container {
+                        name: name.value,
+                        visibility,
+                        generic_params,
+                        extends,
+                        implements,
+                        fields,
+                        methods,
+                    }
+                )
+            }
+        );
+
+    let interface = visibility
+        .then(just(TokenType::Define))
+        .ignore_then(just(TokenType::Interface))
+        .ignore_then(just(TokenType::Called))
+        .ignore_then(just(TokenType::Identifier))
+        .then(generic_params)
+        .then(
+            just(TokenType::From)
+                .ignore_then(type_expr())
+                .separated_by(just(TokenType::Comma))
+                .or_not()
+                .map(|v| v.unwrap_or_default())
+        )
+        .then_ignore(just(TokenType::Colon))
+        .then(
+            just(TokenType::Action)
+                .ignore_then(just(TokenType::Called))
+                .ignore_then(just(TokenType::Identifier))
+                .then(parameters())
+                .then(
+                    just(TokenType::Gives)
+                        .ignore_then(just(TokenType::Back))
+                        .ignore_then(type_expr())
+                        .or_not()
+                )
+                .map(|((name, params), return_type)| {
+                    (name.value, params, return_type)
+                })
+                .repeated()
+        )
+        .then_ignore(just(TokenType::End))
+        .then_ignore(just(TokenType::Interface))
+        .map_with_span(
+            |((((visibility, name), generic_params), extends), methods), span| {
+                spanned(
+                    token_span(&span),
+                    Declaration::Interface {
+                        name: name.value,
+                        visibility,
+                        generic_params,
+                        extends,
+                        methods,
+                    }
+                )
+            }
+        );
+
+    choice((action, container, interface))
+}
+
+/// Parse a complete program
+fn program() -> impl Parser<Token, Program, Error = Simple<Token>> {
+    declaration()
+        .repeated()
+        .then_ignore(end())
+        .map(|declarations| Program { declarations })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Lexer;
+
+    fn parse_str(input: &str) -> ParseResult<Program> {
+        let mut lexer = Lexer::new(input.to_string());
+        let tokens = lexer.tokenize();
+        let parser = WflParser::new();
+        parser.parse(tokens)
+    }
+
+    #[test]
+    fn test_parse_literal() {
+        let input = r#"
+            define action called test:
+                store x as 42
+                store msg as "hello"
+                store flag as yes
+            end action
+        "#;
+        
+        let result = parse_str(input);
+        assert!(result.is_ok());
+        
+        let program = result.unwrap();
+        assert_eq!(program.declarations.len(), 1);
+        
+        if let Declaration::Action { body, .. } = &program.declarations[0].node {
+            assert_eq!(body.len(), 3);
+            
+            // Check number literal
+            if let Statement::Store { value, .. } = &body[0].node {
+                if let Expression::Literal(Literal::Number(n)) = &value.node {
+                    assert_eq!(*n, 42.0);
+                } else {
+                    panic!("Expected number literal");
+                }
+            }
+            
+            // Check string literal
+            if let Statement::Store { value, .. } = &body[1].node {
+                if let Expression::Literal(Literal::Text(s)) = &value.node {
+                    assert_eq!(s, "hello");
+                } else {
+                    panic!("Expected string literal");
+                }
+            }
+            
+            // Check truth literal
+            if let Statement::Store { value, .. } = &body[2].node {
+                if let Expression::Literal(Literal::Truth(b)) = &value.node {
+                    assert_eq!(*b, true);
+                } else {
+                    panic!("Expected truth literal");
+                }
+            }
+        } else {
+            panic!("Expected action declaration");
+        }
+    }
+
+    #[test]
+    fn test_parse_container() {
+        let input = r#"
+            create container called Person:
+                private name is text
+                private age is number
+                
+                public define action called get_name:
+                    give back name
+                end action
+            end container
+        "#;
+        
+        let result = parse_str(input);
+        assert!(result.is_ok());
+        
+        let program = result.unwrap();
+        assert_eq!(program.declarations.len(), 1);
+        
+        if let Declaration::Container {
+            name,
+            visibility,
+            fields,
+            methods,
+            ..
+        } = &program.declarations[0].node {
+            assert_eq!(name, "Person");
+            assert_eq!(visibility, &Visibility::Private); // Default visibility
+            
+            // Check fields
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0].0, "name");
+            assert_eq!(fields[0].1, Type::Text);
+            assert_eq!(fields[0].2, Visibility::Private);
+            
+            assert_eq!(fields[1].0, "age");
+            assert_eq!(fields[1].1, Type::Number);
+            assert_eq!(fields[1].2, Visibility::Private);
+            
+            // Check method
+            assert_eq!(methods.len(), 1);
+            if let Declaration::Action {
+                name,
+                visibility,
+                ..
+            } = &methods[0].node {
+                assert_eq!(name, "get_name");
+                assert_eq!(visibility, &Visibility::Public);
+            } else {
+                panic!("Expected action declaration");
+            }
+        } else {
+            panic!("Expected container declaration");
+        }
+    }
+
+    #[test]
+    fn test_parse_interface() {
+        let input = r#"
+            define interface called DataStore:
+                action called save(data with type any) gives back truth
+                action called load(id with type text) gives back any
+            end interface
+        "#;
+        
+        let result = parse_str(input);
+        assert!(result.is_ok());
+        
+        let program = result.unwrap();
+        assert_eq!(program.declarations.len(), 1);
+        
+        if let Declaration::Interface {
+            name,
+            methods,
+            ..
+        } = &program.declarations[0].node {
+            assert_eq!(name, "DataStore");
+            assert_eq!(methods.len(), 2);
+            
+            // Check save method
+            assert_eq!(methods[0].0, "save");
+            assert_eq!(methods[0].1.len(), 1);
+            assert_eq!(methods[0].1[0].name, "data");
+            assert_eq!(methods[0].1[0].type_annotation, Some(Type::Any));
+            assert_eq!(methods[0].2, Some(Type::Truth));
+            
+            // Check load method
+            assert_eq!(methods[1].0, "load");
+            assert_eq!(methods[1].1.len(), 1);
+            assert_eq!(methods[1].1[0].name, "id");
+            assert_eq!(methods[1].1[0].type_annotation, Some(Type::Text));
+            assert_eq!(methods[1].2, Some(Type::Any));
+        } else {
+            panic!("Expected interface declaration");
+        }
+    }
+
+    #[test]
+    fn test_parse_expressions() {
+        let input = r#"
+            define action called test:
+                store x as 1 plus 2 times 3
+                store y as not (a and b or c)
+                store list as [1, 2, 3]
+                store map as { "key": 42 }
+                store record as record {
+                    name is "test",
+                    value is 123
+                }
+            end action
+        "#;
+        
+        let result = parse_str(input);
+        assert!(result.is_ok());
+        
+        let program = result.unwrap();
+        if let Declaration::Action { body, .. } = &program.declarations[0].node {
+            assert_eq!(body.len(), 5);
+            
+            // Check arithmetic expression
+            if let Statement::Store { value, .. } = &body[0].node {
+                if let Expression::BinaryOp { op: op1, left, right } = &value.node {
+                    assert!(matches!(op1, Operator::Plus));
+                    
+                    if let Expression::Literal(Literal::Number(n)) = &left.node {
+                        assert_eq!(*n, 1.0);
+                    } else {
+                        panic!("Expected number literal");
+                    }
+                    
+                    if let Expression::BinaryOp { op: op2, left, right } = &right.node {
+                        assert!(matches!(op2, Operator::Multiply));
+                        
+                        if let Expression::Literal(Literal::Number(n1)) = &left.node {
+                            assert_eq!(*n1, 2.0);
+                        } else {
+                            panic!("Expected number literal");
+                        }
+                        
+                        if let Expression::Literal(Literal::Number(n2)) = &right.node {
+                            assert_eq!(*n2, 3.0);
+                        } else {
+                            panic!("Expected number literal");
+                        }
+                    } else {
+                        panic!("Expected binary operation");
+                    }
+                } else {
+                    panic!("Expected binary operation");
+                }
+            }
+            
+            // Check logical expression
+            if let Statement::Store { value, .. } = &body[1].node {
+                if let Expression::UnaryOp { op, expr } = &value.node {
+                    assert!(matches!(op, Operator::Not));
+                    
+                    if let Expression::BinaryOp { op, .. } = &expr.node {
+                        assert!(matches!(op, Operator::Or));
+                    } else {
+                        panic!("Expected binary operation");
+                    }
+                } else {
+                    panic!("Expected unary operation");
+                }
+            }
+            
+            // Check list expression
+            if let Statement::Store { value, .. } = &body[2].node {
+                if let Expression::List(items) = &value.node {
+                    assert_eq!(items.len(), 3);
+                } else {
+                    panic!("Expected list");
+                }
+            }
+            
+            // Check map expression
+            if let Statement::Store { value, .. } = &body[3].node {
+                if let Expression::Map(pairs) = &value.node {
+                    assert_eq!(pairs.len(), 1);
+                } else {
+                    panic!("Expected map");
+                }
+            }
+            
+            // Check record expression
+            if let Statement::Store { value, .. } = &body[4].node {
+                if let Expression::Record(fields) = &value.node {
+                    assert_eq!(fields.len(), 2);
+                    assert_eq!(fields[0].0, "name");
+                    assert_eq!(fields[1].0, "value");
+                } else {
+                    panic!("Expected record");
+                }
+            }
+        } else {
+            panic!("Expected action declaration");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the initial implementation of the lexer and parser for WFL.

### Changes

1. **Enhanced Lexer**:
   - Added span tracking for better error reporting
   - Improved error handling with descriptive messages
   - Support for all WFL language tokens
   - Unit tests for various token types

2. **AST Definitions**:
   - Complete AST node types for all language constructs
   - Support for expressions, statements, and declarations
   - Type system representation
   - Pattern matching support

3. **Initial Parser**:
   - Basic parser structure using chumsky
   - Support for literals and basic expressions
   - Framework for parsing all language constructs
   - Error handling and reporting

### TODO

The code still needs some work to be fully functional:
1. Fix the parser to properly handle Token types instead of TokenType
2. Complete the implementation of compound token parsing
3. Add more test cases
4. Improve error handling and reporting

Note: There are still some issues to fix in the parser implementation.