### PR TITLE
feat: add execute file statement for in-process WFL page execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the WFL project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project uses a calendar-based versioning scheme: **YY.MM.BUILD**.
 
+## [Unreleased]
+
+### Added
+- New `execute file` statement for running WFL files in-process: `execute [wfl] file at <path> [with <request>] [and read output as <variable>]`
+- Web servers can now serve dynamic WFL pages PHP-style: execute a `.wfl` file per request, pass it the HTTP request context (`method`, `path`, `client_ip`, `body`, `headers`), capture its display output, and respond with it
+- Output capture mechanism (`display`/`print` redirection) for nested interpreter runs, with correct nesting semantics
+- Request objects from `wait for request` now carry `method`, `path`, `client_ip`, `body` and `headers` properties (in addition to the existing standalone variables)
+- Errors in executed files (missing file, parse errors, runtime errors) are catchable in the parent with `try`/`when`, including `when file not found`
+- Nesting depth guard (4 levels) protects against a file that executes itself
+
 ## [25.9.1] - 2025-09-20
 
 ### Added

--- a/Docs/04-advanced-features/subprocess-execution.md
+++ b/Docs/04-advanced-features/subprocess-execution.md
@@ -105,6 +105,23 @@ wait for read output from process proc as output_data
 display "Output: " with output_data
 ```
 
+## Executing WFL Files In-Process
+
+`execute command` starts a separate program. To run another **WFL file**
+inside the current program — without spawning a process — use `execute file`:
+
+```wfl
+execute wfl file at "report.wfl" and read output as report_output
+display "Captured: " with report_output
+```
+
+The file runs in a fresh, isolated environment with the full standard
+library. With `and read output as`, everything it displays is captured into a
+text variable instead of printed. Errors in the executed file are catchable
+with `try`. This powers dynamic web pages — see
+[Web Servers](web-servers.md#serving-dynamic-wfl-pages) for passing HTTP
+request context with `with <request>`.
+
 ## Error Handling
 
 Always handle subprocess errors:

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -305,6 +305,61 @@ otherwise:
 end check
 ```
 
+## Serving Dynamic WFL Pages
+
+Execute another WFL file on each request and send its output to the browser —
+like PHP, but in WFL. The `execute file` statement runs a `.wfl` file
+in-process, passes it the current request, and captures everything the file
+displays:
+
+```wfl
+listen on port 8080 as web_server
+
+main loop:
+    wait for request comes in on web_server as req
+
+    try:
+        execute wfl file at "pages/home.wfl" with req and read output as page_output
+        respond to req with page_output and content_type "text/html"
+    when file not found:
+        respond to req with "Page not found" and status 404
+    when error:
+        respond to req with "Server error" and status 500
+    end try
+end loop
+```
+
+The page file `pages/home.wfl` is a normal WFL program. Because the request
+was passed along with `with req`, the page sees the same request variables a
+server sees: `method`, `path`, `client_ip`, `body` and `headers`:
+
+```wfl
+display "<h1>Welcome!</h1>"
+display "<p>You asked for " with path with " using " with method with "</p>"
+```
+
+Everything the page displays is captured into `page_output` instead of being
+printed, ready to send to the browser.
+
+### The execute file statement
+
+```wfl
+execute [wfl] file at <path> [with <request>] [and read output as <variable>]
+```
+
+- The word `wfl` is optional — `execute file at "page.wfl"` works the same.
+- `with <request>` is optional. Without it the page runs with no request
+  context.
+- `and read output as <variable>` is optional. Without it the page's output is
+  displayed normally instead of captured.
+- The path is resolved relative to the directory of the WFL file doing the
+  executing, just like `load module`.
+- The page runs in its own fresh environment with the full standard library —
+  it cannot see or change the server's variables.
+- Errors inside the page (a missing file, parse errors, runtime errors) become
+  catchable errors in the server, so one broken page cannot crash the server.
+- Pages can execute other pages (for layouts or partials), up to 4 levels deep.
+
 ## JSON Responses
 
 Build JSON responses for APIs:

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -200,14 +200,14 @@ respond to <request> with <content> and status <code>
 ### With Content Type
 
 ```wfl
-respond to req with "Hello!" and content type "text/plain"
-respond to req with html_content and content type "text/html"
-respond to req with json_data and content type "application/json"
+respond to req with "Hello!" and content_type "text/plain"
+respond to req with html_content and content_type "text/html"
+respond to req with json_data and content_type "application/json"
 ```
 
 **Syntax:**
 ```wfl
-respond to <request> with <content> and content type <type>
+respond to <request> with <content> and content_type <type>
 ```
 
 **Common content types:**
@@ -220,7 +220,7 @@ respond to <request> with <content> and content type <type>
 ### Combined
 
 ```wfl
-respond to req with "Created!" and status 201 and content type "application/json"
+respond to req with "Created!" and status 201 and content_type "application/json"
 ```
 
 ## Routing
@@ -286,13 +286,13 @@ check if path starts with "/static/":
 
             // Determine content type
             check if filepath ends with ".html":
-                respond to req with content and content type "text/html"
+                respond to req with content and content_type "text/html"
             check if filepath ends with ".css":
-                respond to req with content and content type "text/css"
+                respond to req with content and content_type "text/css"
             check if filepath ends with ".js":
-                respond to req with content and content type "application/javascript"
+                respond to req with content and content_type "application/javascript"
             otherwise:
-                respond to req with content and content type "text/plain"
+                respond to req with content and content_type "text/plain"
             end check
         catch:
             respond to req with "Error reading file" and status 500
@@ -359,6 +359,13 @@ execute [wfl] file at <path> [with <request>] [and read output as <variable>]
 - Errors inside the page (a missing file, parse errors, runtime errors) become
   catchable errors in the server, so one broken page cannot crash the server.
 - Pages can execute other pages (for layouts or partials), up to 4 levels deep.
+- A `with` directly after the path always passes request context. To execute a
+  dynamically chosen page, build the path into a variable first:
+
+```wfl
+store page_path as "pages/" with page_name with ".wfl"
+execute wfl file at page_path with req and read output as page_output
+```
 
 ## JSON Responses
 
@@ -375,7 +382,7 @@ check if path is equal to "/api/status":
     \"server\": \"WFL Web Server\",
     \"version\": \"1.0.0\"
 }"
-    respond to req with status_json and content type "application/json"
+    respond to req with status_json and content_type "application/json"
 end check
 ```
 
@@ -389,7 +396,7 @@ store json_response as "{
     \"uptime\": " with uptime with "
 }"
 
-respond to req with json_response and content type "application/json"
+respond to req with json_response and content_type "application/json"
 ```
 
 ## Error Handling
@@ -489,22 +496,22 @@ check if path is equal to "/":
     </ul>
 </body>
 </html>"
-    respond to req with home_html and content type "text/html"
+    respond to req with home_html and content_type "text/html"
 
 check if path is equal to "/hello":
-    respond to req with "Hello from WFL Web Server!" and content type "text/plain"
+    respond to req with "Hello from WFL Web Server!" and content_type "text/plain"
 
 check if path is equal to "/api/status":
     store status_json as "{
     \"status\": \"running\",
     \"requests_handled\": " with request_count with "
 }"
-    respond to req with status_json and content type "application/json"
+    respond to req with status_json and content_type "application/json"
 
 check if path is equal to "/api/time":
     store current as current time in milliseconds
     store time_json as "{\"timestamp\": " with current with "}"
-    respond to req with time_json and content type "application/json"
+    respond to req with time_json and content_type "application/json"
 
 otherwise:
     respond to req with "404 - Not Found" and status 404
@@ -547,7 +554,7 @@ display "Response: " with response
 ```wfl
 check if path is equal to "/api/users":
     store users_json as "{\"users\": [\"Alice\", \"Bob\", \"Carol\"]}"
-    respond to req with users_json and content type "application/json"
+    respond to req with users_json and content_type "application/json"
 end check
 ```
 
@@ -555,7 +562,7 @@ end check
 
 ```wfl
 check if path is equal to "/health":
-    respond to req with "OK" and content type "text/plain"
+    respond to req with "OK" and content_type "text/plain"
 end check
 ```
 

--- a/Docs/reference/syntax-reference.md
+++ b/Docs/reference/syntax-reference.md
@@ -260,6 +260,14 @@ respond to req with content and status 200
 respond to req with content and content_type "text/html"
 ```
 
+## Execute WFL Files
+
+```wfl
+execute wfl file at "page.wfl"
+execute file at "page.wfl" and read output as page_output
+execute wfl file at "page.wfl" with req and read output as page_output
+```
+
 ## Comments
 
 ```wfl

--- a/TestPrograms/execute_pages/dynamic_page.wfl
+++ b/TestPrograms/execute_pages/dynamic_page.wfl
@@ -1,3 +1,4 @@
+// CI-SKIP: page fragment requiring request context, executed by execute_wfl_file tests
 // A dynamic page that uses the HTTP request context passed by the parent
 // via: execute wfl file at "..." with incoming_request and read output as ...
 // The request variables method, path, body, client_ip and headers are

--- a/TestPrograms/execute_pages/dynamic_page.wfl
+++ b/TestPrograms/execute_pages/dynamic_page.wfl
@@ -1,0 +1,8 @@
+// A dynamic page that uses the HTTP request context passed by the parent
+// via: execute wfl file at "..." with incoming_request and read output as ...
+// The request variables method, path, body, client_ip and headers are
+// predefined here, exactly like after "wait for request comes in".
+display "<h1>Dynamic WFL Page</h1>"
+display "<p>Method: " with method with "</p>"
+display "<p>Path: " with path with "</p>"
+display "<p>Client: " with client_ip with "</p>"

--- a/TestPrograms/execute_pages/hello_page.wfl
+++ b/TestPrograms/execute_pages/hello_page.wfl
@@ -1,0 +1,4 @@
+// A simple page executed by the execute file statement.
+// Its display output is captured and served/checked by the parent program.
+display "Hello from an executed WFL page!"
+display "This output was captured by the parent program."

--- a/TestPrograms/execute_wfl_file.test.wfl
+++ b/TestPrograms/execute_wfl_file.test.wfl
@@ -1,0 +1,26 @@
+// WFL test framework validation for the execute file statement.
+// Run with: wfl --test TestPrograms/execute_wfl_file.test.wfl
+
+describe "Execute file statement":
+
+    test "captures display output of an executed page":
+        execute wfl file at "execute_pages/hello_page.wfl" and read output as page_output
+        expect page_output to contain "Hello from an executed WFL page!"
+    end test
+
+    test "short form without wfl keyword works":
+        execute file at "execute_pages/hello_page.wfl" and read output as short_output
+        expect short_output to contain "captured by the parent program"
+    end test
+
+    test "missing page raises a catchable error":
+        store outcome as "not caught"
+        try:
+            execute wfl file at "execute_pages/no_such_page.wfl" and read output as missing_output
+        when file not found:
+            change outcome to "caught"
+        end try
+        expect outcome to equal "caught"
+    end test
+
+end describe

--- a/TestPrograms/execute_wfl_file.wfl
+++ b/TestPrograms/execute_wfl_file.wfl
@@ -1,0 +1,34 @@
+// End-to-end test for the execute file statement:
+//   execute [wfl] file at <path> [with <request>] [and read output as <variable>]
+// Executes another WFL file in-process and captures its display output.
+
+display "1. Execute a page and capture its output"
+execute wfl file at "execute_pages/hello_page.wfl" and read output as hello_output
+check if length of hello_output is greater than 0:
+    display "✓ Captured output from executed page"
+otherwise:
+    display "✗ FAILED: no output captured"
+end check
+display hello_output
+
+display "2. Execute without capture (output passes through)"
+execute wfl file at "execute_pages/hello_page.wfl"
+display "✓ Pass-through execution completed"
+
+display "3. Missing file is a catchable error"
+try:
+    execute wfl file at "execute_pages/no_such_page.wfl" and read output as missing_output
+    display "✗ FAILED: missing file did not raise an error"
+when file not found:
+    display "✓ Correctly caught missing page file"
+end try
+
+display "4. Optional wfl keyword can be omitted"
+execute file at "execute_pages/hello_page.wfl" and read output as short_output
+check if short_output is equal to hello_output:
+    display "✓ Short form captured identical output"
+otherwise:
+    display "✗ FAILED: short form output differs"
+end check
+
+display "All execute file tests completed"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1452,6 +1452,34 @@ impl Analyzer {
                 }
             }
 
+            Statement::ExecuteFileStatement {
+                path,
+                request,
+                variable_name,
+                line,
+                column,
+            } => {
+                self.analyze_expression(path);
+                if let Some(request_expr) = request {
+                    self.analyze_expression(request_expr);
+                }
+
+                if let Some(var_name) = variable_name {
+                    let symbol = Symbol {
+                        name: var_name.clone(),
+                        kind: SymbolKind::Variable { mutable: true },
+                        // Captured display output of the executed file
+                        symbol_type: Some(Type::Text),
+                        line: *line,
+                        column: *column,
+                    };
+
+                    if let Err(error) = self.current_scope.define(symbol) {
+                        self.errors.push(error);
+                    }
+                }
+            }
+
             Statement::SpawnProcessStatement {
                 command,
                 arguments,

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -590,6 +590,22 @@ impl Analyzer {
             Statement::CloseFileStatement { file, .. } => {
                 self.mark_used_in_expression(file, usages);
             }
+            Statement::ExecuteFileStatement {
+                path,
+                request,
+                variable_name,
+                ..
+            } => {
+                self.mark_used_in_expression(path, usages);
+                if let Some(request_expr) = request {
+                    self.mark_used_in_expression(request_expr, usages);
+                }
+                if let Some(var_name) = variable_name
+                    && let Some(usage) = usages.get_mut(var_name)
+                {
+                    usage.used = true;
+                }
+            }
             Statement::WaitForStatement { inner, .. } => {
                 // Mark variables used in the inner statement
                 self.mark_used_variables(inner, usages);

--- a/src/interpreter/io_capture.rs
+++ b/src/interpreter/io_capture.rs
@@ -38,17 +38,12 @@ pub(crate) fn push_capture(buffer: Rc<RefCell<String>>) -> CaptureGuard {
 /// Emit one line of program output: to the innermost active capture buffer on
 /// this thread if there is one, otherwise to stdout.
 pub(crate) fn emit_line(line: &str) {
-    let captured = CAPTURE_STACK.with(|stack| {
-        if let Some(buffer) = stack.borrow().last() {
-            let mut buffer = buffer.borrow_mut();
-            buffer.push_str(line);
-            buffer.push('\n');
-            true
-        } else {
-            false
-        }
-    });
-    if !captured {
+    let active_buffer = CAPTURE_STACK.with(|stack| stack.borrow().last().cloned());
+    if let Some(buffer) = active_buffer {
+        let mut buffer = buffer.borrow_mut();
+        buffer.push_str(line);
+        buffer.push('\n');
+    } else {
         println!("{line}");
     }
 }

--- a/src/interpreter/io_capture.rs
+++ b/src/interpreter/io_capture.rs
@@ -1,0 +1,74 @@
+//! Output capture for nested `execute file` runs.
+//!
+//! `display` and `print` are plain fn pointers (`NativeFunction`) with no
+//! access to interpreter state, so capture is routed through a thread-local
+//! stack instead of an `Interpreter` field. This is sound because the
+//! interpreter — including nested child interpreters started by
+//! `execute file` — runs on a single thread, and the parent is suspended
+//! while a child runs. Only output produced on the interpreter thread is
+//! captured, which is true for all program-output sites today.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+thread_local! {
+    static CAPTURE_STACK: RefCell<Vec<Rc<RefCell<String>>>> = const { RefCell::new(Vec::new()) };
+}
+
+/// RAII guard that pops the capture buffer when dropped, so capture ends
+/// correctly even when execution unwinds through `?`.
+pub(crate) struct CaptureGuard(());
+
+impl Drop for CaptureGuard {
+    fn drop(&mut self) {
+        CAPTURE_STACK.with(|stack| {
+            stack.borrow_mut().pop();
+        });
+    }
+}
+
+/// Push a capture buffer; program output lines are appended to it until the
+/// returned guard is dropped. Buffers nest: only the innermost one receives
+/// output, giving correct semantics when a captured file itself captures.
+pub(crate) fn push_capture(buffer: Rc<RefCell<String>>) -> CaptureGuard {
+    CAPTURE_STACK.with(|stack| stack.borrow_mut().push(buffer));
+    CaptureGuard(())
+}
+
+/// Emit one line of program output: to the innermost active capture buffer on
+/// this thread if there is one, otherwise to stdout.
+pub(crate) fn emit_line(line: &str) {
+    let captured = CAPTURE_STACK.with(|stack| {
+        if let Some(buffer) = stack.borrow().last() {
+            let mut buffer = buffer.borrow_mut();
+            buffer.push_str(line);
+            buffer.push('\n');
+            true
+        } else {
+            false
+        }
+    });
+    if !captured {
+        println!("{line}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capture_collects_lines_and_nests() {
+        let outer = Rc::new(RefCell::new(String::new()));
+        let _outer_guard = push_capture(Rc::clone(&outer));
+        emit_line("outer one");
+        {
+            let inner = Rc::new(RefCell::new(String::new()));
+            let _inner_guard = push_capture(Rc::clone(&inner));
+            emit_line("inner");
+            assert_eq!(*inner.borrow(), "inner\n");
+        }
+        emit_line("outer two");
+        assert_eq!(*outer.borrow(), "outer one\nouter two\n");
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5519,8 +5519,10 @@ impl Interpreter {
                     let first_error = errors.first();
                     RuntimeError::new(
                         format!(
-                            "Parse error in executed file '{}': {}",
+                            "Parse error in executed file '{}' (line {}, column {}): {}",
                             resolved_path.display(),
+                            first_error.map(|e| e.line).unwrap_or(1),
+                            first_error.map(|e| e.column).unwrap_or(1),
                             first_error.map(|e| e.message.as_str()).unwrap_or("unknown")
                         ),
                         *line,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5448,7 +5448,9 @@ impl Interpreter {
 
                 // Evaluate the optional request context and extract the variables
                 // that `wait for request` defines, so the executed file sees the
-                // same names: method, path, client_ip, body, headers
+                // same names. Validate the shape upfront so a wrong object fails
+                // here with a clear message instead of as confusing undefined
+                // variable errors inside the executed file.
                 let request_vars: Vec<(String, Value)> = if let Some(request_expr) = request {
                     let request_value = self
                         .evaluate_expression(request_expr, Rc::clone(&env))
@@ -5456,16 +5458,41 @@ impl Interpreter {
                     match &request_value {
                         Value::Object(props) => {
                             let props = props.borrow();
-                            // Deep clone so the executed file cannot mutate the
-                            // parent's request data (e.g. the headers object)
-                            ["method", "path", "client_ip", "body", "headers"]
-                                .iter()
-                                .filter_map(|key| {
-                                    props
-                                        .get(*key)
-                                        .map(|v| ((*key).to_string(), v.deep_clone()))
-                                })
-                                .collect()
+                            let mut vars = Vec::new();
+                            for key in ["method", "path", "client_ip", "body", "headers"] {
+                                let value = props.get(key).ok_or_else(|| {
+                                    RuntimeError::new(
+                                        format!(
+                                            "Execute file request context is missing '{key}' - pass the request object from 'wait for request'"
+                                        ),
+                                        *line,
+                                        *column,
+                                    )
+                                })?;
+                                let type_ok = match key {
+                                    "headers" => matches!(value, Value::Object(_)),
+                                    _ => matches!(value, Value::Text(_)),
+                                };
+                                if !type_ok {
+                                    return Err(RuntimeError::new(
+                                        format!(
+                                            "Execute file request context field '{key}' must be {}, got {}",
+                                            if key == "headers" {
+                                                "an object"
+                                            } else {
+                                                "text"
+                                            },
+                                            value.type_name()
+                                        ),
+                                        *line,
+                                        *column,
+                                    ));
+                                }
+                                // Deep clone so the executed file cannot mutate the
+                                // parent's request data (e.g. the headers object)
+                                vars.push((key.to_string(), value.deep_clone()));
+                            }
+                            vars
                         }
                         _ => {
                             return Err(RuntimeError::new(

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4934,12 +4934,6 @@ impl Interpreter {
                     }
                 };
 
-                // Store the request in a global map for RespondStatement to access
-                {
-                    let mut pending_responses = self.pending_responses.borrow_mut();
-                    pending_responses.insert(request.id.clone(), request.response_sender);
-                }
-
                 // Define individual variables for request properties (more natural for WFL)
                 let mut env_mut = env.borrow_mut();
 
@@ -5012,6 +5006,15 @@ impl Interpreter {
                 }
 
                 drop(env_mut); // Release the borrow
+
+                // Store the request in a global map for RespondStatement to access.
+                // Done only after every define above succeeded: registering earlier
+                // would park the oneshot sender on an error path and leave the HTTP
+                // client hanging instead of failing fast.
+                {
+                    let mut pending_responses = self.pending_responses.borrow_mut();
+                    pending_responses.insert(request.id.clone(), request.response_sender);
+                }
 
                 Ok((Value::Null, ControlFlow::None))
             }
@@ -5419,10 +5422,10 @@ impl Interpreter {
                         .unwrap_or_else(|_| PathBuf::from(&path_str))
                 };
                 let map_io_error = |e: std::io::Error| {
-                    let kind = if e.kind() == std::io::ErrorKind::NotFound {
-                        ErrorKind::FileNotFound
-                    } else {
-                        ErrorKind::General
+                    let kind = match e.kind() {
+                        std::io::ErrorKind::NotFound => ErrorKind::FileNotFound,
+                        std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
+                        _ => ErrorKind::General,
                     };
                     RuntimeError::with_kind(
                         format!("Cannot execute wfl file '{path_str}': {e}"),
@@ -5448,10 +5451,14 @@ impl Interpreter {
                     match &request_value {
                         Value::Object(props) => {
                             let props = props.borrow();
+                            // Deep clone so the executed file cannot mutate the
+                            // parent's request data (e.g. the headers object)
                             ["method", "path", "client_ip", "body", "headers"]
                                 .iter()
                                 .filter_map(|key| {
-                                    props.get(*key).map(|v| ((*key).to_string(), v.clone()))
+                                    props
+                                        .get(*key)
+                                        .map(|v| ((*key).to_string(), v.deep_clone()))
                                 })
                                 .collect()
                         }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5,6 +5,7 @@ pub mod command_sanitizer;
 pub mod control_flow;
 pub mod environment;
 pub mod error;
+pub(crate) mod io_capture;
 #[cfg(test)]
 mod memory_tests;
 #[cfg(test)]
@@ -199,6 +200,13 @@ fn stmt_type(stmt: &Statement) -> String {
                 "ExecuteCommandStatement".to_string()
             }
         }
+        Statement::ExecuteFileStatement { variable_name, .. } => {
+            if let Some(var) = variable_name {
+                format!("ExecuteFileStatement '{var}'")
+            } else {
+                "ExecuteFileStatement".to_string()
+            }
+        }
         Statement::SpawnProcessStatement { variable_name, .. } => {
             format!("SpawnProcessStatement '{variable_name}'")
         }
@@ -344,6 +352,13 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 // use self::value::FutureValue;
 
+/// Maximum nesting depth for `execute file` runs, guarding against a file
+/// that (directly or indirectly) executes itself. Kept small because each
+/// nesting level polls through the full interpreter recursively, so deep
+/// nesting would exhaust the thread stack (debug builds overflow near a
+/// depth of 8) before a larger guard could fire.
+const MAX_EXECUTE_FILE_DEPTH: usize = 4;
+
 pub struct Interpreter {
     global_env: Rc<RefCell<Environment>>,
     current_count: RefCell<Option<f64>>,
@@ -363,6 +378,7 @@ pub struct Interpreter {
     config: Arc<WflConfig>, // Configuration for security and other settings
     current_source_file: RefCell<Option<PathBuf>>, // Currently executing source file (for path resolution)
     loading_stack: RefCell<Vec<PathBuf>>, // Stack of currently loading files (for circular dependency detection)
+    execute_depth: usize, // Nesting depth of `execute file` runs (guards against circular execution)
     // Test execution state
     test_mode: RefCell<bool>,
     test_results: RefCell<TestResults>,
@@ -1300,6 +1316,7 @@ impl Interpreter {
             config,
             current_source_file: RefCell::new(None), // No source file initially
             loading_stack: RefCell::new(Vec::new()), // Empty loading stack
+            execute_depth: 0,
             // Test execution state
             test_mode: RefCell::new(false),
             test_results: RefCell::new(TestResults::default()),
@@ -1698,13 +1715,14 @@ impl Interpreter {
     }
 
     fn native_display(args: Vec<Value>) -> Result<Value, RuntimeError> {
+        let mut line = String::new();
         for (i, arg) in args.iter().enumerate() {
             if i > 0 {
-                print!(" ");
+                line.push(' ');
             }
-            print!("{arg}");
+            line.push_str(&arg.to_string());
         }
-        println!();
+        io_capture::emit_line(&line);
         Ok(Value::Null)
     }
 
@@ -1997,6 +2015,7 @@ impl Interpreter {
             Statement::StopAcceptingConnectionsStatement { line, column, .. } => (*line, *column),
             Statement::CloseServerStatement { line, column, .. } => (*line, *column),
             Statement::ExecuteCommandStatement { line, column, .. } => (*line, *column),
+            Statement::ExecuteFileStatement { line, column, .. } => (*line, *column),
             Statement::SpawnProcessStatement { line, column, .. } => (*line, *column),
             Statement::ReadProcessOutputStatement { line, column, .. } => (*line, *column),
             Statement::KillProcessStatement { line, column, .. } => (*line, *column),
@@ -2110,7 +2129,7 @@ impl Interpreter {
                 column: _column,
             } => {
                 let value = self.evaluate_expression(value, Rc::clone(&env)).await?;
-                println!("{value}");
+                io_capture::emit_line(&value.to_string());
                 Ok((Value::Null, ControlFlow::None))
             }
 
@@ -4924,12 +4943,38 @@ impl Interpreter {
                 // Define individual variables for request properties (more natural for WFL)
                 let mut env_mut = env.borrow_mut();
 
-                // Define the main request variable (for use in respond statements)
+                // Convert headers to a WFL object (shared by the request object and
+                // the standalone headers variable defined below)
+                let mut headers_map = HashMap::new();
+                for (key, value) in request.headers.iter() {
+                    headers_map.insert(key.clone(), Value::Text(Arc::from(value.clone())));
+                }
+                let headers_object = Value::Object(Rc::new(RefCell::new(headers_map)));
+
+                // Define the main request variable (for use in respond statements and
+                // as request context for `execute file ... with <request>`)
                 let mut request_properties = HashMap::new();
                 request_properties.insert(
                     "_response_sender".to_string(),
                     Value::Text(Arc::from(request.id.clone())),
                 );
+                request_properties.insert(
+                    "method".to_string(),
+                    Value::Text(Arc::from(request.method.clone())),
+                );
+                request_properties.insert(
+                    "path".to_string(),
+                    Value::Text(Arc::from(request.path.clone())),
+                );
+                request_properties.insert(
+                    "client_ip".to_string(),
+                    Value::Text(Arc::from(request.client_ip.clone())),
+                );
+                request_properties.insert(
+                    "body".to_string(),
+                    Value::Text(Arc::from(request.body.clone())),
+                );
+                request_properties.insert("headers".to_string(), headers_object.clone());
                 let request_object = Value::Object(Rc::new(RefCell::new(request_properties)));
 
                 match env_mut.define(request_name, request_object) {
@@ -4960,13 +5005,6 @@ impl Interpreter {
                     Ok(_) => {}
                     Err(msg) => return Err(RuntimeError::new(msg, *line, *column)),
                 }
-
-                // Convert headers to WFL object and define as headers variable
-                let mut headers_map = HashMap::new();
-                for (key, value) in request.headers.iter() {
-                    headers_map.insert(key.clone(), Value::Text(Arc::from(value.clone())));
-                }
-                let headers_object = Value::Object(Rc::new(RefCell::new(headers_map)));
 
                 match env_mut.define("headers", headers_object) {
                     Ok(_) => {}
@@ -5328,6 +5366,207 @@ impl Interpreter {
                 if let Some(var_name) = variable_name {
                     env.borrow_mut()
                         .define(var_name, result_obj)
+                        .map_err(|e| RuntimeError::new(e, *line, *column))?;
+                }
+
+                Ok((Value::Null, ControlFlow::None))
+            }
+            Statement::ExecuteFileStatement {
+                path,
+                request,
+                variable_name,
+                line,
+                column,
+            } => {
+                // Guard against a file that (directly or indirectly) executes itself
+                if self.execute_depth >= MAX_EXECUTE_FILE_DEPTH {
+                    return Err(RuntimeError::new(
+                        format!(
+                            "Maximum execute file nesting depth ({MAX_EXECUTE_FILE_DEPTH}) exceeded - possible circular execution"
+                        ),
+                        *line,
+                        *column,
+                    ));
+                }
+
+                // Evaluate path expression to string
+                let path_value = self.evaluate_expression(path, Rc::clone(&env)).await?;
+                let path_str: String = match &path_value {
+                    Value::Text(s) => s.to_string(),
+                    _ => {
+                        return Err(RuntimeError::new(
+                            format!(
+                                "Execute file path must be text, got {}",
+                                path_value.type_name()
+                            ),
+                            *line,
+                            *column,
+                        ));
+                    }
+                };
+
+                // Resolve relative to the current script's directory (like load module),
+                // mapping a missing file to FileNotFound so `when file not found` works
+                let opt_source = self.current_source_file.borrow().as_ref().cloned();
+                let joined = if let Some(source_path) = opt_source {
+                    source_path
+                        .parent()
+                        .map(|dir| dir.join(&path_str))
+                        .unwrap_or_else(|| PathBuf::from(&path_str))
+                } else {
+                    std::env::current_dir()
+                        .map(|cwd| cwd.join(&path_str))
+                        .unwrap_or_else(|_| PathBuf::from(&path_str))
+                };
+                let map_io_error = |e: std::io::Error| {
+                    let kind = if e.kind() == std::io::ErrorKind::NotFound {
+                        ErrorKind::FileNotFound
+                    } else {
+                        ErrorKind::General
+                    };
+                    RuntimeError::with_kind(
+                        format!("Cannot execute wfl file '{path_str}': {e}"),
+                        *line,
+                        *column,
+                        kind,
+                    )
+                };
+                let resolved_path = tokio::fs::canonicalize(&joined)
+                    .await
+                    .map_err(map_io_error)?;
+                let content = tokio::fs::read_to_string(&resolved_path)
+                    .await
+                    .map_err(map_io_error)?;
+
+                // Evaluate the optional request context and extract the variables
+                // that `wait for request` defines, so the executed file sees the
+                // same names: method, path, client_ip, body, headers
+                let request_vars: Vec<(String, Value)> = if let Some(request_expr) = request {
+                    let request_value = self
+                        .evaluate_expression(request_expr, Rc::clone(&env))
+                        .await?;
+                    match &request_value {
+                        Value::Object(props) => {
+                            let props = props.borrow();
+                            ["method", "path", "client_ip", "body", "headers"]
+                                .iter()
+                                .filter_map(|key| {
+                                    props.get(*key).map(|v| ((*key).to_string(), v.clone()))
+                                })
+                                .collect()
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Execute file request context must be a request object, got {}",
+                                    request_value.type_name()
+                                ),
+                                *line,
+                                *column,
+                            ));
+                        }
+                    }
+                } else {
+                    Vec::new()
+                };
+
+                // Parse the file; errors are catchable in the parent
+                use crate::lexer::lex_wfl_with_positions;
+                use crate::parser::Parser;
+
+                let tokens = lex_wfl_with_positions(&content);
+                let mut parser = Parser::new(&tokens);
+                let program = parser.parse().map_err(|errors| {
+                    let first_error = errors.first();
+                    RuntimeError::new(
+                        format!(
+                            "Parse error in executed file '{}': {}",
+                            resolved_path.display(),
+                            first_error.map(|e| e.message.as_str()).unwrap_or("unknown")
+                        ),
+                        *line,
+                        *column,
+                    )
+                })?;
+
+                // Analyze semantics, seeding the injected request variable names.
+                // The type checker is intentionally skipped: main.rs treats type
+                // errors as warnings only, so a hard gate here would reject files
+                // that run fine standalone.
+                use crate::analyzer::Analyzer;
+
+                let mut seeded_vars: HashMap<String, (crate::parser::ast::Type, bool)> =
+                    HashMap::new();
+                for (name, value) in &request_vars {
+                    seeded_vars.insert(name.clone(), (Self::infer_type_from_value(value), true));
+                }
+                let mut analyzer = Analyzer::with_parent_variables(seeded_vars);
+                if let Err(errors) = analyzer.analyze(&program) {
+                    let first_error = errors.first();
+                    return Err(RuntimeError::new(
+                        format!(
+                            "Semantic error in executed file '{}': {}",
+                            resolved_path.display(),
+                            first_error.map(|e| e.to_string()).unwrap_or_default()
+                        ),
+                        *line,
+                        *column,
+                    ));
+                }
+
+                // Run the file in a fresh nested interpreter (own global env and
+                // stdlib, inherits the parent's config) with request context injected
+                let mut child = Interpreter::with_config(Arc::clone(&self.config));
+                child.set_source_file(resolved_path.clone());
+                child.execute_depth = self.execute_depth + 1;
+
+                {
+                    let mut child_env = child.global_env().borrow_mut();
+                    for (name, value) in request_vars {
+                        if let Err(msg) = child_env.define(&name, value) {
+                            return Err(RuntimeError::new(msg, *line, *column));
+                        }
+                    }
+                }
+
+                // With an output clause, capture the child's display/print output;
+                // without one, child output flows to the current sink (stdout, or
+                // the parent's own capture buffer if the parent is being captured)
+                let capture_buffer = variable_name
+                    .as_ref()
+                    .map(|_| Rc::new(RefCell::new(String::new())));
+                let run_result = {
+                    let _guard = capture_buffer
+                        .as_ref()
+                        .map(|buffer| io_capture::push_capture(Rc::clone(buffer)));
+                    // Box::pin breaks the recursive future (this statement awaits a
+                    // full nested interpret), keeping the future finitely sized
+                    Box::pin(child.interpret(&program)).await
+                };
+
+                if let Err(errors) = run_result {
+                    let first = errors.into_iter().next().unwrap_or_else(|| {
+                        RuntimeError::new("unknown error".to_string(), *line, *column)
+                    });
+                    // Position the error at the parent's execute statement, keep the
+                    // child's error kind so typed `when` clauses still match
+                    return Err(RuntimeError::with_kind(
+                        format!(
+                            "Error in executed file '{}' (line {}): {}",
+                            resolved_path.display(),
+                            first.line,
+                            first.message
+                        ),
+                        *line,
+                        *column,
+                        first.kind,
+                    ));
+                }
+
+                if let (Some(var_name), Some(buffer)) = (variable_name, capture_buffer) {
+                    let output = buffer.borrow();
+                    env.borrow_mut()
+                        .define(var_name, Value::Text(Arc::from(output.as_str())))
                         .map_err(|e| RuntimeError::new(e, *line, *column))?;
                 }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5417,9 +5417,14 @@ impl Interpreter {
                         .map(|dir| dir.join(&path_str))
                         .unwrap_or_else(|| PathBuf::from(&path_str))
                 } else {
-                    std::env::current_dir()
-                        .map(|cwd| cwd.join(&path_str))
-                        .unwrap_or_else(|_| PathBuf::from(&path_str))
+                    let cwd = std::env::current_dir().map_err(|e| {
+                        RuntimeError::new(
+                            format!("Cannot determine current directory: {e}"),
+                            *line,
+                            *column,
+                        )
+                    })?;
+                    cwd.join(&path_str)
                 };
                 let map_io_error = |e: std::io::Error| {
                     let kind = match e.kind() {

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -278,6 +278,16 @@ pub enum Statement {
         line: usize,
         column: usize,
     },
+    /// execute [wfl] file at <path> [with <request>] [and read output as <variable>]
+    /// Runs another WFL file in-process with a nested interpreter, optionally
+    /// passing HTTP request context and capturing its display output.
+    ExecuteFileStatement {
+        path: Expression,
+        request: Option<Expression>,
+        variable_name: Option<String>,
+        line: usize,
+        column: usize,
+    },
     SpawnProcessStatement {
         command: Expression,
         arguments: Option<Expression>,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -476,7 +476,16 @@ impl<'a> StmtParser<'a> for Parser<'a> {
                     // Parse open file statement (handles both regular and "read content" variants)
                     self.parse_open_file_statement()
                 }
-                Token::KeywordExecute => self.parse_execute_command_statement(),
+                Token::KeywordExecute => {
+                    // Distinguish "execute [wfl] file ..." from "execute command ..."
+                    match self.cursor.peek_next().map(|t| &t.token) {
+                        Some(Token::KeywordFile) => self.parse_execute_file_statement(),
+                        Some(Token::Identifier(name)) if name == "wfl" => {
+                            self.parse_execute_file_statement()
+                        }
+                        _ => self.parse_execute_command_statement(),
+                    }
+                }
                 Token::KeywordSpawn => self.parse_spawn_process_statement(),
                 Token::KeywordKill => self.parse_kill_process_statement(),
                 Token::KeywordRead => {

--- a/src/parser/stmt/processes.rs
+++ b/src/parser/stmt/processes.rs
@@ -7,6 +7,7 @@ use crate::parser::expr::{ExprParser, PrimaryExprParser};
 
 pub(crate) trait ProcessParser<'a>: ExprParser<'a> {
     fn parse_execute_command_statement(&mut self) -> Result<Statement, ParseError>;
+    fn parse_execute_file_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_spawn_process_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_kill_process_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_read_process_output_statement(&mut self) -> Result<Statement, ParseError>;
@@ -71,6 +72,66 @@ impl<'a> ProcessParser<'a> for Parser<'a> {
             arguments,
             variable_name,
             use_shell,
+            line: token_pos.line,
+            column: token_pos.column,
+        })
+    }
+
+    // execute [wfl] file at <path> [with <request>] [and read output as <variable>]
+    fn parse_execute_file_statement(&mut self) -> Result<Statement, ParseError> {
+        let token_pos = self.bump_sync().unwrap(); // Consume "execute"
+
+        // Optional "wfl" qualifier
+        if let Some(token) = self.cursor.peek()
+            && matches!(&token.token, Token::Identifier(name) if name == "wfl")
+        {
+            self.bump_sync(); // Consume "wfl"
+        }
+
+        self.expect_token(Token::KeywordFile, "Expected 'file' after 'execute'")?;
+        self.expect_token(Token::KeywordAt, "Expected 'at' after 'execute file'")?;
+
+        let path = self.parse_primary_expression()?;
+
+        // Optional "with <request>" passes HTTP request context to the file
+        let request = if let Some(token) = self.cursor.peek()
+            && matches!(&token.token, Token::KeywordWith)
+        {
+            self.bump_sync(); // Consume "with"
+            Some(self.parse_primary_expression()?)
+        } else {
+            None
+        };
+
+        // Optional "and read output as <variable>" captures the file's display output
+        let variable_name = if let Some(token) = self.cursor.peek()
+            && matches!(&token.token, Token::KeywordAnd)
+        {
+            self.bump_sync(); // Consume "and"
+            self.expect_token(Token::KeywordRead, "Expected 'read' after 'and'")?;
+            self.expect_token(Token::KeywordOutput, "Expected 'output' after 'read'")?;
+            self.expect_token(Token::KeywordAs, "Expected 'as' after 'read output'")?;
+
+            let var_token = self.bump_sync().ok_or_else(|| {
+                ParseError::from_token("Expected identifier after 'as'".to_string(), token_pos)
+            })?;
+
+            if let Token::Identifier(name) = &var_token.token {
+                Some(name.clone())
+            } else {
+                return Err(ParseError::from_token(
+                    format!("Expected identifier, found {:?}", var_token.token),
+                    var_token,
+                ));
+            }
+        } else {
+            None
+        };
+
+        Ok(Statement::ExecuteFileStatement {
+            path,
+            request,
+            variable_name,
             line: token_pos.line,
             column: token_pos.column,
         })

--- a/src/stdlib/core.rs
+++ b/src/stdlib/core.rs
@@ -5,13 +5,14 @@ use crate::interpreter::value::Value;
 use std::sync::Arc;
 
 pub fn native_print(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    let mut line = String::new();
     for (i, arg) in args.iter().enumerate() {
         if i > 0 {
-            print!(" ");
+            line.push(' ');
         }
-        print!("{arg}");
+        line.push_str(&arg.to_string());
     }
-    println!();
+    crate::interpreter::io_capture::emit_line(&line);
     Ok(Value::Null)
 }
 

--- a/src/transpiler/javascript.rs
+++ b/src/transpiler/javascript.rs
@@ -1517,6 +1517,15 @@ impl JavaScriptTranspiler {
                     column: *column,
                 })
             }
+
+            Statement::ExecuteFileStatement { line, column, .. } => {
+                // Execute file statements are not supported in JavaScript transpilation
+                Err(TranspileError {
+                    message: "Execute file statements are not supported in JavaScript transpilation. They require the WFL interpreter.".to_string(),
+                    line: *line,
+                    column: *column,
+                })
+            }
         }
     }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1049,7 +1049,7 @@ impl TypeChecker {
             Statement::ExecuteFileStatement {
                 path,
                 request,
-                variable_name: _,
+                variable_name,
                 line: _line,
                 column: _column,
             } => {
@@ -1067,6 +1067,12 @@ impl TypeChecker {
                 if let Some(request_expr) = request {
                     // Request context is a request object; no constraint beyond inference
                     let _request_type = self.infer_expression_type(request_expr);
+                }
+                // Captured display output of the executed file is text
+                if let Some(var_name) = variable_name
+                    && let Some(symbol) = self.analyzer.get_symbol_mut(var_name)
+                {
+                    symbol.symbol_type = Some(Type::Text);
                 }
             }
             Statement::SpawnProcessStatement {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1046,6 +1046,29 @@ impl TypeChecker {
                     // Arguments can be a list or a single string
                 }
             }
+            Statement::ExecuteFileStatement {
+                path,
+                request,
+                variable_name: _,
+                line: _line,
+                column: _column,
+            } => {
+                let path_type = self.infer_expression_type(path);
+                if path_type != Type::Text && path_type != Type::Unknown && path_type != Type::Error
+                {
+                    self.type_error(
+                        "Expected string for execute file path".to_string(),
+                        Some(Type::Text),
+                        Some(path_type),
+                        *_line,
+                        *_column,
+                    );
+                }
+                if let Some(request_expr) = request {
+                    // Request context is a request object; no constraint beyond inference
+                    let _request_type = self.infer_expression_type(request_expr);
+                }
+            }
             Statement::SpawnProcessStatement {
                 command,
                 arguments,

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -385,6 +385,10 @@ async fn test_execute_file_child_error_mentions_child_path() {
         message.contains("broken.wfl"),
         "Error should mention the child file path, got: {message}"
     );
+    assert!(
+        message.contains("line 1"),
+        "Error should mention the child parse error position, got: {message}"
+    );
 }
 
 #[tokio::test]

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -273,6 +273,47 @@ async fn test_execute_file_passes_request_context() {
     );
 }
 
+#[tokio::test]
+async fn test_execute_file_rejects_malformed_request_context() {
+    // Passing an object that is not a request must fail fast at the execute
+    // statement with a clear message, not as undefined variables in the child
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(temp_dir.path().join("page.wfl"), "display \"never runs\"\n")
+        .expect("Failed to write page file");
+
+    let main_file = temp_dir.path().join("main.wfl");
+    let source =
+        r#"execute wfl file at "page.wfl" with wrong_object and read output as page_output"#;
+    fs::write(&main_file, source).expect("Failed to write main file");
+
+    let ast = parse_program(source).unwrap_or_else(|e| panic!("Parse failed: {e}"));
+    let mut interpreter = Interpreter::new();
+    interpreter.set_source_file(main_file);
+
+    {
+        let mut props = HashMap::new();
+        props.insert("output".to_string(), Value::Text(Arc::from("hi")));
+        interpreter
+            .global_env()
+            .borrow_mut()
+            .define(
+                "wrong_object",
+                Value::Object(std::rc::Rc::new(std::cell::RefCell::new(props))),
+            )
+            .expect("Failed to define wrong_object");
+    }
+
+    let errors = interpreter
+        .interpret(&ast)
+        .await
+        .expect_err("Expected malformed request context to be rejected");
+    let message = &errors.first().expect("Expected at least one error").message;
+    assert!(
+        message.contains("missing 'method'"),
+        "Error should name the missing request field, got: {message}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Error handling
 // ---------------------------------------------------------------------------

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -1,0 +1,487 @@
+// TDD tests for the `execute file` statement:
+//   execute [wfl] file at <path> [with <request>] [and read output as <variable>]
+//
+// Executes another WFL file in-process with a nested interpreter, optionally
+// passing HTTP request context and capturing the child's display/print output.
+
+use std::collections::HashMap;
+use std::fs;
+use std::sync::Arc;
+use tempfile::TempDir;
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::parser::ast::{Expression, Statement};
+
+fn parse_program(source: &str) -> Result<wfl::parser::ast::Program, String> {
+    let tokens = lex_wfl_with_positions(source);
+    let mut parser = Parser::new(&tokens);
+    parser.parse().map_err(|errors| {
+        errors
+            .first()
+            .map(|e| e.message.clone())
+            .unwrap_or_else(|| "unknown parse error".to_string())
+    })
+}
+
+async fn run_program_in_dir(
+    dir: &TempDir,
+    source: &str,
+) -> (
+    Result<Value, Vec<wfl::interpreter::error::RuntimeError>>,
+    Interpreter,
+) {
+    let main_file = dir.path().join("main.wfl");
+    fs::write(&main_file, source).expect("Failed to write main file");
+
+    let ast = parse_program(source).unwrap_or_else(|e| panic!("Parse failed: {e}"));
+    let mut interpreter = Interpreter::new();
+    interpreter.set_source_file(main_file);
+    let result = interpreter.interpret(&ast).await;
+    (result, interpreter)
+}
+
+fn get_global_text(interpreter: &Interpreter, name: &str) -> String {
+    let env = interpreter.global_env().borrow();
+    match env.values.get(name) {
+        Some(Value::Text(text)) => text.to_string(),
+        other => panic!("Expected Text variable '{name}', got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parse tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_parse_execute_file_minimal() {
+    let program = parse_program(r#"execute file at "page.wfl""#).expect("Parse failed");
+    assert_eq!(program.statements.len(), 1);
+    match &program.statements[0] {
+        Statement::ExecuteFileStatement {
+            path,
+            request,
+            variable_name,
+            ..
+        } => {
+            assert!(matches!(path, Expression::Literal(..)));
+            assert!(request.is_none());
+            assert!(variable_name.is_none());
+        }
+        other => panic!("Expected ExecuteFileStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_execute_file_with_optional_wfl_keyword() {
+    let program = parse_program(r#"execute wfl file at "page.wfl""#).expect("Parse failed");
+    assert!(matches!(
+        &program.statements[0],
+        Statement::ExecuteFileStatement {
+            request: None,
+            variable_name: None,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_parse_execute_file_with_output_capture() {
+    let program = parse_program(r#"execute wfl file at "page.wfl" and read output as page_output"#)
+        .expect("Parse failed");
+    match &program.statements[0] {
+        Statement::ExecuteFileStatement {
+            request,
+            variable_name,
+            ..
+        } => {
+            assert!(request.is_none());
+            assert_eq!(variable_name.as_deref(), Some("page_output"));
+        }
+        other => panic!("Expected ExecuteFileStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_execute_file_full_form() {
+    let program = parse_program(
+        r#"execute wfl file at "page.wfl" with incoming_request and read output as page_output"#,
+    )
+    .expect("Parse failed");
+    match &program.statements[0] {
+        Statement::ExecuteFileStatement {
+            request,
+            variable_name,
+            ..
+        } => {
+            assert!(
+                matches!(request, Some(Expression::Variable(name, ..)) if name == "incoming_request")
+            );
+            assert_eq!(variable_name.as_deref(), Some("page_output"));
+        }
+        other => panic!("Expected ExecuteFileStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_parse_execute_file_missing_at_fails() {
+    let result = parse_program(r#"execute file "page.wfl""#);
+    assert!(result.is_err(), "Expected parse error without 'at'");
+}
+
+#[test]
+fn test_parse_execute_command_still_works() {
+    // Regression: dispatch must not break the existing execute command statement
+    let program = parse_program(r#"execute command "echo" with arguments ["hi"] as cmd_result"#)
+        .expect("Parse failed");
+    assert!(matches!(
+        &program.statements[0],
+        Statement::ExecuteCommandStatement { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Output capture
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_file_captures_display_output() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("page.wfl"),
+        "display \"line one\"\ndisplay \"line two\"\n",
+    )
+    .expect("Failed to write page file");
+
+    let source = r#"execute wfl file at "page.wfl" and read output as page_output"#;
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "page_output"),
+        "line one\nline two\n"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_file_captures_print_output() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("page.wfl"),
+        "store greeting as \"hello from print\"\nprint of greeting\n",
+    )
+    .expect("Failed to write page file");
+
+    let source = r#"execute wfl file at "page.wfl" and read output as page_output"#;
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "page_output"),
+        "hello from print\n"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_file_nested_capture() {
+    // outer.wfl executes inner.wfl with capture and decorates its output;
+    // the parent captures outer.wfl. Inner output must not leak.
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("inner.wfl"),
+        "display \"inner content\"\n",
+    )
+    .expect("Failed to write inner file");
+    fs::write(
+        temp_dir.path().join("outer.wfl"),
+        concat!(
+            "execute wfl file at \"inner.wfl\" and read output as inner_output\n",
+            "display \"before\"\n",
+            "display inner_output\n",
+            "display \"after\"\n",
+        ),
+    )
+    .expect("Failed to write outer file");
+
+    let source = r#"execute wfl file at "outer.wfl" and read output as page_output"#;
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "page_output"),
+        "before\ninner content\n\nafter\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Request context
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_file_passes_request_context() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("page.wfl"),
+        concat!(
+            "display method\n",
+            "display path\n",
+            "display body\n",
+            "display client_ip\n",
+        ),
+    )
+    .expect("Failed to write page file");
+
+    let main_file = temp_dir.path().join("main.wfl");
+    let source =
+        r#"execute wfl file at "page.wfl" with fake_request and read output as page_output"#;
+    fs::write(&main_file, source).expect("Failed to write main file");
+
+    let ast = parse_program(source).unwrap_or_else(|e| panic!("Parse failed: {e}"));
+    let mut interpreter = Interpreter::new();
+    interpreter.set_source_file(main_file);
+
+    // Build a request object the way `wait for request` does
+    {
+        let mut headers = HashMap::new();
+        headers.insert("user-agent".to_string(), Value::Text(Arc::from("wfl-test")));
+        let mut props = HashMap::new();
+        props.insert("method".to_string(), Value::Text(Arc::from("POST")));
+        props.insert("path".to_string(), Value::Text(Arc::from("/hello")));
+        props.insert("body".to_string(), Value::Text(Arc::from("name=World")));
+        props.insert("client_ip".to_string(), Value::Text(Arc::from("127.0.0.1")));
+        props.insert(
+            "headers".to_string(),
+            Value::Object(std::rc::Rc::new(std::cell::RefCell::new(headers))),
+        );
+        interpreter
+            .global_env()
+            .borrow_mut()
+            .define(
+                "fake_request",
+                Value::Object(std::rc::Rc::new(std::cell::RefCell::new(props))),
+            )
+            .expect("Failed to define fake_request");
+    }
+
+    let result = interpreter.interpret(&ast).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "page_output"),
+        "POST\n/hello\nname=World\n127.0.0.1\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Error handling
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_file_missing_file_is_catchable() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let source = concat!(
+        "store outcome as \"unset\"\n",
+        "try:\n",
+        "    execute wfl file at \"no_such_page.wfl\" and read output as page_output\n",
+        "    change outcome to \"executed\"\n",
+        "when file not found:\n",
+        "    change outcome to \"caught missing file\"\n",
+        "otherwise:\n",
+        "    change outcome to \"wrong handler\"\n",
+        "end try\n",
+    );
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "outcome"),
+        "caught missing file"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_file_child_parse_error_is_catchable() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("broken.wfl"),
+        "store as as as nonsense gibberish ===\n",
+    )
+    .expect("Failed to write broken file");
+
+    let source = concat!(
+        "store outcome as \"unset\"\n",
+        "try:\n",
+        "    execute wfl file at \"broken.wfl\" and read output as page_output\n",
+        "    change outcome to \"executed\"\n",
+        "when error:\n",
+        "    change outcome to \"caught child error\"\n",
+        "end try\n",
+    );
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "outcome"),
+        "caught child error"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_file_child_error_mentions_child_path() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("broken.wfl"),
+        "store as as as nonsense gibberish ===\n",
+    )
+    .expect("Failed to write broken file");
+
+    let source = r#"execute wfl file at "broken.wfl" and read output as page_output"#;
+    let (result, _interpreter) = run_program_in_dir(&temp_dir, source).await;
+    let errors = result.expect_err("Expected child parse error to propagate");
+    let message = &errors.first().expect("Expected at least one error").message;
+    assert!(
+        message.contains("broken.wfl"),
+        "Error should mention the child file path, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_execute_file_depth_limit_prevents_infinite_recursion() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    // self_exec.wfl executes itself forever; the depth guard must stop it
+    fs::write(
+        temp_dir.path().join("self_exec.wfl"),
+        "execute wfl file at \"self_exec.wfl\" and read output as nested_output\n",
+    )
+    .expect("Failed to write self-executing file");
+
+    let source = r#"execute wfl file at "self_exec.wfl" and read output as page_output"#;
+    let (result, _interpreter) = run_program_in_dir(&temp_dir, source).await;
+    let errors = result.expect_err("Expected depth limit error");
+    let message = &errors.first().expect("Expected at least one error").message;
+    assert!(
+        message.contains("depth"),
+        "Error should mention nesting depth, got: {message}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path resolution
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_execute_file_resolves_relative_to_parent_script() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let pages_dir = temp_dir.path().join("pages");
+    fs::create_dir_all(&pages_dir).expect("Failed to create pages directory");
+    fs::write(pages_dir.join("child.wfl"), "display \"from pages dir\"\n")
+        .expect("Failed to write child file");
+
+    // Run with CWD elsewhere: resolution must be relative to main.wfl's directory
+    let source = r#"execute wfl file at "pages/child.wfl" and read output as page_output"#;
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(
+        get_global_text(&interpreter, "page_output"),
+        "from pages dir\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Pass-through (no capture clause): child output reaches stdout
+// ---------------------------------------------------------------------------
+
+mod test_helpers;
+
+#[test]
+fn test_execute_file_without_capture_passes_output_through() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let page_file = temp_dir.path().join("passthrough_page.wfl");
+    fs::write(&page_file, "display \"PASSTHROUGH_MARKER\"\n").expect("Failed to write page file");
+
+    let program = format!(
+        "execute wfl file at \"{}\"\ndisplay \"MAIN_DONE\"\n",
+        page_file.display()
+    );
+    let output = test_helpers::run_wfl_program(&program, "test_execute_file_passthrough");
+    test_helpers::assert_wfl_success_with_output(
+        &output,
+        &["PASSTHROUGH_MARKER", "MAIN_DONE"],
+        &[],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: web server executes a page and serves its output (PHP-style)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_web_server_serves_executed_wfl_page() {
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    fs::write(
+        temp_dir.path().join("dynamic_page.wfl"),
+        concat!(
+            "display \"<h1>Hello from WFL</h1>\"\n",
+            "display \"<p>You requested \" with path with \"</p>\"\n",
+        ),
+    )
+    .expect("Failed to write page file");
+
+    let port = 8123;
+    let server_file = temp_dir.path().join("server.wfl");
+    let server_code = format!(
+        concat!(
+            "listen on port {} as test_server\n",
+            "wait for request comes in on test_server as incoming_request with timeout 10000\n",
+            "execute wfl file at \"dynamic_page.wfl\" with incoming_request and read output as page_output\n",
+            "respond to incoming_request with page_output and content_type \"text/html\"\n",
+            "close server test_server\n",
+        ),
+        port
+    );
+    fs::write(&server_file, &server_code).expect("Failed to write server file");
+
+    // Run the server on a dedicated thread with its own runtime (interpreter is !Send)
+    let server_handle = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&server_code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("Failed to parse server code");
+            let mut interpreter = Interpreter::new();
+            interpreter.set_source_file(server_file);
+            if let Err(e) = interpreter.interpret(&ast).await {
+                panic!("Server program failed: {e:?}");
+            }
+        });
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    let response = reqwest::get(format!("http://127.0.0.1:{port}/welcome"))
+        .await
+        .expect("Failed to send request");
+    assert_eq!(response.status().as_u16(), 200);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .expect("Missing content-type")
+            .to_str()
+            .unwrap(),
+        "text/html"
+    );
+    let body = response.text().await.expect("Failed to read body");
+    assert!(
+        body.contains("<h1>Hello from WFL</h1>"),
+        "Body should contain page heading, got: {body}"
+    );
+    assert!(
+        body.contains("You requested /welcome"),
+        "Page should see the request path, got: {body}"
+    );
+
+    server_handle.join().expect("Server thread panicked");
+}

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -422,10 +422,10 @@ fn test_execute_file_without_capture_passes_output_through() {
     let page_file = temp_dir.path().join("passthrough_page.wfl");
     fs::write(&page_file, "display \"PASSTHROUGH_MARKER\"\n").expect("Failed to write page file");
 
-    let program = format!(
-        "execute wfl file at \"{}\"\ndisplay \"MAIN_DONE\"\n",
-        page_file.display()
-    );
+    // Forward slashes keep the embedded path lexable on Windows (backslashes
+    // would be treated as escape sequences in the WFL string literal)
+    let page_path = page_file.display().to_string().replace('\\', "/");
+    let program = format!("execute wfl file at \"{page_path}\"\ndisplay \"MAIN_DONE\"\n");
     let output = test_helpers::run_wfl_program(&program, "test_execute_file_passthrough");
     test_helpers::assert_wfl_success_with_output(
         &output,

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -389,6 +389,27 @@ async fn test_execute_file_resolves_relative_to_parent_script() {
     );
 }
 
+#[tokio::test]
+async fn test_execute_file_dynamic_path_via_variable() {
+    // A `with` directly after the path always passes request context, so
+    // dynamically chosen pages are built into a variable first (see docs)
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let pages_dir = temp_dir.path().join("pages");
+    fs::create_dir_all(&pages_dir).expect("Failed to create pages directory");
+    fs::write(pages_dir.join("about.wfl"), "display \"about page\"\n")
+        .expect("Failed to write page file");
+
+    let source = concat!(
+        "store page_name as \"about\"\n",
+        "store page_path as \"pages/\" with page_name with \".wfl\"\n",
+        "execute wfl file at page_path and read output as page_output\n",
+    );
+    let (result, interpreter) = run_program_in_dir(&temp_dir, source).await;
+    result.unwrap_or_else(|e| panic!("Interpret failed: {e:?}"));
+
+    assert_eq!(get_global_text(&interpreter, "page_output"), "about page\n");
+}
+
 // ---------------------------------------------------------------------------
 // Pass-through (no capture clause): child output reaches stdout
 // ---------------------------------------------------------------------------
@@ -429,7 +450,7 @@ async fn test_web_server_serves_executed_wfl_page() {
     )
     .expect("Failed to write page file");
 
-    let port = 8123;
+    let port: u16 = 58123;
     let server_file = temp_dir.path().join("server.wfl");
     let server_code = format!(
         concat!(
@@ -458,7 +479,18 @@ async fn test_web_server_serves_executed_wfl_page() {
         });
     });
 
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    // Wait for the server to accept connections. Probe with a raw TCP connect:
+    // an HTTP probe would consume the server's single `wait for request`.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+            Ok(_) => break,
+            Err(_) if std::time::Instant::now() < deadline => {
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            Err(e) => panic!("Server did not start listening within 10s: {e}"),
+        }
+    }
 
     let response = reqwest::get(format!("http://127.0.0.1:{port}/welcome"))
         .await


### PR DESCRIPTION
## Summary

Adds the ability for a WFL program (typically a web server) to execute another `.wfl` file **in-process** and capture its display output, enabling PHP-style dynamic pages:

```wfl
execute [wfl] file at <path> [with <request>] [and read output as <variable>]
```

### Example: serving dynamic WFL pages

```wfl
listen on port 8080 as web_server
main loop:
    wait for request comes in on web_server as req
    try:
        execute wfl file at "pages/home.wfl" with req and read output as page_output
        respond to req with page_output and content_type "text/html"
    when file not found:
        respond to req with "Page not found" and status 404
    when error:
        respond to req with "Server error" and status 500
    end try
end loop
```

The executed page is a normal WFL program. With `with req` it sees the same request variables a server sees (`method`, `path`, `client_ip`, `body`, `headers`), and everything it `display`s is captured into the output variable instead of printed.

## Implementation

- **New `ExecuteFileStatement`** parsed entirely from existing keywords (no new tokens); syntax follows WFL's natural-language principles, mirroring `open file at ... and read content as ...`
- **Nested interpreter** per execution with a fresh environment and stdlib, inheriting the parent's config; paths resolve relative to the executing file's directory (like `load module`)
- **Output capture** via a new thread-local capture stack (`src/interpreter/io_capture.rs`) that `display`/`print` now route through; capture nests correctly so pages can execute layout/partial pages
- **Depth guard** (4 levels) prevents circular execution; the limit is stack-bound (verified empirically — deeper nesting overflows the thread stack in debug builds before a larger guard could fire)
- **Catchable errors**: missing file, parse errors, and runtime errors in the executed page become catchable parent errors with the page path in the message; `when file not found` matches missing pages, so one broken page cannot crash the server
- **Request object enrichment**: request objects from `wait for request` now also carry `method`, `path`, `client_ip`, `body`, `headers` properties (additive and backward compatible; `respond to` is unchanged)

## Testing (TDD)

Tests were written first and confirmed failing before implementation:

- 23 Rust tests in `tests/execute_file_test.rs`: parse shapes, output capture, nested capture, request context, error catchability, depth guard, relative path resolution, and a true end-to-end test that starts a WFL server and asserts a real HTTP response contains the executed page's output
- `TestPrograms/execute_wfl_file.test.wfl`: WFL-native test framework suite (3 tests, green under `wfl --test`)
- `TestPrograms/execute_wfl_file.wfl` + `TestPrograms/execute_pages/`: end-to-end program for the integration suite
- Full suite: **1019 passed / 0 failed**; `cargo fmt` and `cargo clippy -D warnings` clean
- Integration script failures (21) were verified pre-existing by rebuilding plain `main` and getting the identical list
- Docs examples validated live against the release binary, including a multi-request server session exercising the 404 path

## Docs

- `Docs/04-advanced-features/web-servers.md`: new "Serving Dynamic WFL Pages" section
- `Docs/04-advanced-features/subprocess-execution.md`: "Executing WFL Files In-Process" section
- `Docs/reference/syntax-reference.md`: statement forms
- `CHANGELOG.md`: Unreleased entry

## Notes (pre-existing issues spotted, not addressed here)

- Older examples in `web-servers.md` use `as server`, which fails to parse (`server` is a reserved keyword)
- `scripts/run_web_tests.sh` aborts immediately due to `set -e` + `((counter++))`

https://claude.ai/code/session_011z74V37zumkdS8tUwohjhV

---
_Generated by [Claude Code](https://claude.ai/code/session_011z74V37zumkdS8tUwohjhV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-process WFL file execution with optional request-context passing
  * Capture displayed output from executed files into variables
  * Catchable execution errors (including missing files) and a nesting-depth guard

* **Documentation**
  * New advanced docs for subprocess execution and dynamic WFL page serving
  * Syntax reference examples added; web-server examples updated to use content_type

* **Tests**
  * Comprehensive tests and example programs covering execution, capture, errors, nesting, and server flow
<!-- end of auto-generated comment: release notes by coderabbit.ai -->