### PR TITLE
[JULES] Refactor: Unified contains function for List and Text

### DIFF
--- a/src/stdlib/list.rs
+++ b/src/stdlib/list.rs
@@ -95,16 +95,41 @@ pub fn native_contains(args: Vec<Value>) -> Result<Value, RuntimeError> {
         ));
     }
 
-    let list = expect_list(&args[0])?;
-    let item = &args[1];
-
-    for value in list.borrow().iter() {
-        if value == item {
-            return Ok(Value::Bool(true));
+    match &args[0] {
+        Value::List(list) => {
+            let item = &args[1];
+            for value in list.borrow().iter() {
+                if value == item {
+                    return Ok(Value::Bool(true));
+                }
+            }
+            Ok(Value::Bool(false))
         }
+        Value::Text(text) => {
+            let substring = match &args[1] {
+                Value::Text(s) => s,
+                _ => {
+                    return Err(RuntimeError::new(
+                        format!(
+                            "contains on text expects a text argument, got {}",
+                            args[1].type_name()
+                        ),
+                        0,
+                        0,
+                    ));
+                }
+            };
+            Ok(Value::Bool(text.contains(&**substring)))
+        }
+        _ => Err(RuntimeError::new(
+            format!(
+                "contains expects a list or text, got {}",
+                args[0].type_name()
+            ),
+            0,
+            0,
+        )),
     }
-
-    Ok(Value::Bool(false))
 }
 
 pub fn native_indexof(args: Vec<Value>) -> Result<Value, RuntimeError> {

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -121,21 +121,6 @@ pub fn native_tolowercase(args: Vec<Value>) -> Result<Value, RuntimeError> {
     Ok(Value::Text(Rc::from(lowercase)))
 }
 
-pub fn native_contains(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            format!("contains expects 2 arguments, got {}", args.len()),
-            0,
-            0,
-        ));
-    }
-
-    let text = expect_text(&args[0])?;
-    let substring = expect_text(&args[1])?;
-
-    Ok(Value::Bool(text.contains(&*substring)))
-}
-
 pub fn native_substring(args: Vec<Value>) -> Result<Value, RuntimeError> {
     if args.len() != 3 {
         return Err(RuntimeError::new(
@@ -319,10 +304,6 @@ pub fn register_text(env: &mut Environment) {
     let _ = env.define(
         "tolowercase",
         Value::NativeFunction("tolowercase", native_tolowercase),
-    );
-    let _ = env.define(
-        "contains",
-        Value::NativeFunction("contains", native_contains),
     );
     let _ = env.define(
         "substring",


### PR DESCRIPTION
**The Issue:**
Duplicate logic for `contains` existed in both `src/stdlib/list.rs` and `src/stdlib/text.rs`. Furthermore, because both modules registered a function named `contains` in the same global environment, the registration in `list.rs` (which happened later) overwrote the one in `text.rs`. This caused `contains` to fail when used on Text, as the active implementation expected a List.

**The Rational:**
*   **Fix Bug:** `contains` was broken for Text types.
*   **Reduce Redundancy:** Consolidated near-duplicate logic.
*   **Improve Maintainability:** A single source of truth for `contains`.

**The Solution:**
Refactored `native_contains` in `src/stdlib/list.rs` to act as a polymorphic function. It now checks the type of the first argument:
*   If `Value::List`, it iterates through the list.
*   If `Value::Text`, it performs a substring check (logic moved from `text.rs`).
*   Removed the conflicting `native_contains` from `src/stdlib/text.rs`.

**Verification:**
*   `cargo fmt` and `cargo clippy` passed.
*   Manual verification script `reproduce_contains.wfl` confirmed `contains` works for both List and Text.
*   All existing tests passed (after ensuring release build presence for integration tests).

---
*PR created automatically by Jules for task [7954133854785299130](https://jules.google.com/task/7954133854785299130) started by @logbie*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated the contains operation to support both list and text containment checks with enhanced type validation and improved error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->