### PR TITLE
⚡ Bolt: Add fast-path to native_replace to avoid string allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,6 @@
 ## 2026-04-22 - [Avoid string allocation on single-part split]
 **Learning:** Calling `.split(delimiter)` on a reference-counted string (`Arc<str>`) and `.map()`ing the results into `Arc::from(s)` unconditionally creates a new allocation for every chunk. If the delimiter doesn't exist, the entire string is re-allocated unnecessarily.
 **Action:** When iterating over a split of a reference-counted string, explicitly check if `s.len() == text.len() && !text.is_empty()`. If it is, use `Arc::clone(&text)` to return another reference to the existing string, bypassing the allocation.
+## 2025-05-05 - Avoid Unnecessary String Allocations in Replace
+**Learning:** In Rust, `str::replace` always allocates a new `String` even if the target substring is not found in the source string.
+**Action:** When performing `replace` on `Arc<str>` or `Cow<str>` where the target substring might frequently be missing, first check `.contains()` to avoid the O(N) allocation and instead fast-path by returning an `Arc::clone`.

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -279,6 +279,11 @@ pub fn native_replace(args: Vec<Value>) -> Result<Value, RuntimeError> {
     let text = expect_text(&args[0])?;
     let old = expect_text(&args[1])?;
     let new = expect_text(&args[2])?;
+
+    // Optimization: avoid string allocation if the substring to replace is not found
+    if !text.contains(old.as_ref()) {
+        return Ok(Value::Text(Arc::clone(&text)));
+    }
     let result = text.replace(old.as_ref(), new.as_ref());
     Ok(Value::Text(Arc::from(result)))
 }


### PR DESCRIPTION
💡 What: Added a fast-path `.contains()` check to `native_replace` in `src/stdlib/text.rs`.
🎯 Why: In Rust, `str::replace` always allocates a new `String` even if the target substring is not found. By checking `.contains()` first, we can avoid this allocation and instead return a cheap `Arc::clone` of the original string when no replacement is needed.
📊 Impact: Eliminates O(N) memory allocation and copy operations for `replace` calls where the target substring does not exist in the text.
🔬 Measurement: Can be verified by running micro-benchmarks on `str::replace` vs `str::contains` + `str::replace`. The fast path significantly reduces latency when the substring is missing. Tested correctness with `cargo test`.

---
*PR created automatically by Jules for task [4698546564048008536](https://jules.google.com/task/4698546564048008536) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * String replacement operations now deliver improved performance in common scenarios where the target substring is not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->