### PR TITLE
fix: Add --version and --help support to wfl-lsp

### DIFF
--- a/wfl-lsp/tests/lsp_version_test.rs
+++ b/wfl-lsp/tests/lsp_version_test.rs
@@ -6,20 +6,23 @@ fn test_version_flag_exits_immediately() {
     // Test that --version flag exits immediately and doesn't hang
     let output = Command::new("cargo")
         .arg("run")
+        .arg("-p")
+        .arg("wfl-lsp")
         .arg("--bin")
         .arg("wfl-lsp")
         .arg("--")
         .arg("--version")
-        .current_dir("../") // Run from wfl root
         .output()
         .expect("Failed to execute wfl-lsp --version");
 
-    // Check that the command completed (didn't hang)
-    assert!(output.status.success() || output.status.code() == Some(0));
+    // Check that the command completed successfully (didn't hang)
+    assert!(output.status.success());
 
     // Check that version information is printed
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("wfl-lsp") && stdout.contains("0.1.0"));
+    assert!(stdout.contains("wfl-lsp"));
+    // Use dynamic version from environment instead of hardcoded
+    assert!(stdout.contains(env!("CARGO_PKG_VERSION")));
 }
 
 #[test]
@@ -27,16 +30,17 @@ fn test_help_flag_exits_immediately() {
     // Test that --help flag also exits immediately
     let output = Command::new("cargo")
         .arg("run")
+        .arg("-p")
+        .arg("wfl-lsp")
         .arg("--bin")
         .arg("wfl-lsp")
         .arg("--")
         .arg("--help")
-        .current_dir("../") // Run from wfl root
         .output()
         .expect("Failed to execute wfl-lsp --help");
 
-    // Check that the command completed (didn't hang)
-    assert!(output.status.success() || output.status.code() == Some(0));
+    // Check that the command completed successfully (didn't hang)
+    assert!(output.status.success());
 
     // Check that help information is printed
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -50,23 +54,24 @@ fn test_version_flag_with_timeout() {
 
     let output = Command::new("cargo")
         .arg("run")
+        .arg("-p")
+        .arg("wfl-lsp")
         .arg("--bin")
         .arg("wfl-lsp")
         .arg("--")
         .arg("--version")
-        .current_dir("../")
         .output()
         .expect("Failed to execute wfl-lsp --version");
 
     let elapsed = start.elapsed();
 
-    // Should complete within 5 seconds (way more than needed for version display)
+    // Should complete within 30 seconds (accounting for compilation in CI)
     assert!(
-        elapsed < Duration::from_secs(5),
+        elapsed < Duration::from_secs(30),
         "Command took too long: {:?}",
         elapsed
     );
 
-    // Should exit with code 0
+    // Should exit successfully
     assert!(output.status.success());
 }


### PR DESCRIPTION
Fixes #223

Implements proper command line argument parsing in wfl-lsp to fix the hanging issue when using `--version` flag on Windows 11.

## Changes
- Add `--version` flag that outputs version and exits immediately
- Add `--help` flag that shows usage information and exits immediately
- Support all documented CLI options: `--mcp`, `--stdio`, `--log-level`, etc.
- Add comprehensive error handling for invalid arguments
- Maintain backward compatibility with existing `--mcp` flag
- Add tests to verify functionality

## Root Cause
The original code only handled the `--mcp` flag and fell through to starting an LSP server for any other argument, causing it to hang waiting for LSP communication.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI improvements: support for mode selection (MCP or default LSP), --stdio/--tcp, configurable --log-level, --max-completion-items, and --hover-timeout.
  * Immediate, non-blocking --version and --help output.
  * Logging now respects the configured log level (flag or environment) and provides clearer argument validation errors.

* **Tests**
  * Added integration tests verifying quick exit and expected output for version/help flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->