### PR TITLE
Fix chained binary operations parser bug

### DIFF
--- a/test_chained_operations.wfl
+++ b/test_chained_operations.wfl
@@ -1,0 +1,26 @@
+// Test chained binary operations bug
+store a as 5
+store b as 10 
+store c as 15
+
+// This should be 30 (5 + 10 + 15) but currently returns only 15
+store result as a plus b plus c
+display result
+
+// String concatenation test  
+store x as "hello"
+store y as " "
+store z as "world"
+
+// This should be "hello world" but currently returns only "world"
+store greeting as x plus y plus z
+display greeting
+
+// More complex test with mixed operations
+store num1 as 2
+store num2 as 3
+store num3 as 4
+
+// Should be 14 (2 * 3 + 4 + 2) but likely returns wrong value
+store complex as num1 times num2 plus num3 plus num1
+display complex


### PR DESCRIPTION
Fixes #132

The WFL parser was incorrectly handling chained binary operations like 'a + b + c', causing only the last value to be returned instead of proper left-associative evaluation.

**Root cause:** Operator tokens were consumed before precedence checks, causing tokens to be lost when recursive calls failed precedence validation.

**Solution:** Move token consumption to after precedence validation passes.

**Results:**
- '5 plus 10 plus 15' now correctly outputs 30 (was 15)
- '"hello" plus " " plus "world"' now correctly outputs "hello world" (was "hello ")
- All existing tests pass
- Added comprehensive unit test to prevent regressions

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of binary expressions to ensure correct handling of operator precedence and associativity, especially for chained operations like addition and "divided by".

* **Tests**
  * Added tests to verify correct parsing of chained binary operations and to debug token sequences.
  * Introduced a new test script to check evaluation of chained arithmetic and string operations, with expected results documented.

* **Style**
  * Cleaned up minor whitespace in parsing logic for date and time statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->