### PR TITLE
fix: pass loaded WflConfig to Interpreter (not just timeout)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1180,7 +1180,7 @@ async fn main() -> io::Result<()> {
                 // Log execution start if execution logging is enabled
                 exec_trace!("Starting execution of script: {}", &file_path);
 
-                let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
+                let mut interpreter = Interpreter::with_config(std::sync::Arc::new(config.clone()));
                 interpreter.set_step_mode(step_mode); // Set step mode from CLI flag
                 interpreter.set_test_mode(test_mode); // Set test mode from CLI flag
                 interpreter.set_script_args(script_args); // Pass script arguments


### PR DESCRIPTION
## Summary

`Interpreter::with_timeout(config.timeout_seconds)` in `src/main.rs` constructs a fresh
`WflConfig` with only the timeout field copied across — every other setting falls back
to `WflConfig::default()`. This means `.wflcfg` is *parsed* correctly, but almost
nothing from it actually reaches the interpreter.

The most user-visible symptom is that **`web_server_bind_address`** is silently ignored:
no matter what operators put in `.wflcfg`, `listen on port N as ...` binds `127.0.0.1`
because that's the hard-coded default. WFL web servers are effectively loopback-only
in any production deployment that relies on `.wflcfg` to change the bind address.

`Interpreter::with_config(Arc<WflConfig>)` already exists — it's just not being called
from `main.rs` in the script-run path. This PR switches to it.

## Patch

```rust
- let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
+ let mut interpreter = Interpreter::with_config(std::sync::Arc::new(config.clone()));
```

The `.clone()` is required because `config` is also used later in `main.rs` at
`if config.logging_enabled` (around line 1297). Without it you get `E0382: use of moved value`.

## Repro

Before this change:

```bash
echo "web_server_bind_address = 0.0.0.0" > .wflcfg
cat > server.wfl <<'EOF'
listen on port 8080 as s
main loop:
    wait for request comes in on s as r
    respond to r with "hi" and content_type "text/plain"
end loop
EOF
cargo run --release -- server.wfl &
ss -tlnp | grep :8080
# LISTEN 0 128 127.0.0.1:8080  <-- wrong; should be 0.0.0.0:8080
```

After this change the same repro binds `0.0.0.0:8080` as configured.

## Context

Found while deploying WFL 26.4.1 to host a public splash page on a cloud VPS — the
server daemon insisted on loopback-only and the config file had no effect. Traced to
`with_timeout` discarding everything. Patched locally, site came up, PR'd upstream.

## Notes for review

- `with_timeout` still exists and is still used elsewhere (REPL, tests, etc.), so
  no API surface changes.
- Performance cost of the `.clone()` is negligible — `WflConfig` is a small struct
  and this happens once at startup.
- Existing unit tests should all still pass; this doesn't touch any code paths other
  than "which config the interpreter runs with".

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal configuration handling improvements to enhance system reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->