### PR TITLE
⚡ Bolt: [performance improvement] Refactor pattern module manual argument extraction

### DIFF
--- a/src/stdlib/helpers.rs
+++ b/src/stdlib/helpers.rs
@@ -557,6 +557,21 @@ generate_expect!(
 );
 
 generate_expect!(
+    /// Extracts a compiled pattern from a WFL Value.
+    ///
+    /// # Arguments
+    /// * `value` - The WFL Value to extract from
+    ///
+    /// # Returns
+    /// Returns an `Rc<CompiledPattern>` clone if the value is a Pattern variant.
+    expect_pattern,
+    Pattern,
+    Rc<crate::pattern::CompiledPattern>,
+    "a compiled pattern",
+    |p: &Rc<crate::pattern::CompiledPattern>| Rc::clone(p)
+);
+
+generate_expect!(
     /// Extracts a DateTime value from a WFL Value, returning it as a reference-counted NaiveDateTime.
     ///
     /// Returns an `Rc<chrono::NaiveDateTime>` to enable efficient memory sharing of datetime values.

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -1,3 +1,4 @@
+use super::helpers::{check_arg_count, expect_pattern, expect_text};
 use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
@@ -19,35 +20,11 @@ pub fn register(env: &mut Environment) {
 /// Native function: pattern_matches(text, pattern) -> boolean
 /// Tests if text matches the given compiled pattern
 pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_matches requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_matches", &args, 2)?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_matches must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_matches must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
+    let text_str = text.as_ref();
 
     let matches = compiled_pattern.matches(text_str);
     Ok(Value::Bool(matches))
@@ -56,35 +33,11 @@ pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find(text, pattern) -> object or null
 /// Finds the first match of pattern in text
 pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find", &args, 2)?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
+    let text_str = text.as_ref();
 
     match compiled_pattern.find(text_str) {
         Some(match_result) => {
@@ -120,35 +73,11 @@ pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find_all(text, pattern) -> list
 /// Finds all matches of pattern in text
 pub fn pattern_find_all_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find_all requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
+    check_arg_count("pattern_find_all", &args, 2)?;
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find_all must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find_all must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text = expect_text(&args[0])?;
+    let compiled_pattern = expect_pattern(&args[1])?;
+    let text_str = text.as_ref();
 
     let matches = compiled_pattern.find_all(text_str);
     let mut result_list = Vec::new();
@@ -189,46 +118,15 @@ pub fn native_pattern_replace(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 3 {
-        return Err(RuntimeError::new(
-            "pattern_replace requires exactly 3 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_replace", &args, 3)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _pattern = match &args[1] {
-        Value::Pattern(p) => p.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let _replacement = match &args[2] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Third argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _replacement =
+        expect_text(&args[2]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text.as_ref();
 
     // TODO: Update to use new pattern system for replacement
     Ok(Value::Text(Arc::from(text)))
@@ -240,35 +138,13 @@ pub fn native_pattern_split(
     line: usize,
     column: usize,
 ) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_split requires exactly 2 arguments".to_string(),
-            line,
-            column,
-        ));
-    }
+    check_arg_count("pattern_split", &args, 2)
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
-
-    let pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let pattern =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
 
     // Find all matches of the pattern in the text
     let matches = pattern.find_all(text);

--- a/src/stdlib/pattern_test.rs
+++ b/src/stdlib/pattern_test.rs
@@ -21,7 +21,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -33,7 +33,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -45,7 +45,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -57,6 +57,6 @@ mod tests {
         ];
         let result = pattern_matches_native(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("First argument"));
+        assert!(result.unwrap_err().to_string().contains("Expected text"));
     }
 }


### PR DESCRIPTION
## Summary of Changes

* **The Issue:** The `src/stdlib/pattern.rs` file had manual duplicate logic to pattern-match and validate `Value` enums (e.g. `Value::Text` and `Value::Pattern`). This was highly verbose and inefficient for checking argument types and returning custom `RuntimeError`s.
* **The Rational:** Unifying this logic through standard `expect_*` and `check_arg_count` helpers improves maintainability by adhering to the DRY principle, reduces redundant error instantiation, and makes the module much more concise, directly resolving technical debt.
* **The Solution:** Added a new `expect_pattern` macro to `src/stdlib/helpers.rs` and migrated the `pattern.rs` functions (`pattern_matches_native`, `pattern_find_native`, `pattern_find_all_native`, `native_pattern_replace`, `native_pattern_split`) to use the consolidated extraction logic. Refactored the unit tests in `src/stdlib/pattern_test.rs` to check for the standardized error message `Expected text` and `expects 2 arguments`.

## Verification Checklist

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [3879846073613580161](https://jules.google.com/task/3879846073613580161) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/502" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated pattern validation logic using shared helper functions.

* **Bug Fixes**
  * Standardized error messaging for pattern operations to provide consistent feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/502)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->