### PR TITLE
Fix variable redefinition issue - make it fatal error

### DIFF
--- a/TestPrograms/simple_redefinition_test.wfl
+++ b/TestPrograms/simple_redefinition_test.wfl
@@ -1,0 +1,6 @@
+store x as 5
+display "x is " + x
+
+// This should cause a fatal error
+store x as 10
+display "x is now " + x

--- a/TestPrograms/valid_variables_test.wfl
+++ b/TestPrograms/valid_variables_test.wfl
@@ -1,0 +1,7 @@
+store x as 5
+display "x is " + x
+
+store y as 10
+display "y is " + y
+
+display "Total is " + (x + y)

--- a/TestPrograms/variable_redefinition_test.wfl
+++ b/TestPrograms/variable_redefinition_test.wfl
@@ -1,0 +1,80 @@
+store email3 as "ke5crz@hamplex.com"
+
+// Define named patterns
+create pattern emailme:
+    one or more of (any letter or digit or "._-")
+    then "@"
+    then one or more of (any letter or digit or "-")
+    then "."
+    then 2 to 6 letters
+end pattern
+
+// Simple string matching
+check if email3 matches pattern emailme:
+    display email3 + " is a Valid email!"
+otherwise:
+    display email3 + " is a Invalid email"
+end check
+
+// Custom pattern definition
+create pattern greeting:
+    "hello" or "hi" or "hey"
+end pattern
+
+check if "hello world" matches greeting:
+    display "Found greeting!"
+end check
+
+//create a a pattern for phone numbers
+create pattern phone_number:
+    one or more of (digit)
+    then "-"
+    then one or more of (digit)
+    then "-"
+    then one or more of (digit)
+end pattern
+
+store phone1 as "123-456-7890"
+
+check if phone1 matches phone_number:
+    display phone1 + " is a Valid phone number!"
+otherwise:
+    display phone1 + " is a Invalid phone number"
+end check
+
+create pattern id_number:
+   exactly 3 digits
+    then "-"
+    then 3 to 4 digits
+    then "-"
+    then exactly 3 digits
+end pattern
+
+store id1 as "1234-567-8901"
+
+check if id1 matches id_number:
+    display id1 + " is a Valid ID number!"
+otherwise:
+    display id1 + " is a Invalid ID number"
+end check
+
+create pattern phone:
+    "("
+    then exactly 3 digits
+    then ")"
+    then exactly 3 digits
+    then "-"
+    then exactly 4 digits
+end pattern
+
+// This should cause a fatal error - redefining phone1
+store phone1 as "(123)500-7890"
+
+check if phone1 matches phone:
+    display phone1 + " is a Valid phone number!"
+otherwise:
+    display phone1 + " is a Invalid phone number"
+end check
+
+// Test that the pattern was parsed successfully  
+display "Pattern definition parsed successfully!"


### PR DESCRIPTION
Fixes #118

This PR addresses the variable redefinition issue where WFL was allowing the same variable to be stored multiple times instead of treating it as a fatal error.

## Changes
- Modified `src/main.rs` to check semantic diagnostic severity 
- Added fatal error detection: exit with code 3 if Severity::Error found
- Variable redefinition now properly prevents execution instead of showing warning
- Added comprehensive test cases for both invalid and valid variable usage

## Testing
- ✅ Variable redefinition test cases properly fail with no output
- ✅ Valid programs continue to execute normally
- ✅ All existing analyzer tests pass
- ✅ Code formatting and clippy checks pass

## Backward Compatibility
This change maintains backward compatibility for valid programs while correctly enforcing the "variables must have unique names within scope" rule.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new test programs to validate variable assignment, variable redefinition errors, and pattern matching for strings such as emails and phone numbers.

* **Bug Fixes**
  * Improved error handling to prevent program execution when fatal semantic errors are detected during static analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->