### PR TITLE
Refactor Interpreter to unify operator logic

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -8,6 +8,8 @@ pub mod error;
 #[cfg(test)]
 mod memory_tests;
 #[cfg(test)]
+mod op_refactor_tests;
+#[cfg(test)]
 mod tests;
 pub mod value;
 
@@ -5958,17 +5960,8 @@ impl Interpreter {
                 column,
             } => {
                 if let Some(val) = self.try_evaluate_simple_expr_sync(expression, env)? {
-                    match operator {
-                        UnaryOperator::Not => Ok(Some(Value::Bool(!val.is_truthy()))),
-                        UnaryOperator::Minus => match val {
-                            Value::Number(n) => Ok(Some(Value::Number(-n))),
-                            _ => Err(RuntimeError::new(
-                                format!("Cannot negate {}", val.type_name()),
-                                *line,
-                                *column,
-                            )),
-                        },
-                    }
+                    self.perform_unary_op(operator, val, *line, *column)
+                        .map(Some)
                 } else {
                     Ok(None)
                 }
@@ -5993,40 +5986,8 @@ impl Interpreter {
                 };
 
                 // Perform binary op
-                match operator {
-                    Operator::Plus => self.add(left_val, right_val, *line, *column).map(Some),
-                    Operator::Minus => self.subtract(left_val, right_val, *line, *column).map(Some),
-                    Operator::Multiply => {
-                        self.multiply(left_val, right_val, *line, *column).map(Some)
-                    }
-                    Operator::Divide => self.divide(left_val, right_val, *line, *column).map(Some),
-                    Operator::Modulo => self.modulo(left_val, right_val, *line, *column).map(Some),
-                    Operator::Equals => Ok(Some(Value::Bool(self.is_equal(&left_val, &right_val)))),
-                    Operator::NotEquals => {
-                        Ok(Some(Value::Bool(!self.is_equal(&left_val, &right_val))))
-                    }
-                    Operator::GreaterThan => self
-                        .greater_than(left_val, right_val, *line, *column)
-                        .map(Some),
-                    Operator::LessThan => self
-                        .less_than(left_val, right_val, *line, *column)
-                        .map(Some),
-                    Operator::GreaterThanOrEqual => self
-                        .greater_than_equal(left_val, right_val, *line, *column)
-                        .map(Some),
-                    Operator::LessThanOrEqual => self
-                        .less_than_equal(left_val, right_val, *line, *column)
-                        .map(Some),
-                    Operator::And => Ok(Some(Value::Bool(
-                        left_val.is_truthy() && right_val.is_truthy(),
-                    ))),
-                    Operator::Or => Ok(Some(Value::Bool(
-                        left_val.is_truthy() || right_val.is_truthy(),
-                    ))),
-                    Operator::Contains => {
-                        self.contains(left_val, right_val, *line, *column).map(Some)
-                    }
-                }
+                self.perform_binary_op(operator, left_val, right_val, *line, *column)
+                    .map(Some)
             }
             Expression::Concatenation {
                 left,
@@ -6047,8 +6008,7 @@ impl Interpreter {
                 };
 
                 // Concatenate
-                let result = format!("{left_val}{right_val}");
-                Ok(Some(Value::Text(Arc::from(result.as_str()))))
+                Ok(Some(self.perform_concatenation(left_val, right_val)))
             }
             _ => Ok(None),
         }
@@ -6435,26 +6395,7 @@ impl Interpreter {
 
                 let right_val = self.evaluate_expression(right, Rc::clone(&env)).await?;
 
-                match operator {
-                    Operator::Plus => self.add(left_val, right_val, *line, *column),
-                    Operator::Minus => self.subtract(left_val, right_val, *line, *column),
-                    Operator::Multiply => self.multiply(left_val, right_val, *line, *column),
-                    Operator::Divide => self.divide(left_val, right_val, *line, *column),
-                    Operator::Modulo => self.modulo(left_val, right_val, *line, *column),
-                    Operator::Equals => Ok(Value::Bool(self.is_equal(&left_val, &right_val))),
-                    Operator::NotEquals => Ok(Value::Bool(!self.is_equal(&left_val, &right_val))),
-                    Operator::GreaterThan => self.greater_than(left_val, right_val, *line, *column),
-                    Operator::LessThan => self.less_than(left_val, right_val, *line, *column),
-                    Operator::GreaterThanOrEqual => {
-                        self.greater_than_equal(left_val, right_val, *line, *column)
-                    }
-                    Operator::LessThanOrEqual => {
-                        self.less_than_equal(left_val, right_val, *line, *column)
-                    }
-                    Operator::And => Ok(Value::Bool(left_val.is_truthy() && right_val.is_truthy())),
-                    Operator::Or => Ok(Value::Bool(left_val.is_truthy() || right_val.is_truthy())),
-                    Operator::Contains => self.contains(left_val, right_val, *line, *column),
-                }
+                self.perform_binary_op(operator, left_val, right_val, *line, *column)
             }
 
             Expression::UnaryOperation {
@@ -6467,17 +6408,7 @@ impl Interpreter {
                     .evaluate_expression(expression, Rc::clone(&env))
                     .await?;
 
-                match operator {
-                    UnaryOperator::Not => Ok(Value::Bool(!value.is_truthy())),
-                    UnaryOperator::Minus => match value {
-                        Value::Number(n) => Ok(Value::Number(-n)),
-                        _ => Err(RuntimeError::new(
-                            format!("Cannot negate {}", value.type_name()),
-                            *line,
-                            *column,
-                        )),
-                    },
-                }
+                self.perform_unary_op(operator, value, *line, *column)
             }
 
             Expression::FunctionCall {
@@ -6678,8 +6609,7 @@ impl Interpreter {
 
                 let right_val = self.evaluate_expression(right, Rc::clone(&env)).await?;
 
-                let result = format!("{left_val}{right_val}");
-                Ok(Value::Text(Arc::from(result.as_str())))
+                Ok(self.perform_concatenation(left_val, right_val))
             }
 
             Expression::PatternMatch {
@@ -7425,6 +7355,59 @@ impl Interpreter {
                 Err(error_with_stack)
             }
         }
+    }
+
+    fn perform_binary_op(
+        &self,
+        operator: &Operator,
+        left_val: Value,
+        right_val: Value,
+        line: usize,
+        column: usize,
+    ) -> Result<Value, RuntimeError> {
+        match operator {
+            Operator::Plus => self.add(left_val, right_val, line, column),
+            Operator::Minus => self.subtract(left_val, right_val, line, column),
+            Operator::Multiply => self.multiply(left_val, right_val, line, column),
+            Operator::Divide => self.divide(left_val, right_val, line, column),
+            Operator::Modulo => self.modulo(left_val, right_val, line, column),
+            Operator::Equals => Ok(Value::Bool(self.is_equal(&left_val, &right_val))),
+            Operator::NotEquals => Ok(Value::Bool(!self.is_equal(&left_val, &right_val))),
+            Operator::GreaterThan => self.greater_than(left_val, right_val, line, column),
+            Operator::LessThan => self.less_than(left_val, right_val, line, column),
+            Operator::GreaterThanOrEqual => {
+                self.greater_than_equal(left_val, right_val, line, column)
+            }
+            Operator::LessThanOrEqual => self.less_than_equal(left_val, right_val, line, column),
+            Operator::And => Ok(Value::Bool(left_val.is_truthy() && right_val.is_truthy())),
+            Operator::Or => Ok(Value::Bool(left_val.is_truthy() || right_val.is_truthy())),
+            Operator::Contains => self.contains(left_val, right_val, line, column),
+        }
+    }
+
+    fn perform_unary_op(
+        &self,
+        operator: &UnaryOperator,
+        value: Value,
+        line: usize,
+        column: usize,
+    ) -> Result<Value, RuntimeError> {
+        match operator {
+            UnaryOperator::Not => Ok(Value::Bool(!value.is_truthy())),
+            UnaryOperator::Minus => match value {
+                Value::Number(n) => Ok(Value::Number(-n)),
+                _ => Err(RuntimeError::new(
+                    format!("Cannot negate {}", value.type_name()),
+                    line,
+                    column,
+                )),
+            },
+        }
+    }
+
+    fn perform_concatenation(&self, left_val: Value, right_val: Value) -> Value {
+        let result = format!("{left_val}{right_val}");
+        Value::Text(Arc::from(result.as_str()))
     }
 
     fn add(

--- a/src/interpreter/op_refactor_tests.rs
+++ b/src/interpreter/op_refactor_tests.rs
@@ -1,0 +1,123 @@
+use super::{Interpreter, Value};
+use crate::lexer::lex_wfl_with_positions;
+use crate::parser::Parser;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn test_binary_ops() {
+    let mut interpreter = Interpreter::new();
+
+    // Addition
+    let result = run_expr(&mut interpreter, "2 plus 3").await;
+    assert_eq!(result, Value::Number(5.0));
+
+    // Subtraction
+    let result = run_expr(&mut interpreter, "5 minus 2").await;
+    assert_eq!(result, Value::Number(3.0));
+
+    // Multiplication
+    let result = run_expr(&mut interpreter, "4 times 3").await;
+    assert_eq!(result, Value::Number(12.0));
+
+    // Division
+    let result = run_expr(&mut interpreter, "10 divided by 2").await;
+    assert_eq!(result, Value::Number(5.0));
+
+    // Modulo (using % as modulo keyword is not supported)
+    let result = run_expr(&mut interpreter, "10 % 3").await;
+    assert_eq!(result, Value::Number(1.0));
+
+    // Equality (using 'is equal to' or '=')
+    let result = run_expr(&mut interpreter, "5 is equal to 5").await;
+    assert_eq!(result, Value::Bool(true));
+
+    let result = run_expr(&mut interpreter, "5 = 5").await;
+    assert_eq!(result, Value::Bool(true));
+
+    let result = run_expr(&mut interpreter, "5 is equal to 6").await;
+    assert_eq!(result, Value::Bool(false));
+
+    // Inequality
+    let result = run_expr(&mut interpreter, "5 is not 6").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Greater than
+    let result = run_expr(&mut interpreter, "5 is greater than 3").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Less than
+    let result = run_expr(&mut interpreter, "2 is less than 4").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Greater than or equal
+    let result = run_expr(&mut interpreter, "5 is greater than or equal to 5").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Less than or equal
+    let result = run_expr(&mut interpreter, "3 is less than or equal to 3").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // And
+    let result = run_expr(&mut interpreter, "true and true").await;
+    assert_eq!(result, Value::Bool(true));
+
+    let result = run_expr(&mut interpreter, "true and false").await;
+    assert_eq!(result, Value::Bool(false));
+
+    // Or
+    let result = run_expr(&mut interpreter, "true or false").await;
+    assert_eq!(result, Value::Bool(true));
+
+    let result = run_expr(&mut interpreter, "false or false").await;
+    assert_eq!(result, Value::Bool(false));
+
+    // Contains (List)
+    let result = run_expr(&mut interpreter, "contains 2 in [1, 2, 3]").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Contains (Text)
+    let result = run_expr(&mut interpreter, "contains \"bar\" in \"foobar\"").await;
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[tokio::test]
+async fn test_unary_ops() {
+    let mut interpreter = Interpreter::new();
+
+    // Not
+    let result = run_expr(&mut interpreter, "not true").await;
+    assert_eq!(result, Value::Bool(false));
+
+    let result = run_expr(&mut interpreter, "not false").await;
+    assert_eq!(result, Value::Bool(true));
+
+    // Minus (Negation)
+    let result = run_expr(&mut interpreter, "-5").await;
+    assert_eq!(result, Value::Number(-5.0));
+}
+
+#[tokio::test]
+async fn test_concatenation() {
+    let mut interpreter = Interpreter::new();
+
+    // Using 'with' for concatenation
+    let result = run_expr(&mut interpreter, "\"hello\" with \" \" with \"world\"").await;
+    assert_eq!(result, Value::Text(Arc::from("hello world")));
+
+    // Concatenation with non-text types (implicit string conversion)
+    let result = run_expr(&mut interpreter, "\"count: \" with 5").await;
+    assert_eq!(result, Value::Text(Arc::from("count: 5")));
+}
+
+// Helper function to run expression
+async fn run_expr(interpreter: &mut Interpreter, source: &str) -> Value {
+    let tokens = lex_wfl_with_positions(source);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|_| panic!("Failed to parse: {}", source));
+    interpreter
+        .interpret(&program)
+        .await
+        .unwrap_or_else(|_| panic!("Failed to interpret: {}", source))
+}


### PR DESCRIPTION
Refactored the `Interpreter` to eliminate code duplication in expression evaluation.

**The Issue:**
The `Interpreter` contained duplicated logic for handling binary and unary operations in two places:
1.  `try_evaluate_simple_expr_sync`: A fast-path optimization for synchronous evaluation.
2.  `evaluate_expression` (and `_evaluate_expression`): The general asynchronous evaluation path.

This violation of DRY increased the risk of inconsistencies if one path was updated but not the other.

**The Solution:**
I extracted the common logic into three new private helper methods within the `Interpreter` impl:
*   `perform_binary_op`: Handles all binary operators (`+`, `-`, `*`, `/`, `%`, `==`, etc.).
*   `perform_unary_op`: Handles unary operators (`not`, `-`).
*   `perform_concatenation`: Handles string concatenation.

Both evaluation paths now delegate to these helpers, ensuring consistent behavior and reducing code volume.

**Verification:**
*   Created a new test suite `src/interpreter/op_refactor_tests.rs` covering all supported operators and edge cases.
*   Verified that all existing tests pass.
*   Ran `cargo fmt` and `cargo clippy` to ensure code quality.

---
*PR created automatically by Jules for task [7906676041069873677](https://jules.google.com/task/7906676041069873677) started by @logbie*