### PR TITLE
[JULES] Scheduled Maintenance: Performance optimization for lossy string conversions

### DIFF
--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -935,8 +935,8 @@ impl IoClient {
             .await
             .map_err(|e| format!("Failed to execute command '{}': {}", command, e))?;
 
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         let exit_code = output.status.code().unwrap_or(-1);
 
         Ok((stdout, stderr, exit_code))
@@ -1176,7 +1176,7 @@ impl IoClient {
             .ok_or_else(|| format!("Invalid process ID: {}", process_id))?;
 
         let mut buffer = handle.stdout_buffer.lock().await;
-        let output = String::from_utf8_lossy(&buffer.read_all()).to_string();
+        let output = String::from_utf8_lossy(&buffer.read_all()).into_owned();
         Ok(output)
     }
 
@@ -4665,7 +4665,7 @@ impl Interpreter {
                                 }
 
                                 // Convert body to string
-                                let body_str = String::from_utf8_lossy(&body).to_string();
+                                let body_str = String::from_utf8_lossy(&body).into_owned();
 
                                 // Create response channel
                                 let (response_sender, response_receiver) =
@@ -6431,9 +6431,7 @@ impl Interpreter {
 
                 #[cfg(debug_assertions)]
                 let func_name = match &function_val {
-                    Value::Function(f) => {
-                        f.name.clone().unwrap_or_else(|| "<anonymous>".to_string())
-                    }
+                    Value::Function(f) => f.name.as_deref().unwrap_or("<anonymous>").to_string(),
                     _ => format!("{function_val:?}"),
                 };
 
@@ -7691,7 +7689,7 @@ impl Interpreter {
 
             while let Some(entry) = entries.next_entry().await? {
                 let path = entry.path();
-                let path_str = path.to_string_lossy().to_string();
+                let path_str = path.to_string_lossy().into_owned();
 
                 if path.is_dir() {
                     dirs_to_process.push(path_str);
@@ -7732,7 +7730,7 @@ impl Interpreter {
             let path = entry.path();
 
             if path.is_file() {
-                let path_str = path.to_string_lossy().to_string();
+                let path_str = path.to_string_lossy().into_owned();
 
                 // Check extension filter
                 let file_ext = path

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -160,7 +160,7 @@ impl ReplState {
                         continue;
                     }
 
-                    let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                    let output = String::from_utf8_lossy(buffer.as_slice()).into_owned();
                     error_messages.push(output);
                 }
 
@@ -192,7 +192,7 @@ impl ReplState {
                     continue;
                 }
 
-                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                let output = String::from_utf8_lossy(buffer.as_slice()).into_owned();
                 error_messages.push(output);
             }
 
@@ -217,7 +217,7 @@ impl ReplState {
                     continue;
                 }
 
-                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                let output = String::from_utf8_lossy(buffer.as_slice()).into_owned();
                 error_messages.push(output);
             }
 
@@ -257,7 +257,8 @@ impl ReplState {
                                     continue;
                                 }
 
-                                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                                let output =
+                                    String::from_utf8_lossy(buffer.as_slice()).into_owned();
                                 error_messages.push(output);
                             }
 
@@ -287,7 +288,7 @@ impl ReplState {
                                 continue;
                             }
 
-                            let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                            let output = String::from_utf8_lossy(buffer.as_slice()).into_owned();
                             error_messages.push(output);
                         }
 
@@ -318,7 +319,7 @@ impl ReplState {
                             continue;
                         }
 
-                        let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
+                        let output = String::from_utf8_lossy(buffer.as_slice()).into_owned();
                         error_messages.push(output);
                     }
 


### PR DESCRIPTION
#### **Summary of Changes**

* **The Issue:** Unnecessary string allocations were happening due to the usage of `.to_string()` on `Cow<'_, str>` types returned by `String::from_utf8_lossy` and `Path::to_string_lossy`. Additionally, a string was being unnecessarily cloned inside an `Option` via `.clone().unwrap_or_else(|| "<anonymous>".to_string())`.
* **The Rational:** Reduced memory allocations and performance bottlenecks by utilizing `.into_owned()` and `.as_deref()`.
* **The Solution:** Replaced `.to_string()` with `.into_owned()` on the results of `from_utf8_lossy` and `to_string_lossy()`. Also replaced the `unwrap_or_else` cloning logic with `.as_deref().unwrap_or("<anonymous>").to_string()`.

#### **Verification Checklist**

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [719462761085534486](https://jules.google.com/task/719462761085534486) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/499" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal string handling in subprocess execution, process output retrieval, and error reporting to reduce unnecessary allocations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/499)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->