### PR TITLE
⚡ Bolt: [Optimize substring full extraction fast path]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -61,3 +61,7 @@
 ## 2026-04-22 - [Avoid string allocation on single-part split]
 **Learning:** Calling `.split(delimiter)` on a reference-counted string (`Arc<str>`) and `.map()`ing the results into `Arc::from(s)` unconditionally creates a new allocation for every chunk. If the delimiter doesn't exist, the entire string is re-allocated unnecessarily.
 **Action:** When iterating over a split of a reference-counted string, explicitly check if `s.len() == text.len() && !text.is_empty()`. If it is, use `Arc::clone(&text)` to return another reference to the existing string, bypassing the allocation.
+
+## 2026-06-02 - [Optimize Substring Full Extraction Fast Path]
+**Learning:** When extracting a substring from a reference-counted string (`Arc<str>`), checking if the requested range covers the entire string using an O(1) condition like `start == 0 && length >= text.len()` can avoid an unnecessary O(N) iteration through `text.chars().nth()` and avoids allocating a new string slice.
+**Action:** Always check for full-string extraction fast paths (`start == 0 && length >= text.len()`) before falling back to iterator-based bounds checks. If matched, clone the reference (`Arc::clone(&text)`) instead of slicing.

--- a/crates/wflpkg/src/commands/login.rs
+++ b/crates/wflpkg/src/commands/login.rs
@@ -3,7 +3,7 @@ use crate::registry::auth::AuthManager;
 
 /// Default token reader that uses rpassword to hide input.
 fn default_token_reader(prompt: &str) -> Result<String, PackageError> {
-    rpassword::prompt_password_stdout(prompt)
+    rpassword::prompt_password(prompt)
         .map_err(|e| PackageError::General(format!("Input error: {}", e)))
 }
 

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -146,6 +146,12 @@ pub fn native_substring(args: Vec<Value>) -> Result<Value, RuntimeError> {
         return Ok(Value::Text(Arc::from("")));
     }
 
+    // Optimization: fast path for when the substring requested encompasses the entire string.
+    // Avoids O(N) penalty and allocates nothing.
+    if start == 0 && length >= text.len() {
+        return Ok(Value::Text(Arc::clone(&text)));
+    }
+
     // Optimization: Use chars() iterator which is highly optimized for skipping
     // and as_str() to get slices without allocating intermediate strings.
     let mut chars = text.chars();


### PR DESCRIPTION
💡 What: Added an O(1) fast-path check to `native_substring` in `src/stdlib/text.rs` to return a cloned `Arc` when extracting the full string. Also fixed deprecated `rpassword::prompt_password_stdout` in `crates/wflpkg/src/commands/login.rs` to fix tests.
🎯 Why: To avoid an unnecessary O(N) penalty from `text.chars().nth()` and prevent allocating a new string slice when the requested length encompasses the entire text.
📊 Impact: Reduces substring extraction complexity from O(N) to O(1) and eliminates memory allocation when the requested substring covers the entire original string.
🔬 Measurement: Run substring benchmarks or test with large strings where `start=0` and `length` is very large, and observe the speedup.

---
*PR created automatically by Jules for task [14386155894812334734](https://jules.google.com/task/14386155894812334734) started by @logbie*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Substring text extraction operations now execute faster when extracting full strings from text data.

* **Bug Fixes**
  * Improved password input handling in the login process for better user experience.

* **Documentation**
  * Updated documentation with details on substring extraction optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->