### PR TITLE
Sync AGENTS.md with CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@
 - `src/`: Core compiler/runtime (`main.rs`, `lib.rs`, `repl.rs`, `builtins.rs`).
 - `crates/`: Internal crates (e.g., `wfl_core`).
 - `tests/`: Rust integration/unit tests (e.g., `file_io_*`, `crypto_test.rs`).
+- `benches/`: Performance benchmarks (Criterion).
+- `examples/`: Example WFL programs and demos.
 - `TestPrograms/`: End‑to‑end WFL programs that must all pass.
 - `wfl-lsp/`: Language Server workspace member.
 - `vscode-extension/`: VS Code extension integration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `src/`: Core compiler/runtime (`main.rs`, `lib.rs`, `repl.rs`, `builtins.rs`).
 - `crates/`: Internal crates (e.g., `wfl_core`).
 - `tests/`: Rust integration/unit tests (e.g., `file_io_*`, `crypto_test.rs`).
+- `benches/`: Performance benchmarks (Criterion).
+- `examples/`: Example WFL programs and demos.
 - `TestPrograms/`: End‑to‑end WFL programs that must all pass.
 - `wfl-lsp/`: Language Server workspace member.
 - `vscode-extension/`: VS Code extension integration.


### PR DESCRIPTION
Synchronized `AGENTS.md` with `CLAUDE.md` to ensure they provide consistent guidance. Added missing `benches/` and `examples/` directories to the project structure description in both files. `AGENTS.md` is now a direct subset of `CLAUDE.md` minus the Claude-specific hooks and intro.

---
*PR created automatically by Jules for task [18055491676754459527](https://jules.google.com/task/18055491676754459527) started by @logbie*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project structure documentation to include benches/ directory for performance benchmarks and examples/ directory for example programs and demos.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->