### PR TITLE
fix(analyzer): fix ANALYZE-UNUSED false positives for loop bodies and compound assignments

### DIFF
--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -921,7 +921,9 @@ impl Analyzer {
                     self.mark_used_in_expression(ct_expr, usages);
                 }
             }
-            Statement::ListenStatement { port, server_name, .. } => {
+            Statement::ListenStatement {
+                port, server_name, ..
+            } => {
                 self.mark_used_in_expression(port, usages);
                 if let Some(usage) = usages.get_mut(server_name) {
                     usage.used = true;
@@ -941,13 +943,17 @@ impl Analyzer {
                     self.mark_used_in_expression(timeout_expr, usages);
                 }
             }
-            Statement::AddToListStatement { value, list_name, .. } => {
+            Statement::AddToListStatement {
+                value, list_name, ..
+            } => {
                 self.mark_used_in_expression(value, usages);
                 if let Some(usage) = usages.get_mut(list_name) {
                     usage.used = true;
                 }
             }
-            Statement::RemoveFromListStatement { value, list_name, .. } => {
+            Statement::RemoveFromListStatement {
+                value, list_name, ..
+            } => {
                 self.mark_used_in_expression(value, usages);
                 if let Some(usage) = usages.get_mut(list_name) {
                     usage.used = true;
@@ -958,7 +964,9 @@ impl Analyzer {
                     usage.used = true;
                 }
             }
-            Statement::HttpGetStatement { url, variable_name, .. } => {
+            Statement::HttpGetStatement {
+                url, variable_name, ..
+            } => {
                 self.mark_used_in_expression(url, usages);
                 if let Some(usage) = usages.get_mut(variable_name) {
                     usage.used = true;
@@ -980,7 +988,11 @@ impl Analyzer {
                 self.mark_used_in_expression(list, usages);
                 self.mark_used_in_expression(value, usages);
             }
-            Statement::CreateListStatement { name, initial_values, .. } => {
+            Statement::CreateListStatement {
+                name,
+                initial_values,
+                ..
+            } => {
                 if let Some(usage) = usages.get_mut(name) {
                     usage.used = true;
                 }
@@ -1064,7 +1076,8 @@ impl Analyzer {
                     self.mark_used_variables(stmt, usages);
                 }
             }
-            Statement::EventTrigger { arguments, .. } | Statement::ParentMethodCall { arguments, .. } => {
+            Statement::EventTrigger { arguments, .. }
+            | Statement::ParentMethodCall { arguments, .. } => {
                 for arg in arguments {
                     self.mark_used_in_expression(&arg.value, usages);
                 }
@@ -1089,8 +1102,12 @@ impl Analyzer {
             | Statement::CloseServerStatement { server, .. } => {
                 self.mark_used_in_expression(server, usages);
             }
-            Statement::WriteContentStatement { content, target, .. }
-            | Statement::WriteBinaryStatement { content, target, .. } => {
+            Statement::WriteContentStatement {
+                content, target, ..
+            }
+            | Statement::WriteBinaryStatement {
+                content, target, ..
+            } => {
                 self.mark_used_in_expression(content, usages);
                 self.mark_used_in_expression(target, usages);
             }
@@ -1150,7 +1167,9 @@ impl Analyzer {
                     self.mark_used_variables(stmt, usages);
                 }
             }
-            Statement::ExpectStatement { subject, assertion, .. } => {
+            Statement::ExpectStatement {
+                subject, assertion, ..
+            } => {
                 self.mark_used_in_expression(subject, usages);
                 match assertion {
                     Assertion::Equal(expr)

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -461,12 +461,24 @@ impl Analyzer {
                 body,
                 when_clauses,
                 otherwise_block,
-                ..
+                line,
+                column,
             } => {
                 for stmt in body {
                     self.collect_variable_declarations(stmt, usages);
                 }
                 for clause in when_clauses {
+                    // Register the error variable binding for this catch clause
+                    if !clause.error_name.is_empty() {
+                        usages.insert(
+                            clause.error_name.clone(),
+                            VariableUsage {
+                                name: clause.error_name.clone(),
+                                defined_at: (*line, *column),
+                                used: false,
+                            },
+                        );
+                    }
                     for stmt in &clause.body {
                         self.collect_variable_declarations(stmt, usages);
                     }
@@ -895,6 +907,12 @@ impl Analyzer {
                     self.mark_used_variables(stmt, usages);
                 }
                 for clause in when_clauses {
+                    // Mark the error variable as used (it's implicitly declared in the catch scope)
+                    if !clause.error_name.is_empty() {
+                        if let Some(usage) = usages.get_mut(&clause.error_name) {
+                            usage.used = true;
+                        }
+                    }
                     for stmt in &clause.body {
                         self.mark_used_variables(stmt, usages);
                     }

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -1,6 +1,6 @@
 use super::Analyzer;
 use crate::diagnostics::{Severity, WflDiagnostic};
-use crate::parser::ast::{Expression, Program, Statement, Type};
+use crate::parser::ast::{Assertion, Expression, Program, Statement, Type};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
@@ -436,11 +436,254 @@ impl Analyzer {
                 }
             }
             Statement::WhileLoop { body, .. }
+            | Statement::RepeatWhileLoop { body, .. }
+            | Statement::RepeatUntilLoop { body, .. }
             | Statement::ForEachLoop { body, .. }
-            | Statement::CountLoop { body, .. } => {
+            | Statement::CountLoop { body, .. }
+            | Statement::ForeverLoop { body, .. }
+            | Statement::MainLoop { body, .. }
+            | Statement::TestBlock { body, .. } => {
                 for stmt in body {
                     self.collect_variable_declarations(stmt, usages);
                 }
+            }
+            Statement::SingleLineIf {
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                self.collect_variable_declarations(then_stmt, usages);
+                if let Some(else_s) = else_stmt {
+                    self.collect_variable_declarations(else_s, usages);
+                }
+            }
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                ..
+            } => {
+                for stmt in body {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+                for clause in when_clauses {
+                    for stmt in &clause.body {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+                if let Some(otherwise) = otherwise_block {
+                    for stmt in otherwise {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+            }
+            Statement::EventHandler { handler_body, .. } => {
+                for stmt in handler_body {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+            }
+            Statement::DescribeBlock {
+                setup,
+                teardown,
+                tests,
+                ..
+            } => {
+                if let Some(stmts) = setup {
+                    for stmt in stmts {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+                if let Some(stmts) = teardown {
+                    for stmt in stmts {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+                for stmt in tests {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+            }
+            Statement::HttpGetStatement {
+                variable_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::HttpPostStatement {
+                variable_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::ExecuteCommandStatement {
+                variable_name: Some(variable_name),
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::SpawnProcessStatement {
+                variable_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::ReadProcessOutputStatement {
+                variable_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::WaitForProcessStatement {
+                variable_name: Some(variable_name),
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    variable_name.clone(),
+                    VariableUsage {
+                        name: variable_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::CreateListStatement {
+                name, line, column, ..
+            } => {
+                usages.insert(
+                    name.clone(),
+                    VariableUsage {
+                        name: name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::MapCreation {
+                name, line, column, ..
+            } => {
+                usages.insert(
+                    name.clone(),
+                    VariableUsage {
+                        name: name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::CreateDateStatement {
+                name, line, column, ..
+            } => {
+                usages.insert(
+                    name.clone(),
+                    VariableUsage {
+                        name: name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::CreateTimeStatement {
+                name, line, column, ..
+            } => {
+                usages.insert(
+                    name.clone(),
+                    VariableUsage {
+                        name: name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::WaitForRequestStatement {
+                request_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    request_name.clone(),
+                    VariableUsage {
+                        name: request_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::ListenStatement {
+                server_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    server_name.clone(),
+                    VariableUsage {
+                        name: server_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
+            }
+            Statement::ContainerInstantiation {
+                instance_name,
+                line,
+                column,
+                ..
+            } => {
+                usages.insert(
+                    instance_name.clone(),
+                    VariableUsage {
+                        name: instance_name.clone(),
+                        defined_at: (*line, *column),
+                        used: false,
+                    },
+                );
             }
             Statement::PatternDefinition {
                 name, line, column, ..
@@ -623,6 +866,306 @@ impl Analyzer {
                         self.mark_used_in_expression(content, usages);
                     }
                     _ => {}
+                }
+            }
+            Statement::MainLoop { body, .. } | Statement::ForeverLoop { body, .. } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            Statement::SingleLineIf {
+                condition,
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                self.mark_used_in_expression(condition, usages);
+                self.mark_used_variables(then_stmt, usages);
+                if let Some(else_s) = else_stmt {
+                    self.mark_used_variables(else_s, usages);
+                }
+            }
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                ..
+            } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+                for clause in when_clauses {
+                    for stmt in &clause.body {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+                if let Some(otherwise) = otherwise_block {
+                    for stmt in otherwise {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+            }
+            Statement::RespondStatement {
+                request,
+                content,
+                status,
+                content_type,
+                ..
+            } => {
+                self.mark_used_in_expression(request, usages);
+                self.mark_used_in_expression(content, usages);
+                if let Some(status_expr) = status {
+                    self.mark_used_in_expression(status_expr, usages);
+                }
+                if let Some(ct_expr) = content_type {
+                    self.mark_used_in_expression(ct_expr, usages);
+                }
+            }
+            Statement::ListenStatement { port, server_name, .. } => {
+                self.mark_used_in_expression(port, usages);
+                if let Some(usage) = usages.get_mut(server_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::WaitForRequestStatement {
+                server,
+                request_name,
+                timeout,
+                ..
+            } => {
+                self.mark_used_in_expression(server, usages);
+                if let Some(usage) = usages.get_mut(request_name) {
+                    usage.used = true;
+                }
+                if let Some(timeout_expr) = timeout {
+                    self.mark_used_in_expression(timeout_expr, usages);
+                }
+            }
+            Statement::AddToListStatement { value, list_name, .. } => {
+                self.mark_used_in_expression(value, usages);
+                if let Some(usage) = usages.get_mut(list_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::RemoveFromListStatement { value, list_name, .. } => {
+                self.mark_used_in_expression(value, usages);
+                if let Some(usage) = usages.get_mut(list_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::ClearListStatement { list_name, .. } => {
+                if let Some(usage) = usages.get_mut(list_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::HttpGetStatement { url, variable_name, .. } => {
+                self.mark_used_in_expression(url, usages);
+                if let Some(usage) = usages.get_mut(variable_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::HttpPostStatement {
+                url,
+                data,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(url, usages);
+                self.mark_used_in_expression(data, usages);
+                if let Some(usage) = usages.get_mut(variable_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::PushStatement { list, value, .. } => {
+                self.mark_used_in_expression(list, usages);
+                self.mark_used_in_expression(value, usages);
+            }
+            Statement::CreateListStatement { name, initial_values, .. } => {
+                if let Some(usage) = usages.get_mut(name) {
+                    usage.used = true;
+                }
+                for val in initial_values {
+                    self.mark_used_in_expression(val, usages);
+                }
+            }
+            Statement::MapCreation { name, entries, .. } => {
+                if let Some(usage) = usages.get_mut(name) {
+                    usage.used = true;
+                }
+                for (_, val) in entries {
+                    self.mark_used_in_expression(val, usages);
+                }
+            }
+            Statement::WaitForDurationStatement { duration, .. } => {
+                self.mark_used_in_expression(duration, usages);
+            }
+            Statement::ExecuteCommandStatement {
+                command,
+                arguments,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(command, usages);
+                if let Some(args_expr) = arguments {
+                    self.mark_used_in_expression(args_expr, usages);
+                }
+                if let Some(var) = variable_name {
+                    if let Some(usage) = usages.get_mut(var) {
+                        usage.used = true;
+                    }
+                }
+            }
+            Statement::SpawnProcessStatement {
+                command,
+                arguments,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(command, usages);
+                if let Some(args_expr) = arguments {
+                    self.mark_used_in_expression(args_expr, usages);
+                }
+                if let Some(usage) = usages.get_mut(variable_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::ReadProcessOutputStatement {
+                process_id,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(process_id, usages);
+                if let Some(usage) = usages.get_mut(variable_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::KillProcessStatement { process_id, .. } => {
+                self.mark_used_in_expression(process_id, usages);
+            }
+            Statement::WaitForProcessStatement {
+                process_id,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(process_id, usages);
+                if let Some(var) = variable_name {
+                    if let Some(usage) = usages.get_mut(var) {
+                        usage.used = true;
+                    }
+                }
+            }
+            Statement::EventHandler {
+                event_source,
+                handler_body,
+                ..
+            } => {
+                self.mark_used_in_expression(event_source, usages);
+                for stmt in handler_body {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            Statement::EventTrigger { arguments, .. } | Statement::ParentMethodCall { arguments, .. } => {
+                for arg in arguments {
+                    self.mark_used_in_expression(&arg.value, usages);
+                }
+            }
+            Statement::ContainerInstantiation {
+                instance_name,
+                arguments,
+                property_initializers,
+                ..
+            } => {
+                if let Some(usage) = usages.get_mut(instance_name) {
+                    usage.used = true;
+                }
+                for arg in arguments {
+                    self.mark_used_in_expression(&arg.value, usages);
+                }
+                for init in property_initializers {
+                    self.mark_used_in_expression(&init.value, usages);
+                }
+            }
+            Statement::StopAcceptingConnectionsStatement { server, .. }
+            | Statement::CloseServerStatement { server, .. } => {
+                self.mark_used_in_expression(server, usages);
+            }
+            Statement::WriteContentStatement { content, target, .. }
+            | Statement::WriteBinaryStatement { content, target, .. } => {
+                self.mark_used_in_expression(content, usages);
+                self.mark_used_in_expression(target, usages);
+            }
+            Statement::WriteToStatement { content, file, .. } => {
+                self.mark_used_in_expression(content, usages);
+                self.mark_used_in_expression(file, usages);
+            }
+            Statement::CreateDirectoryStatement { path, .. }
+            | Statement::DeleteFileStatement { path, .. }
+            | Statement::DeleteDirectoryStatement { path, .. }
+            | Statement::LoadModuleStatement { path, .. }
+            | Statement::IncludeStatement { path, .. } => {
+                self.mark_used_in_expression(path, usages);
+            }
+            Statement::CreateFileStatement { path, content, .. } => {
+                self.mark_used_in_expression(path, usages);
+                self.mark_used_in_expression(content, usages);
+            }
+            Statement::CreateDateStatement { name, value, .. } => {
+                if let Some(usage) = usages.get_mut(name) {
+                    usage.used = true;
+                }
+                if let Some(val_expr) = value {
+                    self.mark_used_in_expression(val_expr, usages);
+                }
+            }
+            Statement::CreateTimeStatement { name, value, .. } => {
+                if let Some(usage) = usages.get_mut(name) {
+                    usage.used = true;
+                }
+                if let Some(val_expr) = value {
+                    self.mark_used_in_expression(val_expr, usages);
+                }
+            }
+            Statement::DescribeBlock {
+                setup,
+                teardown,
+                tests,
+                ..
+            } => {
+                if let Some(stmts) = setup {
+                    for stmt in stmts {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+                if let Some(stmts) = teardown {
+                    for stmt in stmts {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+                for stmt in tests {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            Statement::TestBlock { body, .. } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            Statement::ExpectStatement { subject, assertion, .. } => {
+                self.mark_used_in_expression(subject, usages);
+                match assertion {
+                    Assertion::Equal(expr)
+                    | Assertion::Be(expr)
+                    | Assertion::GreaterThan(expr)
+                    | Assertion::LessThan(expr)
+                    | Assertion::Contain(expr)
+                    | Assertion::HaveLength(expr) => {
+                        self.mark_used_in_expression(expr, usages);
+                    }
+                    Assertion::BeYes
+                    | Assertion::BeNo
+                    | Assertion::Exist
+                    | Assertion::BeEmpty
+                    | Assertion::BeOfType(_) => {}
                 }
             }
             _ => {}

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -251,3 +251,75 @@ call x with "test"
         analyzer.errors
     );
 }
+
+// ===== Tests for ANALYZE-UNUSED false positives (issue #468) =====
+
+#[test]
+fn test_arithmetic_assign_counts_as_use() {
+    // `add N to X` is parsed as Assignment{name:X, value:X+N}.
+    // The analyzer must mark X as used, not flag it as ANALYZE-UNUSED.
+    let input = "store req_count as 0\nadd 1 to req_count\ndisplay req_count";
+    let tokens = lex_wfl_with_positions(input);
+    let program = Parser::new(&tokens).parse().unwrap();
+
+    let mut analyzer = Analyzer::new();
+    let diagnostics = analyzer.check_unused_variables(&program, 0);
+
+    let unused: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == "ANALYZE-UNUSED")
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "Expected no ANALYZE-UNUSED warnings, got: {unused:?}"
+    );
+}
+
+#[test]
+fn test_variable_used_in_main_loop_body_not_flagged() {
+    // Variables declared outside a `main loop:..end loop` block and used
+    // inside it must not be flagged as unused (issue #468).
+    let input = r#"store req_count as 0
+store greeting as "hello"
+forever loop:
+    add 1 to req_count
+    display greeting
+end loop"#;
+    let tokens = lex_wfl_with_positions(input);
+    let program = Parser::new(&tokens).parse().unwrap();
+
+    let mut analyzer = Analyzer::new();
+    let diagnostics = analyzer.check_unused_variables(&program, 0);
+
+    let unused: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == "ANALYZE-UNUSED")
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "Expected no ANALYZE-UNUSED warnings for variables used inside forever loop, got: {unused:?}"
+    );
+}
+
+#[test]
+fn test_add_to_list_counts_as_use() {
+    // `add X to my_list` must count as a use of my_list.
+    let input = r#"store my_list as []
+store item as "hello"
+add item to my_list
+display my_list"#;
+    let tokens = lex_wfl_with_positions(input);
+    let program = Parser::new(&tokens).parse().unwrap();
+
+    let mut analyzer = Analyzer::new();
+    let diagnostics = analyzer.check_unused_variables(&program, 0);
+
+    let unused: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| d.code == "ANALYZE-UNUSED")
+        .collect();
+    assert!(
+        unused.is_empty(),
+        "Expected no ANALYZE-UNUSED warnings, got: {unused:?}"
+    );
+}


### PR DESCRIPTION
Fixes #468

## Summary

- `mark_used_variables` and `collect_variable_declarations` in the static analyzer now handle all previously missing statement types
- Primary fix: `MainLoop` body is now traversed, so variables used inside `main loop:...end loop` are no longer false-positive flagged
- Also fixes `RespondStatement`, `AddToListStatement`, `ForeverLoop`, `TryStatement`, and ~20 other statement types that were silently skipped
- Three regression tests added

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/470" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened unused-variable detection to eliminate false positives across more control-flow and statement types (additional loop forms, list mutations, arithmetic-style updates, HTTP/process/container interactions, and assertion variants that include expressions).
* **Tests**
  * Added unit tests confirming unused-variable warnings no longer appear for arithmetic updates, forever-loop usages, and list-mutation operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->