### PR TITLE
⚡ Bolt: Optimize parser length calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2026-04-22 - [Avoid string allocation on single-part split]
 **Learning:** Calling `.split(delimiter)` on a reference-counted string (`Arc<str>`) and `.map()`ing the results into `Arc::from(s)` unconditionally creates a new allocation for every chunk. If the delimiter doesn't exist, the entire string is re-allocated unnecessarily.
 **Action:** When iterating over a split of a reference-counted string, explicitly check if `s.len() == text.len() && !text.is_empty()`. If it is, use `Arc::clone(&text)` to return another reference to the existing string, bypassing the allocation.
+## 2026-05-01 - [Avoid O(N) evaluation on iterators before pre-allocating]
+**Learning:** `program.statements.reserve(self.tokens.clone().count() / 5)` inside `mod_complete.rs` iterates through the cloned token stream to calculate the length, taking O(N) time for every function invocation, increasing parser times significantly. The tokens stream should use the O(1) length from the vector or iterator length method if available.
+**Action:** Replace `self.tokens.clone().count()` with `self.tokens.len()` when `self.tokens` implements `ExactSizeIterator` (e.g. over a `Vec` or slice).

--- a/src/parser/mod_complete.rs
+++ b/src/parser/mod_complete.rs
@@ -27,10 +27,12 @@ impl<'a> Parser<'a> {
 
     pub fn parse(&mut self) -> Result<Program, Vec<ParseError>> {
         let mut program = Program::new();
-        program.statements.reserve(self.tokens.clone().count() / 5);
+        // Bolt optimization: Use O(1) .len() instead of O(N) .clone().count()
+        program.statements.reserve(self.tokens.len() / 5);
 
         while self.tokens.peek().is_some() {
-            let start_len = self.tokens.clone().count();
+            // Bolt optimization: Use O(1) .len() instead of O(N) .clone().count()
+            let start_len = self.tokens.len();
 
             // Comprehensive handling of "end" tokens that might be left unconsumed
             // Check first two tokens to avoid borrow checker issues
@@ -115,7 +117,8 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let end_len = self.tokens.clone().count();
+            // Bolt optimization: Use O(1) .len() instead of O(N) .clone().count()
+            let end_len = self.tokens.len();
 
             // Special case for end of file - if we have processed all meaningful tokens,
             // and only trailing tokens remain (if any), just break


### PR DESCRIPTION
💡 What: Replaced O(N) .clone().count() with O(1) .len() on token iterators.
🎯 Why: Iterating over Peekable iterators was consuming CPU time during token length checks.
📊 Impact: Improves parse operations from O(N) to O(1) for getting token lengths.
🔬 Measurement: Verify with 'cargo bench'.

---
*PR created automatically by Jules for task [5064155073427037953](https://jules.google.com/task/5064155073427037953) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser performance by optimizing internal length calculations for more efficient statement pre-allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->