### PR TITLE
⚡ Bolt: [performance improvement] Consolidate and optimize snake_case operations

### DIFF
--- a/src/fixer/mod.rs
+++ b/src/fixer/mod.rs
@@ -5,6 +5,7 @@ use crate::parser::ast::{
     Expression, Literal, Operator, Program, Statement, Type, UnaryOperator, ValidationRuleType,
     Visibility,
 };
+use crate::utils::string::{is_snake_case, to_snake_case};
 use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
@@ -1010,38 +1011,12 @@ impl CodeFixer {
     }
 
     fn fix_identifier_name(&self, name: &str, summary: &mut FixerSummary) -> String {
-        if !self.is_snake_case(name) {
+        if !is_snake_case(name) {
             summary.vars_renamed += 1;
-            self.to_snake_case(name)
+            to_snake_case(name)
         } else {
             name.to_string()
         }
-    }
-
-    fn is_snake_case(&self, s: &str) -> bool {
-        !s.contains(char::is_uppercase) && !s.contains(' ')
-    }
-
-    fn to_snake_case(&self, s: &str) -> String {
-        let mut result = String::new();
-        let mut previous_char_is_lowercase = false;
-
-        for (i, c) in s.char_indices() {
-            if c.is_uppercase() {
-                if i > 0 && previous_char_is_lowercase {
-                    result.push('_');
-                }
-                result.push(c.to_lowercase().next().unwrap());
-            } else if c == ' ' {
-                result.push('_');
-            } else {
-                result.push(c);
-            }
-
-            previous_char_is_lowercase = c.is_lowercase();
-        }
-
-        result
     }
 
     /// Analyzes a concatenation expression to determine if it needs reformatting

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::await_holding_refcell_ref)]
 
+pub mod utils;
 // Global allocator for dhat heap profiling
 #[cfg(feature = "dhat-heap")]
 #[global_allocator]

--- a/src/linter/mod.rs
+++ b/src/linter/mod.rs
@@ -1,5 +1,6 @@
 use crate::diagnostics::{DiagnosticReporter, Severity, WflDiagnostic};
 use crate::parser::ast::{Program, Statement};
+use crate::utils::string::{is_snake_case, to_snake_case};
 use std::path::Path;
 
 pub trait LintRule {
@@ -503,32 +504,6 @@ fn check_nesting_depth(
         }
         _ => {}
     }
-}
-
-fn is_snake_case(s: &str) -> bool {
-    !s.contains(char::is_uppercase) && !s.contains(' ')
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::new();
-    let mut previous_char_is_lowercase = false;
-
-    for (i, c) in s.char_indices() {
-        if c.is_uppercase() {
-            if i > 0 && previous_char_is_lowercase {
-                result.push('_');
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else if c == ' ' {
-            result.push('_');
-        } else {
-            result.push(c);
-        }
-
-        previous_char_is_lowercase = c.is_lowercase();
-    }
-
-    result
 }
 
 fn line_col_from_pos(source: &str, pos: usize) -> (usize, usize) {

--- a/src/linter/tests.rs
+++ b/src/linter/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::lexer::lex_wfl_with_positions;
 use crate::parser::Parser;
+use crate::utils::string::to_snake_case;
 
 #[test]
 fn test_naming_convention_rule() {
@@ -26,16 +27,6 @@ fn test_snake_case_conversion() {
     assert_eq!(to_snake_case("snake_case"), "snake_case");
     assert_eq!(to_snake_case("with space"), "with_space");
     assert_eq!(to_snake_case("Mixed_Style"), "mixed_style");
-}
-
-#[test]
-fn test_is_snake_case() {
-    assert!(is_snake_case("snake_case"));
-    assert!(is_snake_case("simple"));
-    assert!(!is_snake_case("camelCase"));
-    assert!(!is_snake_case("PascalCase"));
-    assert!(!is_snake_case("with space"));
-    assert!(!is_snake_case("Mixed_Style"));
 }
 
 #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod string;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,0 +1,54 @@
+pub fn is_snake_case(s: &str) -> bool {
+    // Fast path for ASCII strings
+    if s.is_ascii() {
+        !s.bytes().any(|b| b.is_ascii_uppercase() || b == b' ')
+    } else {
+        !s.contains(char::is_uppercase) && !s.contains(' ')
+    }
+}
+
+pub fn to_snake_case(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() + 4);
+    let mut previous_char_is_lowercase = false;
+
+    for (i, c) in s.char_indices() {
+        if c.is_uppercase() {
+            if i > 0 && previous_char_is_lowercase {
+                result.push('_');
+            }
+            result.extend(c.to_lowercase());
+        } else if c == ' ' {
+            result.push('_');
+        } else {
+            result.push(c);
+        }
+
+        previous_char_is_lowercase = c.is_lowercase();
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_snake_case() {
+        assert!(is_snake_case("snake_case"));
+        assert!(is_snake_case("simple"));
+        assert!(!is_snake_case("camelCase"));
+        assert!(!is_snake_case("PascalCase"));
+        assert!(!is_snake_case("with space"));
+        assert!(!is_snake_case("Mixed_Style"));
+    }
+
+    #[test]
+    fn test_to_snake_case() {
+        assert_eq!(to_snake_case("camelCase"), "camel_case");
+        assert_eq!(to_snake_case("PascalCase"), "pascal_case");
+        assert_eq!(to_snake_case("snake_case"), "snake_case");
+        assert_eq!(to_snake_case("with space"), "with_space");
+        assert_eq!(to_snake_case("Mixed_Style"), "mixed_style");
+    }
+}


### PR DESCRIPTION
#### **Summary of Changes**

* **The Issue:** The `is_snake_case` and `to_snake_case` methods were duplicated identically across `src/fixer/mod.rs` and `src/linter/mod.rs`. Additionally, the implementation of `to_snake_case` was sub-optimal (using `.unwrap()` instead of `.extend()` on `char::to_lowercase()`, which is unsafe for 1-to-many Unicode mappings, and using `String::new()` instead of pre-allocating capacity). `is_snake_case` also lacked a fast-path for ascii strings.
* **The Rational:** Reduced binary size and code duplication (DRY principle). Improved runtime performance for linter and fixer rules by avoiding heap re-allocations and safely handling Unicode strings.
* **The Solution:** Consolidated the duplicate string functions into a shared `src/utils/string.rs` module. Optimized `is_snake_case` with a `.is_ascii()` fast path, and optimized `to_snake_case` to use `String::with_capacity` and `.extend()`.

#### **Verification Checklist**

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [1904777503121403585](https://jules.google.com/task/1904777503121403585) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized string utilities into a centralized module for improved maintainability.
  * Made string validation and conversion functions publicly available for reuse across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->