### PR TITLE
[JULES] Refactor: Optimize bytes_to_hex allocation in crypto stdlib

### DIFF
--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -413,7 +413,12 @@ fn wflhash_core_text(input: &[u8], params: &WflHashParams) -> Result<Vec<u8>, Ru
 
 /// Convert bytes to hexadecimal string
 fn bytes_to_hex(bytes: &[u8]) -> String {
-    bytes.iter().map(|b| format!("{:02x}", b)).collect()
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        write!(s, "{:02x}", b).unwrap();
+    }
+    s
 }
 
 /// WFLHASH-256 implementation with security fixes
@@ -500,10 +505,7 @@ pub fn native_generate_csrf_token(args: Vec<Value>) -> Result<Value, RuntimeErro
     rng.fill_bytes(&mut token_bytes);
 
     // Convert to hex string
-    let token = token_bytes
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>();
+    let token = bytes_to_hex(&token_bytes);
 
     Ok(Value::Text(Rc::from(token)))
 }


### PR DESCRIPTION
This PR refactors the `bytes_to_hex` helper function in `src/stdlib/crypto.rs` to improve performance by eliminating unnecessary intermediate String allocations. It also updates `native_generate_csrf_token` to use this shared helper, removing duplicate logic.

The optimization replaces the previous `map` + `format!` implementation with a loop using `std::fmt::Write`, reducing allocation complexity from O(N) to O(1) (single buffer allocation).

---
*PR created automatically by Jules for task [2450228657961212151](https://jules.google.com/task/2450228657961212151) started by @logbie*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal cryptographic utility functions for improved performance characteristics while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->