### PR TITLE
Fix version synchronization issue - update all version references to 25.8.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "wfl"
-version = "25.8.3"
+version = "25.8.11"
 dependencies = [
  "chrono",
  "codespan-reporting",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wfl"
-version = "25.8.3"
+version = "25.8.11"
 edition = "2024"
 description = "WFL (WebFirst Language) is a programming language designed to be readable and intuitive using natural language constructs."
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ authors = ["Logbie LLC <info@logbie.com>"]
 name = "WFL"
 identifier = "com.logbie.wfl"
 icon = ["icons/wfl.png"]
-version = "25.8.3"
+version = "25.8.11"
 copyright = "© 2025 Logbie LLC"
 category = "Developer Tool"
 short_description = "WebFirst Language Compiler and Runtime"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WFL (WebFirst Language)
 
 <div align="center">
-  <img src="https://img.shields.io/badge/version-25.8.3-blue" alt="Version">
+  <img src="https://img.shields.io/badge/version-25.8.11-blue" alt="Version">
   <img src="https://img.shields.io/badge/status-alpha-orange" alt="Status">
   <img src="https://img.shields.io/badge/license-Apache--2.0-green" alt="License">
   <img src="https://img.shields.io/badge/rust-1.75+-brown" alt="Rust Version">

--- a/editors/vscode-wfl/package.json
+++ b/editors/vscode-wfl/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wfl",
   "displayName": "WebFirst Language (WFL)",
   "description": "Language support for the WebFirst Language (WFL)",
-  "version": "25.8.3",
+  "version": "25.8.11",
   "engines": {
     "vscode": "^1.80.0"
   },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wfl",
   "displayName": "WebFirst Language",
   "description": "WebFirst Language (WFL) support for VS Code",
-  "version": "25.8.3",
+  "version": "25.8.11",
   "publisher": "wfl",
   "license": "MIT",
   "engines": {

--- a/vscode-wfl/package.json
+++ b/vscode-wfl/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-wfl",
   "displayName": "WebFirst Language",
   "description": "WebFirst Language (WFL) support for VS Code",
-  "version": "25.8.3",
+  "version": "25.8.11",
   "publisher": "wfl",
   "license": "MIT",
   "engines": {

--- a/wix.toml
+++ b/wix.toml
@@ -3,7 +3,7 @@
 [package]
 name = "WFL"
 manufacturer = "Logbie LLC"
-version = "25.8.3.0" # Updated by bump_version.py
+version = "25.8.11.0" # Updated by bump_version.py
 description = "WebFirst Language"
 license = "LICENSE"
 


### PR DESCRIPTION
The previous version bump to 25.8.11 only updated src/version.rs but left other files at 25.8.3. This PR synchronizes all version references:

- README.md: Updated version badge to 25.8.11
- Cargo.toml: Updated package and bundle versions to 25.8.11
- wix.toml: Updated installer version to 25.8.11.0
- VSCode extension package.json files: Updated to 25.8.11
- Cargo.lock: Updated with new version dependencies

Fixes #119 where README version was not syncing with bump version.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version numbers across documentation and configuration files to 25.8.11. No changes to functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->