### PR TITLE
[JULES] Scheduled Maintenance: Pattern Value Refactor

### DIFF
--- a/src/stdlib/helpers.rs
+++ b/src/stdlib/helpers.rs
@@ -596,6 +596,31 @@ generate_expect!(
     |dt: &Rc<chrono::NaiveDateTime>| Rc::clone(dt)
 );
 
+generate_expect!(
+    /// Extracts a Pattern value from a WFL Value, returning it as a reference-counted CompiledPattern.
+    ///
+    /// Returns an `Rc<crate::pattern::CompiledPattern>` to enable efficient memory sharing.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The WFL Value to extract from
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Rc<crate::pattern::CompiledPattern>` clone (incrementing the reference count) if the value
+    /// is a Pattern variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RuntimeError` if the value is not a Pattern, with an error message
+    /// indicating the expected type and the actual type received.
+    expect_pattern,
+    Pattern,
+    Rc<crate::pattern::CompiledPattern>,
+    "a pattern",
+    |p: &Rc<crate::pattern::CompiledPattern>| Rc::clone(p)
+);
+
 /// Helper for unary list operations (List -> Value)
 ///
 /// Handles argument count checking, type extraction, and operation execution.

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -27,27 +27,10 @@ pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
         ));
     }
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_matches must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text_arc = super::helpers::expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
 
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_matches must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let compiled_pattern = super::helpers::expect_pattern(&args[1])?;
 
     let matches = compiled_pattern.matches(text_str);
     Ok(Value::Bool(matches))
@@ -64,27 +47,10 @@ pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
         ));
     }
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text_arc = super::helpers::expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
 
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let compiled_pattern = super::helpers::expect_pattern(&args[1])?;
 
     match compiled_pattern.find(text_str) {
         Some(match_result) => {
@@ -128,27 +94,10 @@ pub fn pattern_find_all_native(args: Vec<Value>) -> Result<Value, RuntimeError> 
         ));
     }
 
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find_all must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let text_arc = super::helpers::expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
 
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find_all must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    let compiled_pattern = super::helpers::expect_pattern(&args[1])?;
 
     let matches = compiled_pattern.find_all(text_str);
     let mut result_list = Vec::new();
@@ -197,38 +146,17 @@ pub fn native_pattern_replace(
         ));
     }
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = super::helpers::expect_text(&args[0])
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
 
-    let _pattern = match &args[1] {
-        Value::Pattern(p) => p.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let _pattern_rc = super::helpers::expect_pattern(&args[1])
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _pattern = _pattern_rc.as_ref();
 
-    let _replacement = match &args[2] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Third argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let _replacement_arc = super::helpers::expect_text(&args[2])
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _replacement = _replacement_arc.as_ref();
 
     // TODO: Update to use new pattern system for replacement
     Ok(Value::Text(Arc::from(text)))
@@ -248,27 +176,12 @@ pub fn native_pattern_split(
         ));
     }
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = super::helpers::expect_text(&args[0])
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
 
-    let pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let pattern = super::helpers::expect_pattern(&args[1])
+        .map_err(|e| RuntimeError::new(e.message, line, column))?;
 
     // Find all matches of the pattern in the text
     let matches = pattern.find_all(text);

--- a/src/stdlib/pattern_test.rs
+++ b/src/stdlib/pattern_test.rs
@@ -57,6 +57,11 @@ mod tests {
         ];
         let result = pattern_matches_native(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("First argument"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Expected text, got Number")
+        );
     }
 }


### PR DESCRIPTION
#### **Summary of Changes**

* **The Issue:** Manual `match` blocks were being used repeatedly across `src/stdlib/pattern.rs` to extract `Value::Text` and `Value::Pattern` from function arguments, duplicating error handling and extraction logic.
* **The Rational:** Improved maintainability, eliminated redundancy, and standardized error messaging.
* **The Solution:** Added a new macro-generated `expect_pattern` to `src/stdlib/helpers.rs` and refactored multiple functions in `src/stdlib/pattern.rs` (`pattern_matches_native`, `pattern_find_native`, `pattern_find_all_native`, `native_pattern_replace`, `native_pattern_split`) to use the `expect_text` and `expect_pattern` helpers instead of manual pattern matching.

#### **Verification Checklist**

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [17883455864191053605](https://jules.google.com/task/17883455864191053605) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/504" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated pattern validation logic and improved error messages across pattern-related operations, including matching, finding, replacement, and splitting functions.

* **Tests**
  * Updated test assertions to verify more specific and descriptive error messages when pattern functions receive incorrect argument types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/504)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->