### PR TITLE
⚡ Bolt: [Optimize string replacement fast path]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2026-04-22 - [Avoid string allocation on single-part split]
 **Learning:** Calling `.split(delimiter)` on a reference-counted string (`Arc<str>`) and `.map()`ing the results into `Arc::from(s)` unconditionally creates a new allocation for every chunk. If the delimiter doesn't exist, the entire string is re-allocated unnecessarily.
 **Action:** When iterating over a split of a reference-counted string, explicitly check if `s.len() == text.len() && !text.is_empty()`. If it is, use `Arc::clone(&text)` to return another reference to the existing string, bypassing the allocation.
+
+## 2026-05-11 - [Optimize String Replacement Fast Path]
+**Learning:** Calling `text.replace(old, new)` unconditionally allocates a new `String` internally, even if `old` is not found. When wrapping the result in an `Arc<str>`, this creates an unnecessary allocation for unmodified strings.
+**Action:** When performing text replacements on reference-counted strings (like `Arc<str>`), always add a fast-path check using `.contains()` before calling `.replace()`. If the substring is not found, return an `Arc::clone` of the original string to prevent unnecessary memory allocation.

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -279,6 +279,13 @@ pub fn native_replace(args: Vec<Value>) -> Result<Value, RuntimeError> {
     let text = expect_text(&args[0])?;
     let old = expect_text(&args[1])?;
     let new = expect_text(&args[2])?;
+
+    // Optimization: If the substring is not found, avoid string allocation
+    // and reuse the original reference via Arc::clone.
+    if !text.contains(old.as_ref()) {
+        return Ok(Value::Text(Arc::clone(&text)));
+    }
+
     let result = text.replace(old.as_ref(), new.as_ref());
     Ok(Value::Text(Arc::from(result)))
 }


### PR DESCRIPTION
## Summary of Changes
**The Issue:** `native_replace` unconditionally calls `.replace()`, which allocates a new string even if the substring is not found.
**The Rational:** We can avoid unnecessary memory allocations by returning a reference clone of the original string when the target substring is absent.
**The Solution:** Added a `.contains()` fast-path check in `native_replace` to return an `Arc::clone` of the original string.

## Verification Checklist
- [x] cargo fmt
- [x] cargo clippy
- [x] cargo test

💡 What: Added a fast-path to `native_replace` using `.contains()` to return an `Arc::clone` if the search string is missing.
🎯 Why: To prevent the standard library from allocating a new `String` (and subsequently a new `Arc<str>`) when no replacements are made.
📊 Impact: Reduces memory allocation from O(N) to O(1) for strings that do not contain the target substring.
🔬 Measurement: Can be verified by benchmarking string replacement on strings without the target substring; memory allocations will be zero.

---
*PR created automatically by Jules for task [8784871428562524629](https://jules.google.com/task/8784871428562524629) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation detailing an optimization for string replacement operations.

* **Chores**
  * Optimized string replacement: implemented check for target substring existence prior to processing. When target is not found, the function returns the original string unchanged, eliminating unnecessary memory allocations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/498)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->