### PR TITLE
Fix type inference for builtins in included files (issue #551)

### DIFF
--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -187,7 +187,18 @@ impl TypeChecker {
             // Crypto functions
             "wflhash256" | "wflhash512" | "wflhash256_with_salt" | "wflmac256" => Type::Text,
 
-            _ => Type::Unknown,
+            // JSON functions
+            "parse_json" => Type::Any, // object/list/scalar depending on the JSON
+            "stringify_json" | "stringify_json_pretty" => Type::Text,
+
+            // Text functions registered under stdlib-specific names
+            "string_split" => Type::List(Box::new(Type::Text)),
+
+            // Every registered builtin returns a value (void ones return
+            // Nothing above). For names without an explicit entry, Any keeps
+            // variables bound to their results inferable instead of raising
+            // spurious "Could not infer type" errors (issue #551).
+            _ => Type::Any,
         }
     }
 
@@ -2090,6 +2101,28 @@ impl TypeChecker {
             },
             Expression::Variable(name, _line, _column) => {
                 if let Some(symbol) = self.analyzer.get_symbol(name) {
+                    // Builtin stdlib functions get injected into an included
+                    // file's scope as parent-scope variable bindings (defined
+                    // at position 0:0) whose runtime value is a native
+                    // function, so their recorded type is Unknown. Resolve
+                    // them to their real builtin signature so variables bound
+                    // to their results stay inferable (issue #551). A user who
+                    // shadows a builtin with a concrete value keeps that
+                    // value's type and the normal path below.
+                    let is_injected_builtin = symbol.line == 0
+                        && symbol.column == 0
+                        && Analyzer::is_builtin_function(name);
+                    if is_injected_builtin
+                        && matches!(symbol.symbol_type, None | Some(Type::Unknown))
+                    {
+                        let param_count = builtins::get_function_arity(name);
+                        return Type::Function {
+                            parameters: vec![Type::Any; param_count],
+                            return_type: Box::new(
+                                self.get_builtin_function_type(name, param_count),
+                            ),
+                        };
+                    }
                     if let Some(var_type) = &symbol.symbol_type {
                         var_type.clone()
                     } else {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -139,9 +139,10 @@ impl TypeChecker {
     /// Get the return type for builtin functions
     fn get_builtin_function_type(&self, name: &str, _arg_count: usize) -> Type {
         match name {
-            // Type functions
+            // Core functions
             "typeof" | "type_of" => Type::Text,
             "isnothing" | "is_nothing" => Type::Boolean,
+            "print" | "sleep" | "foreach" => Type::Nothing, // Void functions
 
             // Math functions
             "abs" | "round" | "floor" | "ceil" | "clamp" | "min" | "max" | "power" | "sqrt"
@@ -155,8 +156,9 @@ impl TypeChecker {
 
             // Text functions
             "length" | "indexof" | "index_of" | "lastindexof" | "last_index_of" => Type::Number,
-            "touppercase" | "tolowercase" | "substring" | "replace" | "trim" | "padleft"
-            | "padright" | "capitalize" | "reverse" => Type::Text,
+            "touppercase" | "to_uppercase" | "tolowercase" | "to_lowercase" | "substring"
+            | "replace" | "trim" | "padleft" | "padright" | "capitalize" | "reverse"
+            | "reverse_text" => Type::Text,
             "contains" | "startswith" | "starts_with" | "endswith" | "ends_with" => Type::Boolean,
             "split" => Type::List(Box::new(Type::Text)),
             "join" => Type::Text,
@@ -165,39 +167,66 @@ impl TypeChecker {
             "push" | "pop" | "shift" | "unshift" | "removeat" | "remove_at" | "insertat"
             | "insert_at" | "slice" | "concat" | "unique" | "sort" | "reverse_list" | "clear"
             | "filter" | "map" => Type::List(Box::new(Type::Any)),
-            "find" => Type::Any,
-            "count" | "size" => Type::Number,
-            "includes" => Type::Boolean,
+            "find" | "reduce" => Type::Any,
+            "count" | "size" | "find_index" => Type::Number,
+            "includes" | "every" | "some" => Type::Boolean,
 
             // Time functions
             "now" | "today" | "time" | "date" | "year" | "month" | "day" | "hour" | "minute"
             | "second" | "dayofweek" | "day_of_week" | "adddays" | "add_days" | "addmonths"
             | "add_months" | "addyears" | "add_years" | "addhours" | "add_hours" | "addminutes"
             | "add_minutes" | "addseconds" | "add_seconds" => Type::Number,
-            "formatdate" | "format_date" | "formattime" | "format_time" => Type::Text,
+            "formatdate" | "format_date" | "formattime" | "format_time" | "format_datetime"
+            | "current_date" => Type::Text,
             "parsedate" | "parse_date" | "isleapyear" | "is_leap_year" => Type::Number,
+            // DateTime-valued functions: no static type exists for DateTime
+            "datetime_now" | "create_time" | "create_date" | "parse_time" => Type::Any,
             "daysbetween" | "days_between" | "monthsbetween" | "months_between"
             | "yearsbetween" | "years_between" => Type::Number,
 
             // Pattern functions
             "pattern" | "match" | "test" | "replace_pattern" | "extract" => Type::Text,
-            "ismatch" | "is_match" => Type::Boolean,
+            "ismatch" | "is_match" | "pattern_matches" => Type::Boolean,
             "findall" | "find_all" => Type::List(Box::new(Type::Text)),
+            "pattern_find" => Type::Any, // Match object or nothing
+            "pattern_find_all" => Type::List(Box::new(Type::Any)),
 
             // Crypto functions
-            "wflhash256" | "wflhash512" | "wflhash256_with_salt" | "wflmac256" => Type::Text,
+            "wflhash256"
+            | "wflhash512"
+            | "wflhash256_with_salt"
+            | "wflmac256"
+            | "generate_uuid"
+            | "generate_csrf_token" => Type::Text,
 
             // JSON functions
             "parse_json" => Type::Any, // object/list/scalar depending on the JSON
             "stringify_json" | "stringify_json_pretty" => Type::Text,
 
+            // Query and form parsing (objects with string values)
+            "parse_query_string" | "parse_cookies" | "parse_form_urlencoded" => Type::Any,
+
+            // Web routing helpers
+            "path_params" => Type::Map(Box::new(Type::Text), Box::new(Type::Text)),
+            "path_matches" => Type::Boolean,
+
             // Text functions registered under stdlib-specific names
             "string_split" => Type::List(Box::new(Type::Text)),
 
+            // Filesystem functions
+            "list_dir" | "glob" | "rglob" | "list_directory" => Type::List(Box::new(Type::Text)),
+            "path_join" | "path_basename" | "path_dirname" | "path_extension" | "path_stem"
+            | "read_file" => Type::Text,
+            "path_exists" | "is_file" | "is_dir" | "file_exists" | "is_directory" => Type::Boolean,
+            "file_size" | "file_mtime" | "count_lines" => Type::Number,
+            "makedirs" | "copy_file" | "move_file" | "remove_file" | "remove_dir"
+            | "write_file" | "delete_file" | "create_directory" => Type::Nothing,
+
             // Every registered builtin returns a value (void ones return
-            // Nothing above). For names without an explicit entry, Any keeps
-            // variables bound to their results inferable instead of raising
-            // spurious "Could not infer type" errors (issue #551).
+            // Nothing above). For the few remaining names without an explicit
+            // entry (test helpers, not-yet-implemented placeholders), Any
+            // keeps variables bound to their results inferable instead of
+            // raising spurious "Could not infer type" errors (issue #551).
             _ => Type::Any,
         }
     }

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -290,3 +290,96 @@ fn uses_inside_main_loop_are_counted() {
         "variable used inside main loop should not be flagged: {out}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #551 — variable bound to a builtin result inside an included file
+// ---------------------------------------------------------------------------
+
+#[test]
+fn included_action_can_store_builtin_result_in_variable() {
+    // `store full as wflhash256 of s` inside an included action must
+    // type-check: builtins are injected into the include's analyzer scope as
+    // plain parent variables with an Unknown type, which used to abort with
+    // "Could not infer type for variable 'full'" (issue #551).
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "define action called h with parameters s:\n    store full as wflhash256 of s\n    return full\nend action\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.wfl"),
+        "include from \"mod.wfl\"\nstore r as call h with \"x\"\ndisplay \"R=\" with r\n",
+    )
+    .unwrap();
+
+    let out = run_file(&dir, "main.wfl");
+    assert!(
+        !out.contains("Could not infer type"),
+        "builtin result variable must be inferable in an included file: {out}"
+    );
+    // wflhash256 of "x" is a 64-hex-char digest.
+    assert!(
+        out.contains("R=") && !out.contains("R=\n"),
+        "included action should run and return the hash: {out}"
+    );
+}
+
+#[test]
+fn included_file_can_store_builtin_result_at_top_level() {
+    // Same failure mode for a top-level `store` in the included file.
+    let dir = TempDir::new().expect("tempdir");
+    // The digest is displayed from inside the included file itself: main-file
+    // visibility of include-defined variables is a separate concern from the
+    // type-inference bug covered here.
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "store digest as wflhash256 of \"a\"\ndisplay \"D=\" with digest\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("main.wfl"), "include from \"mod.wfl\"\n").unwrap();
+
+    let out = run_file(&dir, "main.wfl");
+    assert!(
+        !out.contains("Could not infer type"),
+        "top-level builtin result variable must be inferable: {out}"
+    );
+    assert!(out.contains("D="), "included store should run: {out}");
+}
+
+#[test]
+fn included_action_can_store_parse_json_result() {
+    // parse_json had no entry in the builtin return-type table, so even the
+    // main-file inference produced "Could not infer type"; in an included
+    // file it was fatal (issue #551).
+    let dir = TempDir::new().expect("tempdir");
+    fs::write(
+        dir.path().join("mod.wfl"),
+        "define action called first_elem with parameters s:\n    store p as parse_json of s\n    return p\nend action\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("main.wfl"),
+        "include from \"mod.wfl\"\nstore r as call first_elem with \"[7]\"\ndisplay \"P=\" with r\n",
+    )
+    .unwrap();
+
+    let out = run_file(&dir, "main.wfl");
+    assert!(
+        !out.contains("Could not infer type"),
+        "parse_json result variable must be inferable in an included file: {out}"
+    );
+    assert!(out.contains("P=[7]"), "expected 'P=[7]', got: {out}");
+}
+
+#[test]
+fn parse_json_result_variable_is_inferable_in_main_file() {
+    // Guard for the return-type table: parse_json in the main file must not
+    // produce a spurious "Could not infer type" diagnostic either.
+    let out = run_wfl("store p as parse_json of \"[1]\"\ndisplay p\n");
+    assert!(
+        !out.contains("Could not infer type"),
+        "parse_json result must be inferable in the main file: {out}"
+    );
+    assert!(out.contains("[1]"), "expected '[1]', got: {out}");
+}


### PR DESCRIPTION
## Summary
Fixes a type inference bug where variables bound to builtin function results would fail with "Could not infer type" errors when used in included files. The issue occurred because builtins are injected into included scopes as parent variables with Unknown type, preventing proper type resolution.

## Key Changes

- **Type checker builtin return types** (`src/typechecker/mod.rs`):
  - Added explicit return type entries for `parse_json` (returns `Type::Any`), `stringify_json`/`stringify_json_pretty` (return `Type::Text`), and `string_split` (returns `Type::List(Text)`)
  - Changed the default fallback from `Type::Unknown` to `Type::Any` for unregistered builtins, allowing variables bound to their results to remain inferable
  - Added logic to detect injected builtins (position 0:0 with Unknown/None type) and resolve them to their actual builtin function signatures using `get_builtin_function_type()` and `get_function_arity()`

- **Test coverage** (`tests/docs_parser_and_include_fixes_test.rs`):
  - Added `included_action_can_store_builtin_result_in_variable()` - tests `wflhash256` in an included action
  - Added `included_file_can_store_builtin_result_at_top_level()` - tests top-level builtin result storage in included files
  - Added `included_action_can_store_parse_json_result()` - tests `parse_json` (which had no return type entry)
  - Added `parse_json_result_variable_is_inferable_in_main_file()` - guards against spurious errors in main files

## Implementation Details

The fix works by detecting when a variable reference in an included file points to an injected builtin (identified by position 0:0 and Unknown/None type), then resolving it to the proper builtin function type using the existing `get_builtin_function_type()` method. This allows the type checker to properly infer the return type of builtin calls even when the builtin is accessed through the parent scope injection mechanism used for includes.

https://claude.ai/code/session_01AhKSguwesKWJAGL6ez1Bue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for builtin function results, especially when results are stored in or passed through variables from included files, reducing false “Could not infer type” errors.
  * Variable bindings originating from injected builtins now resolve to more precise function and return types.
* **Tests**
  * Added regression coverage for include-file and main-file scenarios involving builtin results (e.g., hashing and JSON parsing), asserting the prior fatal diagnostic no longer appears.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->