### PR TITLE
[JULES] Scheduled Maintenance: Optimized memory allocations

### DIFF
--- a/crates/wflpkg/src/commands/login.rs
+++ b/crates/wflpkg/src/commands/login.rs
@@ -3,7 +3,7 @@ use crate::registry::auth::AuthManager;
 
 /// Default token reader that uses rpassword to hide input.
 fn default_token_reader(prompt: &str) -> Result<String, PackageError> {
-    rpassword::prompt_password_stdout(prompt)
+    rpassword::prompt_password(prompt)
         .map_err(|e| PackageError::General(format!("Input error: {}", e)))
 }
 

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -146,6 +146,14 @@ pub fn native_substring(args: Vec<Value>) -> Result<Value, RuntimeError> {
         return Ok(Value::Text(Arc::from("")));
     }
 
+    // Optimization: Fast path for when the requested substring covers the entire string.
+    // We check byte length first (O(1)). This may occasionally miss cases where the requested
+    // length in characters is between the string's character count and byte count, but avoids
+    // an O(N) check that would penalize valid smaller substring extractions.
+    if start == 0 && length >= text.len() {
+        return Ok(Value::Text(Arc::clone(&text)));
+    }
+
     // Optimization: Use chars() iterator which is highly optimized for skipping
     // and as_str() to get slices without allocating intermediate strings.
     let mut chars = text.chars();


### PR DESCRIPTION
## Summary of Changes

* **The Issue:** `native_substring` in `src/stdlib/text.rs` unconditionally allocates a new string slice (`Arc<str>`), even when the requested substring covers the entire original string. Additionally, the `wflpkg` crate was failing to compile due to the deprecated `rpassword::prompt_password_stdout` function in `crates/wflpkg/src/commands/login.rs`.
* **The Rational:** Unnecessary memory allocations during substring operations create performance bottlenecks. Furthermore, failing to resolve the `rpassword` deprecation prevents the workspace from compiling successfully during verification loops.
* **The Solution:** Implemented a fast-path optimization in `native_substring` to check if `start == 0` and the length covers the entire string. If so, it now clones the existing `Arc<str>`, bypassing the allocation. The length check uses an O(1) byte length check instead of character length to prevent penalizing regular substrings. Also replaced the deprecated `rpassword::prompt_password_stdout` with the current `rpassword::prompt_password` to fix the compilation error permanently.

## Verification Checklist

* [x] `cargo fmt` executed and passed.
* [x] `cargo clippy` returned no warnings or errors.
* [x] All `cargo test` suites passed (100% success rate).

---
*PR created automatically by Jules for task [5323770746730430691](https://jules.google.com/task/5323770746730430691) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated password prompt handling in the login authentication process.

* **Refactor**
  * Improved substring operation performance with optimized string handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->