### PR TITLE
[JULES] Refactor pattern stdlib boilerplate and eliminate redundant string allocations

### DIFF
--- a/src/stdlib/helpers.rs
+++ b/src/stdlib/helpers.rs
@@ -1,5 +1,6 @@
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
+use crate::pattern::CompiledPattern;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -639,3 +640,25 @@ where
     let list = expect_list(&args[0])?;
     op(list, val)
 }
+
+generate_expect!(
+    /// Extracts a Pattern value from a WFL Value, returning it as a reference-counted CompiledPattern.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The WFL Value to extract from
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Rc<CompiledPattern>` clone (incrementing the reference count) if the value
+    /// is a Pattern variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RuntimeError` if the value is not a Pattern.
+    expect_pattern,
+    Pattern,
+    Rc<CompiledPattern>,
+    "a Pattern",
+    |p: &Rc<CompiledPattern>| Rc::clone(p)
+);

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -1,3 +1,4 @@
+use super::helpers::{check_arg_count, expect_pattern, expect_text};
 use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
@@ -19,74 +20,22 @@ pub fn register(env: &mut Environment) {
 /// Native function: pattern_matches(text, pattern) -> boolean
 /// Tests if text matches the given compiled pattern
 pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_matches requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_matches", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_matches must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_matches must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let matches = compiled_pattern.matches(text_str);
+    let matches = compiled_pattern.matches(&text);
     Ok(Value::Bool(matches))
 }
 
 /// Native function: pattern_find(text, pattern) -> object or null
 /// Finds the first match of pattern in text
 pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    match compiled_pattern.find(text_str) {
+    match compiled_pattern.find(&text) {
         Some(match_result) => {
             let mut result_map = HashMap::new();
             result_map.insert(
@@ -120,37 +69,11 @@ pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find_all(text, pattern) -> list
 /// Finds all matches of pattern in text
 pub fn pattern_find_all_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find_all requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find_all", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find_all must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find_all must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let matches = compiled_pattern.find_all(text_str);
+    let matches = compiled_pattern.find_all(&text);
     let mut result_list = Vec::new();
 
     for match_result in matches {
@@ -189,49 +112,17 @@ pub fn native_pattern_replace(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 3 {
-        return Err(RuntimeError::new(
-            "pattern_replace requires exactly 3 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_replace", &args, 3)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _pattern = match &args[1] {
-        Value::Pattern(p) => p.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _replacement = match &args[2] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Third argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _replacement =
+        expect_text(&args[2]).map_err(|e| RuntimeError::new(e.message, line, column))?;
 
     // TODO: Update to use new pattern system for replacement
-    Ok(Value::Text(Arc::from(text)))
+    Ok(Value::Text(Arc::clone(&text)))
 }
 
 /// Native function for pattern splitting (called by interpreter)
@@ -240,42 +131,19 @@ pub fn native_pattern_split(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_split requires exactly 2 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_split", &args, 2)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
 
     // Find all matches of the pattern in the text
-    let matches = pattern.find_all(text);
+    let matches = pattern.find_all(&text);
 
     // If no matches, return the entire text as a single element
     if matches.is_empty() {
-        let parts = vec![Value::Text(Arc::from(text))];
+        let parts = vec![Value::Text(Arc::clone(&text))];
         return Ok(Value::List(Rc::new(RefCell::new(parts))));
     }
 

--- a/src/stdlib/pattern_test.rs
+++ b/src/stdlib/pattern_test.rs
@@ -21,7 +21,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -33,7 +33,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -45,7 +45,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -57,6 +57,11 @@ mod tests {
         ];
         let result = pattern_matches_native(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("First argument"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Expected text, got Number")
+        );
     }
 }


### PR DESCRIPTION
#### **Summary of Changes**

* **The Issue:** The `src/stdlib/pattern.rs` file contained highly redundant argument validation and type extraction logic using manual `match` blocks for `Value::Text` and `Value::Pattern`. Additionally, there was a performance debt where `pattern_split` unnecessarily allocated a new `Arc<str>` from a text slice that it already owned an `Arc` reference to (`Arc::from(text)` instead of `Arc::clone(&text)`).
* **The Rational:** Consolidating the manual matching logic significantly improves readability and reduces boilerplate by relying on standard repository helpers. Resolving the unnecessary `Arc::from` conversion eliminates a redundant heap allocation, reducing overhead during pattern splitting operations and satisfying `clippy::useless_conversion` warnings.
* **The Solution:** Added `expect_pattern` to `src/stdlib/helpers.rs` using `generate_expect!`. Refactored all native pattern functions (`pattern_matches_native`, `pattern_find_native`, `pattern_find_all_native`, `native_pattern_replace`, and `native_pattern_split`) to use `check_arg_count`, `expect_text`, and `expect_pattern`. Fixed the performance debt by updating `Arc::from` to `Arc::clone` in the `pattern_split` fast-path and updated the standard library tests to expect the new error message formats.

#### **Verification Checklist**

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [13034455029881876816](https://jules.google.com/task/13034455029881876816) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for pattern operations to provide clearer validation feedback.

* **Refactor**
  * Introduced shared helper utilities for argument validation and type checking, reducing code duplication across pattern functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->