### PR TITLE
Fix parser, analyzer, and typechecker for documented forms and includes

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -161,6 +161,11 @@ pub struct Analyzer {
     action_parameters: std::collections::HashSet<String>,
     containers: HashMap<String, ContainerInfo>,
     current_container: Option<String>,
+    /// True when the program contains `include from` statements. Included files
+    /// are resolved dynamically at runtime, so the analyzer cannot know which
+    /// actions/variables they expose; undefined-action errors are suppressed to
+    /// avoid false fatal failures for include-exposed actions.
+    has_includes: bool,
 }
 
 impl Default for Analyzer {
@@ -314,6 +319,7 @@ impl Analyzer {
             action_parameters: std::collections::HashSet::new(),
             containers: HashMap::new(),
             current_container: None,
+            has_includes: false,
         }
     }
 
@@ -363,6 +369,17 @@ impl Analyzer {
     }
 
     pub fn analyze(&mut self, program: &Program) -> Result<(), Vec<SemanticError>> {
+        // Detect include statements up front. Includes are resolved at runtime
+        // and can expose actions/variables the analyzer never sees, so their
+        // presence relaxes undefined-action reporting (see `has_includes`).
+        if program
+            .statements
+            .iter()
+            .any(|s| matches!(s, Statement::IncludeStatement { .. }))
+        {
+            self.has_includes = true;
+        }
+
         // PASS 1: Register all top-level action signatures
         // This allows forward references between actions at the top level
         for statement in &program.statements {
@@ -2059,7 +2076,17 @@ impl Analyzer {
                 self.analyze_expression(function);
 
                 if let Expression::Variable(name, _, _) = &**function {
-                    if let Some(symbol) = self.current_scope.resolve(name) {
+                    if Self::is_builtin_function(name) {
+                        // Built-in stdlib functions (touppercase, wflhash256,
+                        // parse_json, ...) are always callable. When an included
+                        // file is analyzed, parent-scope bindings for these
+                        // natives are injected as plain variables, so without this
+                        // guard the call below would be flagged as
+                        // "'<name>' is not a function".
+                        for arg in arguments {
+                            self.analyze_expression(&arg.value);
+                        }
+                    } else if let Some(symbol) = self.current_scope.resolve(name) {
                         match &symbol.kind {
                             SymbolKind::Function { signatures } => {
                                 // For now, just check the first signature for compatibility
@@ -2316,8 +2343,12 @@ impl Analyzer {
                             ));
                         }
                     }
-                } else {
-                    // Action not found in scope and not a builtin
+                } else if !self.has_includes {
+                    // Action not found in scope and not a builtin. When the
+                    // program uses `include from`, the action may be exposed by
+                    // an included file at runtime, so we cannot flag it here
+                    // (doing so would fatally abort the program before the
+                    // include ever runs — see issue #548).
                     self.errors.push(SemanticError::new(
                         format!("Undefined action '{}'", name),
                         *line,

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -170,13 +170,18 @@ pub fn program_has_includes(program: &Program) -> bool {
 pub struct Analyzer {
     current_scope: Scope,
     errors: Vec<SemanticError>,
+    /// Non-fatal semantic warnings. Currently used for undefined-action calls in
+    /// programs that use `include from`: the action may be provided by an
+    /// included module at runtime, but it could also be a typo, so it is
+    /// surfaced as a warning rather than a fatal error or silent suppression.
+    warnings: Vec<SemanticError>,
     action_parameters: std::collections::HashSet<String>,
     containers: HashMap<String, ContainerInfo>,
     current_container: Option<String>,
     /// True when the program contains `include from` statements. Included files
     /// are resolved dynamically at runtime, so the analyzer cannot know which
-    /// actions/variables they expose; undefined-action errors are suppressed to
-    /// avoid false fatal failures for include-exposed actions.
+    /// actions/variables they expose; undefined-action errors are downgraded to
+    /// warnings to avoid false fatal failures for include-exposed actions.
     has_includes: bool,
 }
 
@@ -328,6 +333,7 @@ impl Analyzer {
         Analyzer {
             current_scope: global_scope,
             errors: Vec::new(),
+            warnings: Vec::new(),
             action_parameters: std::collections::HashSet::new(),
             containers: HashMap::new(),
             current_container: None,
@@ -408,6 +414,12 @@ impl Analyzer {
 
     pub fn get_errors(&self) -> &Vec<SemanticError> {
         &self.errors
+    }
+
+    /// Non-fatal semantic warnings collected during analysis (e.g. undefined
+    /// actions in a program that uses `include from`).
+    pub fn get_warnings(&self) -> &Vec<SemanticError> {
+        &self.warnings
     }
 
     fn analyze_statement(&mut self, statement: &Statement) {
@@ -2361,12 +2373,21 @@ impl Analyzer {
                             ));
                         }
                     }
-                } else if !self.has_includes {
-                    // Action not found in scope and not a builtin. When the
-                    // program uses `include from`, the action may be exposed by
-                    // an included file at runtime, so we cannot flag it here
-                    // (doing so would fatally abort the program before the
-                    // include ever runs — see issue #548).
+                } else if self.has_includes {
+                    // Action not found in scope and not a builtin, but the program
+                    // uses `include from`. The action may be exposed by an
+                    // included file at runtime (which the analyzer cannot see), so
+                    // treating this as a fatal error would abort the program
+                    // before the include runs (see issue #548). It may also be a
+                    // genuine typo, so it is reported as a non-fatal warning rather
+                    // than being fully suppressed.
+                    self.warnings.push(SemanticError::new(
+                        format!("Undefined action '{}'", name),
+                        *line,
+                        *column,
+                    ));
+                } else {
+                    // Action not found in scope and not a builtin.
                     self.errors.push(SemanticError::new(
                         format!("Undefined action '{}'", name),
                         *line,

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -390,9 +390,9 @@ impl Analyzer {
         // Detect include statements up front. Includes are resolved at runtime
         // and can expose actions/variables the analyzer never sees, so their
         // presence relaxes undefined-action reporting (see `has_includes`).
-        if program_has_includes(program) {
-            self.has_includes = true;
-        }
+        // Assign directly (not just set-to-true) so a reused analyzer instance
+        // does not carry a stale flag from a previous program.
+        self.has_includes = program_has_includes(program);
 
         // PASS 1: Register all top-level action signatures
         // This allows forward references between actions at the top level
@@ -2129,13 +2129,19 @@ impl Analyzer {
                             _ => {
                                 // The symbol resolved to something that is not a
                                 // function. Built-in stdlib functions (touppercase,
-                                // wflhash256, parse_json, ...) can be injected into
-                                // an included file's scope as plain variables
-                                // (parent-scope bindings), so those are still
-                                // callable; only genuinely non-callable symbols are
-                                // an error. Real builtin Function symbols take the
-                                // arm above, so their arity checks are preserved.
-                                if Self::is_builtin_function(name) {
+                                // wflhash256, parse_json, ...) get injected into an
+                                // included file's scope as plain variables
+                                // (parent-scope bindings, defined at position 0:0),
+                                // so those remain callable. A user who genuinely
+                                // shadows a builtin name with a non-function value
+                                // (e.g. `store touppercase as "x"`) has a real
+                                // source position, so that still reports
+                                // "is not a function". Real builtin Function
+                                // symbols take the arm above (arity preserved).
+                                let is_injected_builtin = Self::is_builtin_function(name)
+                                    && symbol.line == 0
+                                    && symbol.column == 0;
+                                if is_injected_builtin {
                                     for arg in arguments {
                                         self.analyze_expression(&arg.value);
                                     }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -155,6 +155,18 @@ impl fmt::Display for SemanticError {
 
 impl std::error::Error for SemanticError {}
 
+/// Returns true if the program contains any top-level `include from` statement.
+///
+/// Included files are resolved dynamically at runtime, so their presence relaxes
+/// static undefined-action reporting in both the analyzer and the type checker.
+/// Shared so the two stay consistent if the detection rule ever changes.
+pub fn program_has_includes(program: &Program) -> bool {
+    program
+        .statements
+        .iter()
+        .any(|s| matches!(s, Statement::IncludeStatement { .. }))
+}
+
 pub struct Analyzer {
     current_scope: Scope,
     errors: Vec<SemanticError>,
@@ -372,11 +384,7 @@ impl Analyzer {
         // Detect include statements up front. Includes are resolved at runtime
         // and can expose actions/variables the analyzer never sees, so their
         // presence relaxes undefined-action reporting (see `has_includes`).
-        if program
-            .statements
-            .iter()
-            .any(|s| matches!(s, Statement::IncludeStatement { .. }))
-        {
+        if program_has_includes(program) {
             self.has_includes = true;
         }
 
@@ -2076,17 +2084,7 @@ impl Analyzer {
                 self.analyze_expression(function);
 
                 if let Expression::Variable(name, _, _) = &**function {
-                    if Self::is_builtin_function(name) {
-                        // Built-in stdlib functions (touppercase, wflhash256,
-                        // parse_json, ...) are always callable. When an included
-                        // file is analyzed, parent-scope bindings for these
-                        // natives are injected as plain variables, so without this
-                        // guard the call below would be flagged as
-                        // "'<name>' is not a function".
-                        for arg in arguments {
-                            self.analyze_expression(&arg.value);
-                        }
-                    } else if let Some(symbol) = self.current_scope.resolve(name) {
+                    if let Some(symbol) = self.current_scope.resolve(name) {
                         match &symbol.kind {
                             SymbolKind::Function { signatures } => {
                                 // For now, just check the first signature for compatibility
@@ -2104,7 +2102,7 @@ impl Analyzer {
                                             .map(|sig| sig.parameters.len().to_string())
                                             .collect();
                                         self.errors.push(SemanticError::new(
-                                            format!("Function '{}' expects {} arguments, but {} were provided", 
+                                            format!("Function '{}' expects {} arguments, but {} were provided",
                                                 name, expected_arities.join(" or "), arguments.len()),
                                             *line,
                                             *column,
@@ -2117,12 +2115,32 @@ impl Analyzer {
                                 }
                             }
                             _ => {
-                                self.errors.push(SemanticError::new(
-                                    format!("'{name}' is not a function"),
-                                    *line,
-                                    *column,
-                                ));
+                                // The symbol resolved to something that is not a
+                                // function. Built-in stdlib functions (touppercase,
+                                // wflhash256, parse_json, ...) can be injected into
+                                // an included file's scope as plain variables
+                                // (parent-scope bindings), so those are still
+                                // callable; only genuinely non-callable symbols are
+                                // an error. Real builtin Function symbols take the
+                                // arm above, so their arity checks are preserved.
+                                if Self::is_builtin_function(name) {
+                                    for arg in arguments {
+                                        self.analyze_expression(&arg.value);
+                                    }
+                                } else {
+                                    self.errors.push(SemanticError::new(
+                                        format!("'{name}' is not a function"),
+                                        *line,
+                                        *column,
+                                    ));
+                                }
                             }
+                        }
+                    } else if Self::is_builtin_function(name) {
+                        // A known builtin that isn't present as a scope symbol is
+                        // still callable (its arguments are still analyzed).
+                        for arg in arguments {
+                            self.analyze_expression(&arg.value);
                         }
                     }
                 } else {

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -129,7 +129,28 @@ impl StaticAnalyzer for Analyzer {
         // Store action parameters in the analyzer for use by the type checker
         self.action_parameters = action_parameters.clone();
 
-        if let Err(errors) = self.analyze(program) {
+        let analyze_result = self.analyze(program);
+
+        // Emit non-fatal semantic warnings (e.g. undefined actions in a program
+        // that uses `include from` — the action may be provided by an included
+        // module at runtime, but could also be a typo).
+        for warning in self.get_warnings().clone() {
+            diagnostics.push(WflDiagnostic::new(
+                Severity::Warning,
+                warning.message.clone(),
+                Some(
+                    "This action is not defined in this file; it may be provided by an included module at runtime, otherwise this is likely a typo."
+                        .to_string(),
+                ),
+                "ANALYZE-SEMANTIC".to_string(),
+                file_id,
+                warning.line,
+                warning.column,
+                None,
+            ));
+        }
+
+        if let Err(errors) = analyze_result {
             for error in errors {
                 // Skip errors about undefined variables that are actually action parameters
                 if error.message.starts_with("Variable '")

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -664,6 +664,144 @@ impl Analyzer {
                     _ => {}
                 }
             }
+            // Blocks that hold nested statements: recurse so variables used
+            // only inside them are counted (fixes ANALYZE-UNUSED false positives
+            // for code inside a `main loop`, etc.).
+            Statement::MainLoop { body, .. } | Statement::ForeverLoop { body, .. } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            Statement::SingleLineIf {
+                condition,
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                self.mark_used_in_expression(condition, usages);
+                self.mark_used_variables(then_stmt, usages);
+                if let Some(else_stmt) = else_stmt {
+                    self.mark_used_variables(else_stmt, usages);
+                }
+            }
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                ..
+            } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+                for clause in when_clauses {
+                    for stmt in &clause.body {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+                if let Some(otherwise) = otherwise_block {
+                    for stmt in otherwise {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+            }
+            Statement::DescribeBlock {
+                setup,
+                teardown,
+                tests,
+                ..
+            } => {
+                if let Some(setup) = setup {
+                    for stmt in setup {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+                for stmt in tests {
+                    self.mark_used_variables(stmt, usages);
+                }
+                if let Some(teardown) = teardown {
+                    for stmt in teardown {
+                        self.mark_used_variables(stmt, usages);
+                    }
+                }
+            }
+            Statement::TestBlock { body, .. } => {
+                for stmt in body {
+                    self.mark_used_variables(stmt, usages);
+                }
+            }
+            // Compound-assignment / list statements read (and write) their
+            // operand variables — count them as uses.
+            Statement::AddToListStatement {
+                value, list_name, ..
+            }
+            | Statement::RemoveFromListStatement {
+                value, list_name, ..
+            } => {
+                self.mark_used_in_expression(value, usages);
+                if let Some(usage) = usages.get_mut(list_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::ClearListStatement { list_name, .. } => {
+                if let Some(usage) = usages.get_mut(list_name) {
+                    usage.used = true;
+                }
+            }
+            Statement::PushStatement { list, value, .. } => {
+                self.mark_used_in_expression(list, usages);
+                self.mark_used_in_expression(value, usages);
+            }
+            // Web server statements reference their operand variables.
+            Statement::RespondStatement {
+                request,
+                content,
+                status,
+                content_type,
+                ..
+            } => {
+                self.mark_used_in_expression(request, usages);
+                self.mark_used_in_expression(content, usages);
+                if let Some(status) = status {
+                    self.mark_used_in_expression(status, usages);
+                }
+                if let Some(content_type) = content_type {
+                    self.mark_used_in_expression(content_type, usages);
+                }
+            }
+            Statement::ListenStatement { port, .. } => {
+                self.mark_used_in_expression(port, usages);
+            }
+            Statement::WaitForRequestStatement {
+                server,
+                request_name,
+                timeout,
+                ..
+            } => {
+                self.mark_used_in_expression(server, usages);
+                if let Some(usage) = usages.get_mut(request_name) {
+                    usage.used = true;
+                }
+                if let Some(timeout) = timeout {
+                    self.mark_used_in_expression(timeout, usages);
+                }
+            }
+            Statement::StopAcceptingConnectionsStatement { server, .. }
+            | Statement::CloseServerStatement { server, .. } => {
+                self.mark_used_in_expression(server, usages);
+            }
+            Statement::WriteToStatement { content, file, .. } => {
+                self.mark_used_in_expression(content, usages);
+                self.mark_used_in_expression(file, usages);
+            }
+            Statement::WriteContentStatement {
+                content, target, ..
+            }
+            | Statement::WriteBinaryStatement {
+                content, target, ..
+            } => {
+                self.mark_used_in_expression(content, usages);
+                self.mark_used_in_expression(target, usages);
+            }
             _ => {}
         }
     }

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -437,7 +437,67 @@ impl Analyzer {
             }
             Statement::WhileLoop { body, .. }
             | Statement::ForEachLoop { body, .. }
-            | Statement::CountLoop { body, .. } => {
+            | Statement::CountLoop { body, .. }
+            | Statement::MainLoop { body, .. }
+            | Statement::ForeverLoop { body, .. } => {
+                for stmt in body {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+            }
+            // Mirror the recursion done by `mark_used_variables` so variables
+            // declared inside these blocks are also tracked for unused-variable
+            // analysis (otherwise they would silently escape detection).
+            Statement::SingleLineIf {
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                self.collect_variable_declarations(then_stmt, usages);
+                if let Some(else_stmt) = else_stmt {
+                    self.collect_variable_declarations(else_stmt, usages);
+                }
+            }
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                ..
+            } => {
+                for stmt in body {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+                for clause in when_clauses {
+                    for stmt in &clause.body {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+                if let Some(otherwise) = otherwise_block {
+                    for stmt in otherwise {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+            }
+            Statement::DescribeBlock {
+                setup,
+                teardown,
+                tests,
+                ..
+            } => {
+                if let Some(setup) = setup {
+                    for stmt in setup {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+                for stmt in tests {
+                    self.collect_variable_declarations(stmt, usages);
+                }
+                if let Some(teardown) = teardown {
+                    for stmt in teardown {
+                        self.collect_variable_declarations(stmt, usages);
+                    }
+                }
+            }
+            Statement::TestBlock { body, .. } => {
                 for stmt in body {
                     self.collect_variable_declarations(stmt, usages);
                 }

--- a/src/parser/expr/binary.rs
+++ b/src/parser/expr/binary.rs
@@ -98,6 +98,20 @@ impl<'a> BinaryExprParser<'a> for Parser<'a> {
                             }
                             Token::KeywordNot => {
                                 self.bump_sync(); // Consume "not"
+
+                                // Support the natural "is not equal to" form by
+                                // consuming an optional "equal" and an optional "to"
+                                // (mirroring the "is equal to" branch above).
+                                if let Some(equal_token) = self.cursor.peek()
+                                    && matches!(&equal_token.token, Token::KeywordEqual)
+                                {
+                                    self.bump_sync(); // Consume "equal"
+                                    if let Some(to_token) = self.cursor.peek()
+                                        && matches!(&to_token.token, Token::KeywordTo)
+                                    {
+                                        self.bump_sync(); // Consume "to"
+                                    }
+                                }
                                 Some((Operator::NotEquals, 0))
                             }
                             Token::KeywordGreater => {
@@ -424,6 +438,14 @@ impl<'a> BinaryExprParser<'a> for Parser<'a> {
                 }
                 Token::KeywordSplit => {
                     self.bump_sync(); // Consume "split"
+
+                    // Accept the documented `split of X by DELIM` form by
+                    // optionally consuming "of" (equivalent to `split X by DELIM`).
+                    if let Some(of_token) = self.cursor.peek()
+                        && matches!(&of_token.token, Token::KeywordOf)
+                    {
+                        self.bump_sync(); // Consume "of"
+                    }
 
                     // Parse the text expression to split
                     let text_expr = self.parse_binary_expression(precedence + 1)?;

--- a/src/parser/expr/binary.rs
+++ b/src/parser/expr/binary.rs
@@ -441,11 +441,7 @@ impl<'a> BinaryExprParser<'a> for Parser<'a> {
 
                     // Accept the documented `split of X by DELIM` form by
                     // optionally consuming "of" (equivalent to `split X by DELIM`).
-                    if let Some(of_token) = self.cursor.peek()
-                        && matches!(&of_token.token, Token::KeywordOf)
-                    {
-                        self.bump_sync(); // Consume "of"
-                    }
+                    self.consume_optional_of();
 
                     // Parse the text expression to split
                     let text_expr = self.parse_binary_expression(precedence + 1)?;

--- a/src/parser/expr/primary.rs
+++ b/src/parser/expr/primary.rs
@@ -816,6 +816,15 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                 }
                 Token::KeywordSplit => {
                     self.bump_sync(); // Consume "split"
+
+                    // Accept the documented `split of X by DELIM` form by
+                    // optionally consuming "of" (equivalent to `split X by DELIM`).
+                    if let Some(of_token) = self.cursor.peek()
+                        && matches!(&of_token.token, Token::KeywordOf)
+                    {
+                        self.bump_sync(); // Consume "of"
+                    }
+
                     let text_expr = self.parse_expression()?;
 
                     // Check for "by" (string split) or "on" (pattern split)
@@ -1098,9 +1107,22 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                                     value: first_arg,
                                 });
 
-                                while let Some(and_token) = self.cursor.peek() {
-                                    if let Token::KeywordAnd = &and_token.token {
-                                        self.bump_sync(); // Consume "and"
+                                while let Some(sep_token) = self.cursor.peek() {
+                                    // Accept "and" as well as the natural-language
+                                    // separators used by documented stdlib calls
+                                    // (e.g. `substring of X from START length LEN`,
+                                    // `split of X by DELIM`). The word "length" is a
+                                    // plain identifier rather than a keyword.
+                                    let is_separator = matches!(
+                                        &sep_token.token,
+                                        Token::KeywordAnd | Token::KeywordFrom | Token::KeywordBy
+                                    ) || matches!(
+                                        &sep_token.token,
+                                        Token::Identifier(id) if id == "length"
+                                    );
+
+                                    if is_separator {
+                                        self.bump_sync(); // Consume the separator
 
                                         // Use parse_primary_expression to avoid treating next "and" as binary operator
                                         let arg_value = self.parse_primary_expression()?;

--- a/src/parser/expr/primary.rs
+++ b/src/parser/expr/primary.rs
@@ -819,11 +819,7 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
 
                     // Accept the documented `split of X by DELIM` form by
                     // optionally consuming "of" (equivalent to `split X by DELIM`).
-                    if let Some(of_token) = self.cursor.peek()
-                        && matches!(&of_token.token, Token::KeywordOf)
-                    {
-                        self.bump_sync(); // Consume "of"
-                    }
+                    self.consume_optional_of();
 
                     let text_expr = self.parse_expression()?;
 
@@ -1118,7 +1114,7 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                                         Token::KeywordAnd | Token::KeywordFrom | Token::KeywordBy
                                     ) || matches!(
                                         &sep_token.token,
-                                        Token::Identifier(id) if id == "length"
+                                        Token::Identifier(id) if id.eq_ignore_ascii_case("length")
                                     );
 
                                     if is_separator {

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -357,4 +357,16 @@ impl<'a> Parser<'a> {
             .peek_next()
             .is_some_and(|tok| matches!(tok.token, Token::KeywordBy))
     }
+
+    /// Consumes an optional leading `of` keyword if present.
+    ///
+    /// Used by the `split` handlers to accept both `split X by DELIM` and the
+    /// documented `split of X by DELIM` spelling from a single place.
+    pub(crate) fn consume_optional_of(&mut self) {
+        if let Some(of_token) = self.cursor.peek()
+            && matches!(&of_token.token, Token::KeywordOf)
+        {
+            self.bump_sync(); // Consume "of"
+        }
+    }
 }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -92,6 +92,10 @@ pub struct TypeChecker {
     errors: Vec<TypeError>,
     analyzer_already_run: bool,
     current_container: Option<String>,
+    /// True when the program contains `include from` statements. Included files
+    /// expose their actions dynamically at runtime, so undefined-action errors
+    /// are suppressed to match the analyzer (see issue #548).
+    has_includes: bool,
 }
 
 impl Default for TypeChecker {
@@ -111,6 +115,7 @@ impl TypeChecker {
             errors: Vec::new(),
             analyzer_already_run: false,
             current_container: None,
+            has_includes: false,
         }
     }
 
@@ -122,6 +127,7 @@ impl TypeChecker {
             errors: Vec::new(),
             analyzer_already_run: true, // Analyzer has already been run when passed in
             current_container: None,
+            has_includes: false,
         }
     }
 
@@ -186,6 +192,15 @@ impl TypeChecker {
     }
 
     pub fn check_types(&mut self, program: &Program) -> Result<(), Vec<TypeError>> {
+        // Detect includes: their exposed actions are only known at runtime.
+        if program
+            .statements
+            .iter()
+            .any(|s| matches!(s, Statement::IncludeStatement { .. }))
+        {
+            self.has_includes = true;
+        }
+
         // Only run the analyzer if it hasn't been run already
         // When created with with_analyzer(), the analyzer has already been run,
         // so we don't need to analyze again. This prevents duplicate symbol registration.
@@ -2746,6 +2761,11 @@ impl TypeChecker {
                             return self.get_builtin_function_type(name, arguments.len());
                         }
                         return Type::Unknown;
+                    } else if self.has_includes {
+                        // Action may be provided by an included file at runtime;
+                        // its result type is unknowable statically, so treat it as
+                        // Any to avoid cascading "could not infer type" errors.
+                        return Type::Any;
                     } else {
                         self.type_error(
                             format!("Undefined action '{name}'"),

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -193,11 +193,7 @@ impl TypeChecker {
 
     pub fn check_types(&mut self, program: &Program) -> Result<(), Vec<TypeError>> {
         // Detect includes: their exposed actions are only known at runtime.
-        if program
-            .statements
-            .iter()
-            .any(|s| matches!(s, Statement::IncludeStatement { .. }))
-        {
+        if crate::analyzer::program_has_includes(program) {
             self.has_includes = true;
         }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -193,9 +193,9 @@ impl TypeChecker {
 
     pub fn check_types(&mut self, program: &Program) -> Result<(), Vec<TypeError>> {
         // Detect includes: their exposed actions are only known at runtime.
-        if crate::analyzer::program_has_includes(program) {
-            self.has_includes = true;
-        }
+        // Assign directly so a reused TypeChecker (e.g. an editor session) does
+        // not carry a stale flag from a program that used includes.
+        self.has_includes = crate::analyzer::program_has_includes(program);
 
         // Only run the analyzer if it hasn't been run already
         // When created with with_analyzer(), the analyzer has already been run,
@@ -2761,6 +2761,12 @@ impl TypeChecker {
                         // Action may be provided by an included file at runtime;
                         // its result type is unknowable statically, so treat it as
                         // Any to avoid cascading "could not infer type" errors.
+                        // Still infer each argument expression first so type errors
+                        // inside the arguments are not missed in include-using
+                        // programs.
+                        for arg in arguments {
+                            let _ = self.infer_expression_type(&arg.value);
+                        }
                         return Type::Any;
                     } else {
                         self.type_error(

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -1,0 +1,230 @@
+//! Regression tests for a batch of reported issues:
+//!
+//! * #549 — documented/natural forms that the parser rejected:
+//!   `substring of X from START length LEN`, `split of X by DELIM`, and
+//!   `check if n is not equal to N`.
+//! * #547 — actions in an `include from` file could not call stdlib functions
+//!   (analyzer reported "'touppercase' is not a function").
+//! * #548 — an include-exposed action called from a top-level statement raised
+//!   a fatal "Undefined action", aborting the program before any code ran.
+//! * #468 — `add ... to X` and `respond ... with X` were not counted as uses of
+//!   `X`, producing false ANALYZE-UNUSED warnings.
+
+use std::fs;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn wfl_exe() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "target/release/wfl.exe"
+    } else {
+        "target/release/wfl"
+    }
+}
+
+/// Run a single WFL program (written to a temp file) and return combined
+/// stdout + stderr.
+fn run_wfl(code: &str) -> String {
+    let dir = TempDir::new().expect("tempdir");
+    let main = dir.path().join("main.wfl");
+    fs::write(&main, code).expect("write main.wfl");
+    run_file(&dir, "main.wfl")
+}
+
+/// Run a WFL file that lives inside `dir` (so `include from` can resolve
+/// sibling modules), returning combined stdout + stderr.
+fn run_file(dir: &TempDir, name: &str) -> String {
+    let path = dir.path().join(name);
+    let output = Command::new(wfl_exe())
+        .arg(&path)
+        .output()
+        .expect("Failed to execute WFL");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}")
+}
+
+/// Run `wfl --analyze <file>` and return combined output.
+fn analyze_wfl(code: &str) -> String {
+    let dir = TempDir::new().expect("tempdir");
+    let main = dir.path().join("main.wfl");
+    fs::write(&main, code).expect("write");
+    let output = Command::new(wfl_exe())
+        .arg("--analyze")
+        .arg(&main)
+        .output()
+        .expect("Failed to execute WFL");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}")
+}
+
+// ---------------------------------------------------------------------------
+// #549.1 — substring ... from ... length ...
+// ---------------------------------------------------------------------------
+
+#[test]
+fn substring_from_length_form_parses_and_runs() {
+    let out = run_wfl("display substring of \"abcdefghij\" from 0 length 5\n");
+    assert!(out.contains("abcde"), "expected 'abcde', got: {out}");
+    assert!(
+        !out.to_lowercase().contains("error"),
+        "unexpected error: {out}"
+    );
+}
+
+#[test]
+fn substring_and_form_still_works() {
+    // The original spelling must keep working.
+    let out = run_wfl("display substring of \"abcdefghij\" and 0 and 5\n");
+    assert!(out.contains("abcde"), "expected 'abcde', got: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// #549.2 — split of X by DELIM
+// ---------------------------------------------------------------------------
+
+#[test]
+fn split_of_by_form_parses_and_runs() {
+    let out = run_wfl("store parts as split of \"a-b-c\" by \"-\"\ndisplay parts\n");
+    assert!(out.contains("a") && out.contains("b") && out.contains("c"));
+    assert!(
+        !out.to_lowercase().contains("error"),
+        "unexpected error: {out}"
+    );
+}
+
+#[test]
+fn split_without_of_still_works() {
+    let out = run_wfl("store parts as split \"a-b-c\" by \"-\"\ndisplay parts\n");
+    assert!(out.contains("a") && out.contains("b") && out.contains("c"));
+    assert!(
+        !out.to_lowercase().contains("error"),
+        "unexpected error: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #549.3 — is not equal to
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_not_equal_to_true_branch() {
+    let out = run_wfl("check if 5 is not equal to 3:\n  display \"neq\"\nend check\n");
+    assert!(out.contains("neq"), "expected 'neq', got: {out}");
+    assert!(
+        !out.to_lowercase().contains("error"),
+        "unexpected error: {out}"
+    );
+}
+
+#[test]
+fn is_not_equal_to_false_branch() {
+    let out = run_wfl(
+        "check if 3 is not equal to 3:\n  display \"neq\"\notherwise:\n  display \"eq\"\nend check\n",
+    );
+    assert!(out.contains("eq") && !out.contains("neq"), "got: {out}");
+}
+
+#[test]
+fn is_equal_to_still_works() {
+    let out = run_wfl("check if 3 is equal to 3:\n  display \"yes\"\nend check\n");
+    assert!(out.contains("yes"), "expected 'yes', got: {out}");
+}
+
+// ---------------------------------------------------------------------------
+// #547 — included action can call stdlib functions
+// ---------------------------------------------------------------------------
+
+#[test]
+fn included_action_can_call_stdlib() {
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "define action called shout with parameters s:\n    return touppercase of s\nend action\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.wfl"),
+        "include from \"mod.wfl\"\nmain loop:\n    store g as call shout with \"bob\"\n    display \"R=\" with g\n    break\nend loop\n",
+    )
+    .unwrap();
+
+    let out = run_file(&dir, "main.wfl");
+    assert!(out.contains("R=BOB"), "expected 'R=BOB', got: {out}");
+    assert!(
+        !out.contains("is not a function"),
+        "should not report stdlib fn as non-function: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #548 — include-exposed action callable from a top-level statement
+// ---------------------------------------------------------------------------
+
+#[test]
+fn included_action_callable_from_top_level() {
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "define action called greet with parameters s:\n    return \"HI-\" with s\nend action\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.wfl"),
+        "include from \"mod.wfl\"\ndisplay \"BEFORE\"\nstore g as call greet with \"bob\"\ndisplay \"AFTER=\" with g\n",
+    )
+    .unwrap();
+
+    let out = run_file(&dir, "main.wfl");
+    assert!(
+        out.contains("BEFORE"),
+        "BEFORE must print (not aborted): {out}"
+    );
+    assert!(
+        out.contains("AFTER=HI-bob"),
+        "expected 'AFTER=HI-bob', got: {out}"
+    );
+    assert!(
+        !out.contains("Undefined action"),
+        "should not fatally report undefined action: {out}"
+    );
+}
+
+#[test]
+fn undefined_action_without_include_still_errors() {
+    // Guard: the include relaxation must NOT hide genuinely undefined actions
+    // in programs that do not use `include from`.
+    let out = run_wfl("store g as call totally_missing with \"x\"\ndisplay g\n");
+    assert!(
+        out.contains("Undefined action"),
+        "undefined action should still be reported without includes: {out}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #468 — add-to / respond uses are counted
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_variable_to_counter_counts_as_use() {
+    let out = analyze_wfl(
+        "store req_count as 0\nstore step as 1\nadd step to req_count\ndisplay req_count\n",
+    );
+    assert!(
+        !out.contains("Unused variable"),
+        "no variable should be flagged unused: {out}"
+    );
+}
+
+#[test]
+fn uses_inside_main_loop_are_counted() {
+    // Variables used only inside a `main loop` body must be seen as used.
+    let out = analyze_wfl(
+        "store greeting as \"hello\"\nmain loop:\n    display greeting\n    break\nend loop\n",
+    );
+    assert!(
+        !out.contains("Unused variable"),
+        "variable used inside main loop should not be flagged: {out}"
+    );
+}

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -188,6 +188,9 @@ fn included_action_callable_from_top_level() {
     )
     .unwrap();
 
+    // The undefined-action check is downgraded to a non-fatal warning when a
+    // program uses `include from`, so the program must run to completion even
+    // though the analyzer cannot statically see the included action.
     let out = run_file(&dir, "main.wfl");
     assert!(
         out.contains("BEFORE"),
@@ -196,10 +199,6 @@ fn included_action_callable_from_top_level() {
     assert!(
         out.contains("AFTER=HI-bob"),
         "expected 'AFTER=HI-bob', got: {out}"
-    );
-    assert!(
-        !out.contains("Undefined action"),
-        "should not fatally report undefined action: {out}"
     );
 }
 
@@ -211,6 +210,45 @@ fn undefined_action_without_include_still_errors() {
     assert!(
         out.contains("Undefined action"),
         "undefined action should still be reported without includes: {out}"
+    );
+}
+
+#[test]
+fn undefined_action_with_include_is_surfaced_as_warning() {
+    // With includes present, a genuinely undefined action (e.g. a typo) is still
+    // surfaced — as a non-fatal warning rather than being silently suppressed.
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "define action called greet with parameters s:\n    return \"HI-\" with s\nend action\n",
+    )
+    .unwrap();
+    // `grret` is a typo for `greet`.
+    let main = dir.path().join("main.wfl");
+    fs::write(
+        &main,
+        "include from \"mod.wfl\"\nstore g as call grret with \"bob\"\ndisplay g\n",
+    )
+    .unwrap();
+
+    let output = Command::new(wfl_exe())
+        .arg("--analyze")
+        .arg(&main)
+        .output()
+        .expect("run --analyze");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("Undefined action") && combined.contains("grret"),
+        "typo'd action should be surfaced as a warning even with includes: {combined}"
+    );
+    // The analyzer must not abort with a fatal error for this case.
+    assert!(
+        combined.to_lowercase().contains("warning"),
+        "should be reported at warning severity: {combined}"
     );
 }
 

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -203,6 +203,18 @@ fn included_action_callable_from_top_level() {
 }
 
 #[test]
+fn shadowing_a_builtin_with_a_non_function_still_errors() {
+    // The builtin relaxation only applies to include-injected symbols. A user
+    // who shadows a builtin name with a non-function value and then calls it
+    // must still get an "is not a function" error rather than a silent pass.
+    let out = run_wfl("store touppercase as \"x\"\ndisplay touppercase of \"y\"\n");
+    assert!(
+        out.contains("is not a function"),
+        "shadowed builtin used as a function should still error: {out}"
+    );
+}
+
+#[test]
 fn undefined_action_without_include_still_errors() {
     // Guard: the include relaxation must NOT hide genuinely undefined actions
     // in programs that do not use `include from`.

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -80,6 +80,18 @@ fn substring_and_form_still_works() {
     assert!(out.contains("abcde"), "expected 'abcde', got: {out}");
 }
 
+#[test]
+fn substring_length_separator_is_case_insensitive() {
+    // `length` as an argument separator should match case-insensitively, like
+    // other bareword pseudo-keywords in the parser.
+    let out = run_wfl("display substring of \"abcdefghij\" from 0 Length 5\n");
+    assert!(out.contains("abcde"), "expected 'abcde', got: {out}");
+    assert!(
+        !out.to_lowercase().contains("error"),
+        "unexpected error: {out}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // #549.2 — split of X by DELIM
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR fixes four reported issues affecting the parser, analyzer, and typechecker:
- **#549**: Parser now accepts documented natural-language forms for `substring`, `split`, and comparison operators
- **#547**: Included actions can now call stdlib functions without false "not a function" errors
- **#548**: Included actions are now callable from top-level statements without fatal "Undefined action" errors
- **#468**: Variables used in `add`/`respond` statements and nested blocks are now properly counted as used

## Key Changes

### Parser (`src/parser/expr/primary.rs` and `src/parser/expr/binary.rs`)
- **Substring form**: Added support for `substring of X from START length LEN` by accepting optional `from` and `length` separators in function call arguments
- **Split form**: Added support for `split of X by DELIM` by optionally consuming `of` keyword before the text expression
- **Comparison operators**: Added support for `is not equal to` form by consuming optional `equal` and `to` keywords after `not` in binary expressions
- All changes maintain backward compatibility with existing syntax forms

### Analyzer (`src/analyzer/mod.rs` and `src/analyzer/static_analyzer.rs`)
- **Include detection**: Added `has_includes` flag to detect `include from` statements upfront
- **Undefined action suppression**: When includes are present, undefined-action errors are suppressed since included files expose actions dynamically at runtime (fixes #548)
- **Builtin function handling**: Added guard to recognize builtin stdlib functions even when they appear as plain variables in included file scopes (fixes #547)
- **Variable usage tracking**: Extended `mark_used_variables()` to recursively traverse nested statement blocks (`MainLoop`, `ForeverLoop`, `SingleLineIf`, `TryStatement`, `DescribeBlock`, `TestBlock`) and compound-assignment statements (`AddToListStatement`, `RemoveFromListStatement`, `RespondStatement`, etc.) to properly count variables as used (fixes #468)

### TypeChecker (`src/typechecker/mod.rs`)
- **Include detection**: Added `has_includes` flag matching analyzer behavior
- **Undefined action suppression**: Suppresses undefined-action errors when includes are present, maintaining consistency with analyzer (fixes #548)
- **Type inference for included actions**: Returns `Type::Any` for actions that may be provided by included files at runtime, avoiding cascading type inference errors

### Tests (`tests/docs_parser_and_include_fixes_test.rs`)
- Added comprehensive regression test suite covering all four issues
- Tests verify both positive cases (correct parsing/execution) and negative cases (guard against regressions)
- Includes integration tests that write temporary files and execute the WFL compiler

https://claude.ai/code/session_01VUG4otZGqWhSAvoamQ9G9L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded parsing to accept more natural phrasing, including `split of X by ...`, `is not equal to ...`, and additional member-call argument separators (including `length`).
* **Bug Fixes**
  * Improved `include from` behavior so undefined actions can be reported as non-fatal warnings (and type-checking aligns), while truly undefined actions still error when no includes exist.
  * Enhanced function-call validation for builtin shadowing and broadened unused-variable tracking across nested control-flow blocks and more statement types.
* **Tests**
  * Added regression tests covering parsing variants, include behavior, warning-vs-error handling, and unused-variable counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->