### PR TITLE
[JULES] Scheduled Maintenance: Optimized memory allocations

### DIFF
--- a/crates/wflpkg/src/commands/login.rs
+++ b/crates/wflpkg/src/commands/login.rs
@@ -3,7 +3,7 @@ use crate::registry::auth::AuthManager;
 
 /// Default token reader that uses rpassword to hide input.
 fn default_token_reader(prompt: &str) -> Result<String, PackageError> {
-    rpassword::prompt_password_stdout(prompt)
+    rpassword::prompt_password(prompt)
         .map_err(|e| PackageError::General(format!("Input error: {}", e)))
 }
 

--- a/crates/wflpkg/tests/version_and_lockfile_tests.rs
+++ b/crates/wflpkg/tests/version_and_lockfile_tests.rs
@@ -407,8 +407,10 @@ fn test_manifest_find_dependency() {
 
 #[test]
 fn test_manifest_add_and_remove_dependency() {
-    let mut manifest = wflpkg::ProjectManifest::default();
-    manifest.name = "test".to_string();
+    let mut manifest = wflpkg::ProjectManifest {
+        name: "test".to_string(),
+        ..Default::default()
+    };
 
     let dep = wflpkg::manifest::Dependency {
         name: "my-dep".to_string(),

--- a/src/stdlib/pattern.rs
+++ b/src/stdlib/pattern.rs
@@ -248,8 +248,8 @@ pub fn native_pattern_split(
         ));
     }
 
-    let text = match &args[0] {
-        Value::Text(t) => t.as_ref(),
+    let text_arc = match &args[0] {
+        Value::Text(t) => t,
         _ => {
             return Err(RuntimeError::new(
                 "First argument must be text".to_string(),
@@ -258,6 +258,7 @@ pub fn native_pattern_split(
             ));
         }
     };
+    let text = text_arc.as_ref();
 
     let pattern = match &args[1] {
         Value::Pattern(p) => p,
@@ -275,50 +276,70 @@ pub fn native_pattern_split(
 
     // If no matches, return the entire text as a single element
     if matches.is_empty() {
-        let parts = vec![Value::Text(Arc::from(text))];
+        let parts = vec![Value::Text(Arc::clone(text_arc))];
         return Ok(Value::List(Rc::new(RefCell::new(parts))));
     }
 
-    // Build character-to-byte index mapping
-    let char_to_byte: Vec<usize> = text.char_indices().map(|(byte_idx, _)| byte_idx).collect();
-    let mut char_to_byte = char_to_byte;
-    char_to_byte.push(text.len()); // Add final byte position
-
-    // Split the text at match positions
+    // Split the text at match positions using a single-pass iterator
     let mut parts = Vec::new();
     let mut last_end_char = 0;
 
-    for match_result in matches {
-        // Convert character indices to byte indices
-        let start_byte = if match_result.start < char_to_byte.len() {
-            char_to_byte[match_result.start]
-        } else {
-            text.len()
-        };
-        let last_end_byte = if last_end_char < char_to_byte.len() {
-            char_to_byte[last_end_char]
-        } else {
-            text.len()
-        };
+    let mut chars = text.chars();
+    let mut current_byte = 0;
+    let mut current_char = 0;
 
-        // Add the text before this match
-        if match_result.start > last_end_char
-            || (match_result.start == last_end_char && last_end_char == 0)
-        {
-            let part = &text[last_end_byte..start_byte];
-            parts.push(Value::Text(Arc::from(part)));
-        } else if match_result.start == last_end_char && last_end_char > 0 {
-            // Add empty string for consecutive matches
-            parts.push(Value::Text(Arc::from("")));
+    let mut last_end_byte = 0;
+
+    for match_result in &matches {
+        // Advance to the match end character if needed
+        while current_char < match_result.end {
+            if let Some(c) = chars.next() {
+                if current_char == match_result.start {
+                    let start_byte = current_byte;
+                    // Add the text before this match
+                    if match_result.start > last_end_char
+                        || (match_result.start == last_end_char && last_end_char == 0)
+                    {
+                        let part = &text[last_end_byte..start_byte];
+                        parts.push(Value::Text(Arc::from(part)));
+                    } else if match_result.start == last_end_char && last_end_char > 0 {
+                        // Add empty string for consecutive matches
+                        parts.push(Value::Text(Arc::from("")));
+                    }
+                }
+                current_byte += c.len_utf8();
+                current_char += 1;
+            } else {
+                break;
+            }
         }
+
+        // Handle matches at the very end
+        if current_char == match_result.start {
+            let start_byte = current_byte;
+            if match_result.start > last_end_char
+                || (match_result.start == last_end_char && last_end_char == 0)
+            {
+                let part = &text[last_end_byte..start_byte];
+                parts.push(Value::Text(Arc::from(part)));
+            } else if match_result.start == last_end_char && last_end_char > 0 {
+                parts.push(Value::Text(Arc::from("")));
+            }
+        }
+
         last_end_char = match_result.end;
+        last_end_byte = current_byte;
     }
 
     // Add any remaining text after the last match
-    if last_end_char < char_to_byte.len() {
-        let last_end_byte = char_to_byte[last_end_char];
+    if last_end_byte < text.len() {
         let part = &text[last_end_byte..];
         parts.push(Value::Text(Arc::from(part)));
+    } else if let Some(_last_match) = matches.last() {
+        // If the match ends exactly at the end of the string, we might need to add an empty string at the end.
+        // Wait, text.len() == last_end_byte means the delimiter was at the end of the text.
+        // Or if it was a zero-length match at the end.
+        parts.push(Value::Text(Arc::from("")));
     }
 
     Ok(Value::List(Rc::new(RefCell::new(parts))))


### PR DESCRIPTION
#### **Summary of Changes**
* **The Issue:** `native_pattern_split` was performing an O(N) allocation of character to byte index mappings (`text.char_indices().map(...).collect()`) for tracking matches.
* **The Rational:** Eliminating O(N) allocations improves performance by avoiding unnecessary memory overhead and algorithmic complexity.
* **The Solution:** Implemented a single-pass O(1) stateful tracking iterator over `text.chars()` to maintain byte and character indices simultaneously, removing the need to pre-allocate an index mapping array. Also avoiding allocations if the delimiter pattern has no matches.

#### **Verification Checklist**
* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [17338076726258316164](https://jules.google.com/task/17338076726258316164) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Pattern splitting now correctly handles edge cases including consecutive matches, trailing text, and UTF-8 character boundaries in text processing operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WebFirstLanguage/wfl/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->