### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2026-04-22 - [Avoid string allocation on single-part split]
 **Learning:** Calling `.split(delimiter)` on a reference-counted string (`Arc<str>`) and `.map()`ing the results into `Arc::from(s)` unconditionally creates a new allocation for every chunk. If the delimiter doesn't exist, the entire string is re-allocated unnecessarily.
 **Action:** When iterating over a split of a reference-counted string, explicitly check if `s.len() == text.len() && !text.is_empty()`. If it is, use `Arc::clone(&text)` to return another reference to the existing string, bypassing the allocation.
+
+## 2026-05-18 - [Avoid Vec allocation for pattern match indices]
+**Learning:** Collecting `char_indices` into a `Vec<usize>` inside `pattern.find_all` result conversions causes an unnecessary O(N) allocation. Using a single-pass tracking iterator on `chars()` with `len_utf8()` increments safely handles UTF-8 while preserving O(1) memory overhead.
+**Action:** For continuous index mapping in string search and split operations, convert character indices to byte indices monotonically on demand instead of pre-allocating an array of all indices.

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -279,27 +279,36 @@ pub fn native_pattern_split(
         return Ok(Value::List(Rc::new(RefCell::new(parts))));
     }
 
-    // Build character-to-byte index mapping
-    let char_to_byte: Vec<usize> = text.char_indices().map(|(byte_idx, _)| byte_idx).collect();
-    let mut char_to_byte = char_to_byte;
-    char_to_byte.push(text.len()); // Add final byte position
-
-    // Split the text at match positions
+    // Split the text at match positions using tracking iterators
+    // avoiding the O(N) memory allocation of building char_to_byte array
     let mut parts = Vec::new();
     let mut last_end_char = 0;
 
+    let mut current_char_idx = 0;
+    let mut current_byte_idx = 0;
+    let mut chars = text.chars();
+    let mut last_end_byte = 0;
+
     for match_result in matches {
-        // Convert character indices to byte indices
-        let start_byte = if match_result.start < char_to_byte.len() {
-            char_to_byte[match_result.start]
-        } else {
-            text.len()
-        };
-        let last_end_byte = if last_end_char < char_to_byte.len() {
-            char_to_byte[last_end_char]
-        } else {
-            text.len()
-        };
+        // Convert character indices to byte indices by advancing tracking iterator
+        while current_char_idx < match_result.start {
+            if let Some(c) = chars.next() {
+                current_byte_idx += c.len_utf8();
+                current_char_idx += 1;
+            } else {
+                break;
+            }
+        }
+        let start_byte = current_byte_idx;
+
+        while current_char_idx < match_result.end {
+            if let Some(c) = chars.next() {
+                current_byte_idx += c.len_utf8();
+                current_char_idx += 1;
+            } else {
+                break;
+            }
+        }
 
         // Add the text before this match
         if match_result.start > last_end_char
@@ -311,15 +320,14 @@ pub fn native_pattern_split(
             // Add empty string for consecutive matches
             parts.push(Value::Text(Arc::from("")));
         }
+
         last_end_char = match_result.end;
+        last_end_byte = current_byte_idx;
     }
 
     // Add any remaining text after the last match
-    if last_end_char < char_to_byte.len() {
-        let last_end_byte = char_to_byte[last_end_char];
-        let part = &text[last_end_byte..];
-        parts.push(Value::Text(Arc::from(part)));
-    }
+    let part = &text[last_end_byte..];
+    parts.push(Value::Text(Arc::from(part)));
 
     Ok(Value::List(Rc::new(RefCell::new(parts))))
 }


### PR DESCRIPTION
### 💡 What
Refactored `native_pattern_split` to replace the O(N) `Vec<usize>` index mapping array with a single-pass tracking iterator.

### 🎯 Why
The previous implementation allocated a vector equal to the character length of the string to map character indices to byte indices, causing high memory and performance overhead for large strings.

### 📊 Impact
Reduces memory complexity from O(N) to O(1) by avoiding the `char_to_byte` array, resulting in substantially faster split operations for large texts.

### 🔬 Measurement
Run `cargo bench` or tests verifying split behavior; the exact performance gain can be reproduced using a test script that measures the time spent on `Vec` allocation vs a tracking iterator.

---
*PR created automatically by Jules for task [12818685356410182413](https://jules.google.com/task/12818685356410182413) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/512" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized string pattern matching operations for improved performance by streamlining internal processing of character-to-byte index conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->