### PR TITLE
[JULES] Scheduled Maintenance: Optimized string conversions

### DIFF
--- a/src/interpreter/assertion_helpers.rs
+++ b/src/interpreter/assertion_helpers.rs
@@ -226,9 +226,9 @@ impl Interpreter {
         match value {
             Value::Number(n) => {
                 if n.fract() == 0.0 {
-                    format!("{}", *n as i64)
+                    (*n as i64).to_string()
                 } else {
-                    format!("{}", n)
+                    n.to_string()
                 }
             }
             Value::Text(s) => format!("\"{}\"", s),

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7543,8 +7543,12 @@ impl Interpreter {
             return Value::Text(Arc::from(s));
         }
 
-        let result = format!("{left_val}{right_val}");
-        Value::Text(Arc::from(result.as_str()))
+        let left_str = left_val.to_string_fast();
+        let right_str = right_val.to_string_fast();
+        let mut s = String::with_capacity(left_str.len() + right_str.len());
+        s.push_str(&left_str);
+        s.push_str(&right_str);
+        Value::Text(Arc::from(s))
     }
 
     fn add(
@@ -7564,12 +7568,18 @@ impl Interpreter {
                 Ok(Value::Text(Arc::from(s)))
             }
             (Value::Text(a), b) => {
-                let result = format!("{a}{b}");
-                Ok(Value::Text(Arc::from(result.as_str())))
+                let b_str = b.to_string_fast();
+                let mut s = String::with_capacity(a.len() + b_str.len());
+                s.push_str(&a);
+                s.push_str(&b_str);
+                Ok(Value::Text(Arc::from(s)))
             }
             (a, Value::Text(b)) => {
-                let result = format!("{a}{b}");
-                Ok(Value::Text(Arc::from(result.as_str())))
+                let a_str = a.to_string_fast();
+                let mut s = String::with_capacity(a_str.len() + b.len());
+                s.push_str(&a_str);
+                s.push_str(&b);
+                Ok(Value::Text(Arc::from(s)))
             }
             (a, b) => Err(RuntimeError::new(
                 format!("Cannot add {} and {}", a.type_name(), b.type_name()),

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -157,6 +157,16 @@ pub struct ActionSignature {
 }
 
 impl Value {
+    pub fn to_string_fast(&self) -> std::borrow::Cow<'_, str> {
+        match self {
+            Value::Text(s) => std::borrow::Cow::Borrowed(s.as_ref()),
+            Value::Number(n) => std::borrow::Cow::Owned(n.to_string()),
+            Value::Bool(b) => std::borrow::Cow::Borrowed(if *b { "yes" } else { "no" }),
+            Value::Null | Value::Nothing => std::borrow::Cow::Borrowed("nothing"),
+            _ => std::borrow::Cow::Owned(self.to_string()),
+        }
+    }
+
     pub fn type_name(&self) -> &'static str {
         match self {
             Value::Number(_) => "Number",


### PR DESCRIPTION
#### **Summary of Changes**

* **The Issue:** The interpreter used `format!` and generic `.to_string()` machinery for primitive string conversions and string concatenation in `src/interpreter/mod.rs` and `src/interpreter/assertion_helpers.rs`, incurring unnecessary formatting overhead and memory allocations.
* **The Rational:** Eliminated bottleneck by reducing format macro overhead and unnecessary intermediate allocations on the hot path for string concatenation and conversions, improving performance.
* **The Solution:** Added a `to_string_fast` method to `Value` that uses `Cow` to efficiently borrow strings or lazily format numbers/booleans. Replaced `format!` in string concatenation operations and assertion helpers with direct string building.

#### **Verification Checklist**

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [14922208771358742622](https://jules.google.com/task/14922208771358742622) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Enhanced string formatting and concatenation operations for faster execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->