### PR TITLE
⚡ Bolt: Optimize Peekable iterator count check

### DIFF
--- a/src/parser/mod_complete.rs
+++ b/src/parser/mod_complete.rs
@@ -27,10 +27,11 @@ impl<'a> Parser<'a> {
 
     pub fn parse(&mut self) -> Result<Program, Vec<ParseError>> {
         let mut program = Program::new();
-        program.statements.reserve(self.tokens.clone().count() / 5);
+        // BOLT OPTIMIZATION: Replaced .clone().count() (O(N)) with .len() (O(1))
+        program.statements.reserve(self.tokens.len() / 5);
 
         while self.tokens.peek().is_some() {
-            let start_len = self.tokens.clone().count();
+            let start_len = self.tokens.len();
 
             // Comprehensive handling of "end" tokens that might be left unconsumed
             // Check first two tokens to avoid borrow checker issues
@@ -115,7 +116,7 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            let end_len = self.tokens.clone().count();
+            let end_len = self.tokens.len();
 
             // Special case for end of file - if we have processed all meaningful tokens,
             // and only trailing tokens remain (if any), just break


### PR DESCRIPTION
💡 What: Replaced `.clone().count()` with `.len()` on Peekable iterators in `src/parser/mod_complete.rs`.
🎯 Why: Calling `.clone().count()` on a Peekable iterator consumes the cloned iterator, making it an O(N) operation. Since the underlying iterator implements `ExactSizeIterator`, we can use `.len()` for an O(1) length check. This reduces the time complexity of the parser loop, especially for large files.
📊 Impact: Reduces the time complexity of the length check from O(N) to O(1), improving parsing speed by removing O(N^2) complexity.
🔬 Measurement: Verified with `cargo test` and `cargo bench` (theoretical O(1) impact).

---
*PR created automatically by Jules for task [3018659926605868389](https://jules.google.com/task/3018659926605868389) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/480" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized parser performance by streamlining internal token processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->