### PR TITLE
[JULES] Scheduled Maintenance: Refactor Pattern Native Functions

### DIFF
--- a/src/stdlib/helpers.rs
+++ b/src/stdlib/helpers.rs
@@ -1,5 +1,6 @@
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
+use crate::pattern::CompiledPattern;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -594,6 +595,29 @@ generate_expect!(
     Rc<chrono::NaiveDateTime>,
     "a DateTime",
     |dt: &Rc<chrono::NaiveDateTime>| Rc::clone(dt)
+);
+
+generate_expect!(
+    /// Extracts a CompiledPattern value from a WFL Value, returning it as a reference-counted CompiledPattern.
+    ///
+    /// Returns an `Rc<CompiledPattern>` to enable efficient memory sharing without compiling again.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The WFL Value to extract from
+    ///
+    /// # Returns
+    ///
+    /// Returns an `Rc<CompiledPattern>` clone (incrementing the reference count) if the value is a Pattern variant.
+    ///
+    /// # Errors
+    ///
+    /// Returns `RuntimeError` if the value is not a Pattern.
+    expect_pattern,
+    Pattern,
+    Rc<CompiledPattern>,
+    "a pattern",
+    |p: &Rc<CompiledPattern>| Rc::clone(p)
 );
 
 /// Helper for unary list operations (List -> Value)

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -1,6 +1,7 @@
 use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
+use crate::stdlib::helpers::{check_arg_count, expect_pattern, expect_text};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -19,35 +20,10 @@ pub fn register(env: &mut Environment) {
 /// Native function: pattern_matches(text, pattern) -> boolean
 /// Tests if text matches the given compiled pattern
 pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_matches requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
-
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_matches must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_matches must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    check_arg_count("pattern_matches", &args, 2)?;
+    let text_arc = expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
+    let compiled_pattern = expect_pattern(&args[1])?;
 
     let matches = compiled_pattern.matches(text_str);
     Ok(Value::Bool(matches))
@@ -56,35 +32,10 @@ pub fn pattern_matches_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find(text, pattern) -> object or null
 /// Finds the first match of pattern in text
 pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
-
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    check_arg_count("pattern_find", &args, 2)?;
+    let text_arc = expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
+    let compiled_pattern = expect_pattern(&args[1])?;
 
     match compiled_pattern.find(text_str) {
         Some(match_result) => {
@@ -120,35 +71,10 @@ pub fn pattern_find_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
 /// Native function: pattern_find_all(text, pattern) -> list
 /// Finds all matches of pattern in text
 pub fn pattern_find_all_native(args: Vec<Value>) -> Result<Value, RuntimeError> {
-    if args.len() != 2 {
-        return Err(RuntimeError::new(
-            "pattern_find_all requires exactly 2 arguments (text, pattern)".to_string(),
-            0,
-            0,
-        ));
-    }
-
-    let text_str = match &args[0] {
-        Value::Text(s) => s.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument to pattern_find_all must be text".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
-
-    let compiled_pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument to pattern_find_all must be a compiled pattern".to_string(),
-                0,
-                0,
-            ));
-        }
-    };
+    check_arg_count("pattern_find_all", &args, 2)?;
+    let text_arc = expect_text(&args[0])?;
+    let text_str = text_arc.as_ref();
+    let compiled_pattern = expect_pattern(&args[1])?;
 
     let matches = compiled_pattern.find_all(text_str);
     let mut result_list = Vec::new();
@@ -191,44 +117,22 @@ pub fn native_pattern_replace(
 ) -> Result<Value, RuntimeError> {
     if args.len() != 3 {
         return Err(RuntimeError::new(
-            "pattern_replace requires exactly 3 arguments".to_string(),
+            "pattern_replace expects 3 arguments".to_string(),
             line,
             column,
         ));
     }
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
 
-    let _pattern = match &args[1] {
-        Value::Pattern(p) => p.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let pattern_rc =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _pattern = pattern_rc.as_ref();
 
-    let _replacement = match &args[2] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "Third argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let replacement_arc =
+        expect_text(&args[2]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let _replacement = replacement_arc.as_ref();
 
     // TODO: Update to use new pattern system for replacement
     Ok(Value::Text(Arc::from(text)))
@@ -242,33 +146,18 @@ pub fn native_pattern_split(
 ) -> Result<Value, RuntimeError> {
     if args.len() != 2 {
         return Err(RuntimeError::new(
-            "pattern_split requires exactly 2 arguments".to_string(),
+            "pattern_split expects 2 arguments".to_string(),
             line,
             column,
         ));
     }
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
-        _ => {
-            return Err(RuntimeError::new(
-                "First argument must be text".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let text_arc = expect_text(&args[0]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let text = text_arc.as_ref();
 
-    let pattern = match &args[1] {
-        Value::Pattern(p) => p,
-        _ => {
-            return Err(RuntimeError::new(
-                "Second argument must be a pattern".to_string(),
-                line,
-                column,
-            ));
-        }
-    };
+    let pattern_rc =
+        expect_pattern(&args[1]).map_err(|e| RuntimeError::new(e.message, line, column))?;
+    let pattern = pattern_rc.as_ref();
 
     // Find all matches of the pattern in the text
     let matches = pattern.find_all(text);

--- a/src/stdlib/pattern_test.rs
+++ b/src/stdlib/pattern_test.rs
@@ -21,7 +21,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -33,7 +33,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -45,7 +45,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("exactly 2 arguments")
+                .contains("expects 2 arguments")
         );
     }
 
@@ -57,6 +57,6 @@ mod tests {
         ];
         let result = pattern_matches_native(args);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("First argument"));
+        assert!(result.unwrap_err().to_string().contains("Expected text"));
     }
 }


### PR DESCRIPTION
## Summary of Changes
* **The Issue:** The `pattern.rs` file uses boilerplate `match` blocks to extract arguments instead of standard type extraction helpers like `expect_text`.
* **The Rational:** Eliminates redundant code and improves maintainability by using centralized helper macros.
* **The Solution:** Added `expect_pattern` to `helpers.rs` and refactored `pattern.rs` native functions to use `expect_pattern` and `expect_text`.

## Verification Checklist
- [x] `cargo fmt` executed and passed.
- [x] `cargo clippy` returned no warnings or errors.
- [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [7850186710577598919](https://jules.google.com/task/7850186710577598919) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized argument validation for pattern operations.

* **Tests**
  * Updated unit tests to reflect refined error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->