### PR TITLE
[JULES] Refactor Pattern Standard Library Functions to Eliminate Redundancy

### DIFF
--- a/src/stdlib/helpers.rs
+++ b/src/stdlib/helpers.rs
@@ -1,5 +1,6 @@
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
+use crate::pattern::CompiledPattern;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -594,6 +595,15 @@ generate_expect!(
     Rc<chrono::NaiveDateTime>,
     "a DateTime",
     |dt: &Rc<chrono::NaiveDateTime>| Rc::clone(dt)
+);
+
+generate_expect!(
+    /// Extracts a compiled pattern value from a WFL Value, returning it as a reference-counted CompiledPattern.
+    expect_pattern,
+    Pattern,
+    Rc<CompiledPattern>,
+    "a pattern",
+    |p: &Rc<CompiledPattern>| Rc::clone(p)
 );
 
 /// Helper for unary list operations (List -> Value)

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -1,3 +1,4 @@
+use super::helpers::{check_arg_count, expect_pattern, expect_text};
 use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
@@ -19,74 +20,22 @@ pub fn register(env: &mut Environment) {
 /// Native function: pattern_matches(text, pattern) -> boolean
 /// Tests if text matches the given compiled pattern
 pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_matches requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_matches", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_matches must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_matches must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let matches = compiled_pattern.matches(text_str);
+    let matches = compiled_pattern.matches(text.as_ref());
     Ok(Value::Bool(matches))
 }
 
 /// Native function: pattern_find(text, pattern) -> object or null
 /// Finds the first match of pattern in text
 pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    match compiled_pattern.find(text_str) {
+    match compiled_pattern.find(text.as_ref()) {
         Some(match_result) => {
             let mut result_map = HashMap::new();
             result_map.insert(
@@ -120,37 +69,11 @@ pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find_all(text, pattern) -> list
 /// Finds all matches of pattern in text
 pub fn pattern_find_all_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find_all requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find_all", &args, 2)?;
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find_all must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find_all must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let matches = compiled_pattern.find_all(text_str);
+    let matches = compiled_pattern.find_all(text.as_ref());
     let mut result_list = Vec::new();
 
     for match_result in matches {
@@ -189,49 +112,17 @@ pub fn native_pattern_replace(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 3 {
-        return Err(RuntimeError::new(
-            "pattern_replace requires exactly 3 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_replace", &args, 3)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _pattern = match &args[1] {
-        Value::Pattern(p) => p.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _replacement = match &args[2] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Third argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _replacement =
+        expect_text(&args[2]).map_err(|e| RuntimeError::new(e.message, line, column))?;
 
     // TODO: Update to use new pattern system for replacement
-    Ok(Value::Text(Arc::from(text)))
+    Ok(Value::Text(Arc::clone(&text)))
 }
 
 /// Native function for pattern splitting (called by interpreter)
@@ -240,42 +131,20 @@ pub fn native_pattern_split(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_split requires exactly 2 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_split", &args, 2)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
+    let pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
 
     // Find all matches of the pattern in the text
     let matches = pattern.find_all(text);
 
     // If no matches, return the entire text as a single element
     if matches.is_empty() {
-        let parts = vec![Value::Text(Arc::from(text))];
+        let parts = vec![Value::Text(Arc::clone(&text_arc))];
         return Ok(Value::List(Rc::new(RefCell::new(parts))));
     }
 

--- a/src/stdlib/pattern_test.rs
+++ b/src/stdlib/pattern_test.rs
@@ -21,7 +21,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -33,7 +33,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -45,7 +45,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -57,6 +57,6 @@ mod tests {
         ];
         let result = pattern_matches_native(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("First argument"));
+        assert!(result.unwrap_err().to_string().contains("Expected text"));
     }
 }


### PR DESCRIPTION
### Summary of Changes

* **The Issue:** The native pattern functions (`pattern_matches_native`, `pattern_find_native`, `pattern_find_all_native`, `native_pattern_replace`, and `native_pattern_split`) in `src/stdlib/pattern.rs` contained highly redundant code for matching on `Value` enums to extract texts and compiled patterns. They also manually checked argument lengths and constructed repetitive error strings using `.to_string()`, generating unnecessary allocations.
* **The Rational:** Eliminating this boilerplate improves the maintainability and DRYness of the `pattern` module. It also removes the performance debt and technical debt associated with the repetitive allocations and manual boilerplate checks, replacing them with the project's standard extraction mechanisms.
* **The Solution:** Added a new macro-generated helper, `expect_pattern`, to `src/stdlib/helpers.rs` alongside the other standardized type extractors. Refactored all functions in `src/stdlib/pattern.rs` to use `check_arg_count`, `expect_text`, and `expect_pattern`. Furthermore, in `native_pattern_split` and `native_pattern_replace`, `Arc::from` was replaced with the zero-allocation `Arc::clone` using the extracted arcs. Tests in `src/stdlib/pattern_test.rs` were updated to assert against the new, unified error messages.

### Verification Checklist

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy --all-targets -- -D warnings` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [201104489420881395](https://jules.google.com/task/201104489420881395) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal error handling in pattern operations for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->