### PR TITLE
Support database queries and executes in return expressions

### DIFF
--- a/Docs/04-advanced-features/databases.md
+++ b/Docs/04-advanced-features/databases.md
@@ -100,6 +100,20 @@ store row as rows[0]
 store new_id as row["id"]
 ```
 
+## Returning Results from Actions
+
+`query` and `execute` — with or without `and parameters [...]` — can be
+returned directly from an action, which keeps small data-access helpers to
+one line:
+
+```wfl
+define action called ages_for_name with parameters conn and who:
+    return query conn with "SELECT age FROM users WHERE name = ?" and parameters [who]
+end action
+
+store rows as call ages_for_name with db and "Alice"
+```
+
 ## Waiting Explicitly
 
 Database statements run asynchronously inside WFL's runtime; you can make the

--- a/TestPrograms/database_sqlite_test.wfl
+++ b/TestPrograms/database_sqlite_test.wfl
@@ -1,7 +1,8 @@
 // End-to-end database test using SQLite (no external services required)
 // Exercises: open database, execute (DDL/INSERT/UPDATE/DELETE with bound
-// parameters), query (SELECT with bound parameters), NULL handling, and
-// close database.
+// parameters), query (SELECT with bound parameters), NULL handling,
+// returning parameterized query/execute results directly from actions,
+// and close database.
 
 display "=== Database SQLite E2E Test ==="
 
@@ -105,6 +106,33 @@ check if error_caught is equal to "yes":
     display "✓ Malformed SQL raises a catchable error"
 otherwise:
     display "✗ FAILED: malformed SQL did not raise an error"
+    add 1 to failures
+end check
+
+// 9. Return a parameterized query directly from an action (issue #559)
+define action called ages_for_name with parameters conn and who:
+    return query conn with "SELECT age FROM users WHERE name = ?" and parameters [who]
+end action
+
+store alice_rows as call ages_for_name with db and "Alice"
+store alice_row as alice_rows[0]
+check if alice_row["age"] is equal to 31:
+    display "✓ return query with parameters works from an action"
+otherwise:
+    display "✗ FAILED: return query with parameters gave wrong row"
+    add 1 to failures
+end check
+
+// 10. Return a parameterized execute directly from an action
+define action called add_user with parameters conn and user_name and user_age:
+    return execute conn with "INSERT INTO users (name, age) VALUES (?, ?)" and parameters [user_name and user_age]
+end action
+
+store add_result as call add_user with db and "Carol" and 20
+check if add_result["affected_rows"] is equal to 1:
+    display "✓ return execute with parameters works from an action"
+otherwise:
+    display "✗ FAILED: return execute with parameters affected_rows wrong"
     add 1 to failures
 end check
 

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2550,6 +2550,18 @@ impl Analyzer {
             } => {
                 self.analyze_expression(process_id);
             }
+            Expression::DatabaseQuery {
+                db,
+                sql,
+                parameters,
+                ..
+            } => {
+                self.analyze_expression(db);
+                self.analyze_expression(sql);
+                if let Some(params) = parameters {
+                    self.analyze_expression(params);
+                }
+            }
         }
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -351,6 +351,7 @@ fn expr_type(expr: &Expression) -> String {
             format!("CurrentTimeFormatted '{format}'")
         }
         Expression::ProcessRunning { .. } => "ProcessRunning".to_string(),
+        Expression::DatabaseQuery { .. } => "DatabaseQuery".to_string(),
     }
 }
 
@@ -2834,75 +2835,17 @@ impl Interpreter {
                 line,
                 column,
             } => {
-                let db_value = self.evaluate_expression(db, Rc::clone(&env)).await?;
-                let handle = match &db_value {
-                    Value::Text(s) => s.clone(),
-                    _ => {
-                        return Err(RuntimeError::new(
-                            format!("Expected a database handle, got {db_value:?}"),
-                            *line,
-                            *column,
-                        ));
-                    }
-                };
-
-                let sql_value = self.evaluate_expression(sql, Rc::clone(&env)).await?;
-                let sql_str = match &sql_value {
-                    Value::Text(s) => s.clone(),
-                    _ => {
-                        return Err(RuntimeError::new(
-                            format!("Expected text for SQL statement, got {sql_value:?}"),
-                            *line,
-                            *column,
-                        ));
-                    }
-                };
-
-                let params = match parameters {
-                    Some(params_expr) => {
-                        let params_value = self
-                            .evaluate_expression(params_expr, Rc::clone(&env))
-                            .await?;
-                        match &params_value {
-                            Value::List(list) => {
-                                let mut sql_params = Vec::new();
-                                for value in list.borrow().iter() {
-                                    sql_params.push(
-                                        database::value_to_sql_param(value)
-                                            .map_err(|e| RuntimeError::new(e, *line, *column))?,
-                                    );
-                                }
-                                sql_params
-                            }
-                            _ => {
-                                return Err(RuntimeError::new(
-                                    format!(
-                                        "Expected a list of query parameters, got {params_value:?}"
-                                    ),
-                                    *line,
-                                    *column,
-                                ));
-                            }
-                        }
-                    }
-                    None => Vec::new(),
-                };
-
-                let pool = self
-                    .io_client
-                    .get_database(&handle)
-                    .await
-                    .map_err(|e| RuntimeError::new(e, *line, *column))?;
-
-                let result = match kind {
-                    crate::parser::ast::DatabaseQueryKind::Query => {
-                        database::run_query(&pool, &sql_str, &params).await
-                    }
-                    crate::parser::ast::DatabaseQueryKind::Execute => {
-                        database::run_execute(&pool, &sql_str, &params).await
-                    }
-                }
-                .map_err(|e| RuntimeError::new(e, *line, *column))?;
+                let result = self
+                    .evaluate_database_query(
+                        db,
+                        sql,
+                        parameters.as_ref(),
+                        *kind,
+                        *line,
+                        *column,
+                        Rc::clone(&env),
+                    )
+                    .await?;
 
                 match env.borrow_mut().define(variable_name, result) {
                     Ok(_) => Ok((Value::Null, ControlFlow::None)),
@@ -6536,6 +6479,88 @@ impl Interpreter {
         }
     }
 
+    /// Run a database query/execute and return the result value. Shared by
+    /// `DatabaseQueryStatement` and the expression form (`return query ...`).
+    #[allow(clippy::too_many_arguments)]
+    async fn evaluate_database_query(
+        &self,
+        db: &Expression,
+        sql: &Expression,
+        parameters: Option<&Expression>,
+        kind: crate::parser::ast::DatabaseQueryKind,
+        line: usize,
+        column: usize,
+        env: Rc<RefCell<Environment>>,
+    ) -> Result<Value, RuntimeError> {
+        let db_value = self.evaluate_expression(db, Rc::clone(&env)).await?;
+        let handle = match &db_value {
+            Value::Text(s) => s.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    format!("Expected a database handle, got {db_value:?}"),
+                    line,
+                    column,
+                ));
+            }
+        };
+
+        let sql_value = self.evaluate_expression(sql, Rc::clone(&env)).await?;
+        let sql_str = match &sql_value {
+            Value::Text(s) => s.clone(),
+            _ => {
+                return Err(RuntimeError::new(
+                    format!("Expected text for SQL statement, got {sql_value:?}"),
+                    line,
+                    column,
+                ));
+            }
+        };
+
+        let params = match parameters {
+            Some(params_expr) => {
+                let params_value = self
+                    .evaluate_expression(params_expr, Rc::clone(&env))
+                    .await?;
+                match &params_value {
+                    Value::List(list) => {
+                        let mut sql_params = Vec::new();
+                        for value in list.borrow().iter() {
+                            sql_params.push(
+                                database::value_to_sql_param(value)
+                                    .map_err(|e| RuntimeError::new(e, line, column))?,
+                            );
+                        }
+                        sql_params
+                    }
+                    _ => {
+                        return Err(RuntimeError::new(
+                            format!("Expected a list of query parameters, got {params_value:?}"),
+                            line,
+                            column,
+                        ));
+                    }
+                }
+            }
+            None => Vec::new(),
+        };
+
+        let pool = self
+            .io_client
+            .get_database(&handle)
+            .await
+            .map_err(|e| RuntimeError::new(e, line, column))?;
+
+        match kind {
+            crate::parser::ast::DatabaseQueryKind::Query => {
+                database::run_query(&pool, &sql_str, &params).await
+            }
+            crate::parser::ast::DatabaseQueryKind::Execute => {
+                database::run_execute(&pool, &sql_str, &params).await
+            }
+        }
+        .map_err(|e| RuntimeError::new(e, line, column))
+    }
+
     async fn evaluate_expression(
         &self,
         expr: &Expression,
@@ -7733,6 +7758,25 @@ impl Interpreter {
                 // Check if process is running
                 let is_running = self.io_client.is_process_running(proc_id).await;
                 Ok(Value::Bool(is_running))
+            }
+            Expression::DatabaseQuery {
+                db,
+                sql,
+                parameters,
+                kind,
+                line,
+                column,
+            } => {
+                self.evaluate_database_query(
+                    db,
+                    sql,
+                    parameters.as_deref(),
+                    *kind,
+                    *line,
+                    *column,
+                    Rc::clone(&env),
+                )
+                .await
             }
         };
         self.assert_invariants();

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -737,6 +737,16 @@ pub enum Expression {
         line: usize,
         column: usize,
     },
+    /// Database query/execute in expression position:
+    /// `return query <db> with <sql> [and parameters <list>]`
+    DatabaseQuery {
+        db: Box<Expression>,
+        sql: Box<Expression>,
+        parameters: Option<Box<Expression>>,
+        kind: DatabaseQueryKind,
+        line: usize,
+        column: usize,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/parser/stmt/actions.rs
+++ b/src/parser/stmt/actions.rs
@@ -538,17 +538,16 @@ impl<'a> ActionParser<'a> for Parser<'a> {
         }
 
         let value = if let Some(token) = self.cursor.peek() {
+            // Position of the returned expression itself (not the `return`
+            // keyword), so diagnostics point at the actual operation.
+            let (value_line, value_column) = (token.line, token.column);
             if matches!(&token.token, Token::NothingLiteral) {
                 self.bump_sync(); // Consume "nothing"
                 None
             } else if let Some(kind) = self.peek_database_query_kind() {
                 // Database forms: `return query/execute <db> with <sql>
                 // [and parameters <list>]`, mirroring the `store ... as` value side.
-                Some(self.parse_database_query_expression(
-                    kind,
-                    return_token.line,
-                    return_token.column,
-                )?)
+                Some(self.parse_database_query_expression(kind, value_line, value_column)?)
             } else {
                 Some(self.parse_expression()?)
             }

--- a/src/parser/stmt/actions.rs
+++ b/src/parser/stmt/actions.rs
@@ -2,6 +2,7 @@
 
 use super::super::{Parameter, ParseError, Parser, Statement, Type};
 use super::StmtParser;
+use super::database::DatabaseParser;
 use crate::exec_trace;
 use crate::lexer::token::{Token, TokenWithPosition};
 use crate::parser::expr::ExprParser;
@@ -540,6 +541,14 @@ impl<'a> ActionParser<'a> for Parser<'a> {
             if matches!(&token.token, Token::NothingLiteral) {
                 self.bump_sync(); // Consume "nothing"
                 None
+            } else if let Some(kind) = self.peek_database_query_kind() {
+                // Database forms: `return query/execute <db> with <sql>
+                // [and parameters <list>]`, mirroring the `store ... as` value side.
+                Some(self.parse_database_query_expression(
+                    kind,
+                    return_token.line,
+                    return_token.column,
+                )?)
             } else {
                 Some(self.parse_expression()?)
             }

--- a/src/parser/stmt/database.rs
+++ b/src/parser/stmt/database.rs
@@ -8,7 +8,7 @@
 
 use super::super::{ParseError, Parser, Statement};
 use crate::lexer::token::Token;
-use crate::parser::ast::DatabaseQueryKind;
+use crate::parser::ast::{DatabaseQueryKind, Expression};
 use crate::parser::expr::{ExprParser, PrimaryExprParser};
 
 pub(crate) trait DatabaseParser<'a>: ExprParser<'a> {
@@ -41,6 +41,16 @@ pub(crate) trait DatabaseParser<'a>: ExprParser<'a> {
         line: usize,
         column: usize,
     ) -> Result<Statement, ParseError>;
+
+    /// Parse `query/execute <db> with <sql> [and parameters <list>]` as an
+    /// expression (used in return position) with the cursor positioned on
+    /// `query`/`execute`.
+    fn parse_database_query_expression(
+        &mut self,
+        kind: DatabaseQueryKind,
+        line: usize,
+        column: usize,
+    ) -> Result<Expression, ParseError>;
 }
 
 impl<'a> DatabaseParser<'a> for Parser<'a> {
@@ -158,6 +168,34 @@ impl<'a> DatabaseParser<'a> for Parser<'a> {
         line: usize,
         column: usize,
     ) -> Result<Statement, ParseError> {
+        let Expression::DatabaseQuery {
+            db,
+            sql,
+            parameters,
+            kind,
+            ..
+        } = self.parse_database_query_expression(kind, line, column)?
+        else {
+            unreachable!("parse_database_query_expression always returns DatabaseQuery");
+        };
+
+        Ok(Statement::DatabaseQueryStatement {
+            db: *db,
+            sql: *sql,
+            parameters: parameters.map(|p| *p),
+            variable_name: name,
+            kind,
+            line,
+            column,
+        })
+    }
+
+    fn parse_database_query_expression(
+        &mut self,
+        kind: DatabaseQueryKind,
+        line: usize,
+        column: usize,
+    ) -> Result<Expression, ParseError> {
         let db = match self.cursor.peek() {
             Some(token) => match &token.token {
                 // Merged token form: Identifier("query <handle>")
@@ -165,7 +203,7 @@ impl<'a> DatabaseParser<'a> for Parser<'a> {
                     let handle = id["query ".len()..].to_string();
                     let (handle_line, handle_column) = (token.line, token.column);
                     self.bump_sync(); // Consume "query <handle>"
-                    super::super::Expression::Variable(handle, handle_line, handle_column)
+                    Expression::Variable(handle, handle_line, handle_column)
                 }
                 Token::KeywordExecute => {
                     self.bump_sync(); // Consume "execute"
@@ -195,16 +233,15 @@ impl<'a> DatabaseParser<'a> for Parser<'a> {
         {
             self.bump_sync(); // Consume "and"
             self.bump_sync(); // Consume "parameters"
-            Some(self.parse_primary_expression()?)
+            Some(Box::new(self.parse_primary_expression()?))
         } else {
             None
         };
 
-        Ok(Statement::DatabaseQueryStatement {
-            db,
-            sql,
+        Ok(Expression::DatabaseQuery {
+            db: Box::new(db),
+            sql: Box::new(sql),
             parameters,
-            variable_name: name,
             kind,
             line,
             column,

--- a/src/parser/stmt/database.rs
+++ b/src/parser/stmt/database.rs
@@ -172,7 +172,6 @@ impl<'a> DatabaseParser<'a> for Parser<'a> {
             db,
             sql,
             parameters,
-            kind,
             ..
         } = self.parse_database_query_expression(kind, line, column)?
         else {

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -235,6 +235,11 @@ impl<'a> IoParser<'a> for Parser<'a> {
                         column,
                     })
                 }
+                Expression::DatabaseQuery { line, column, .. } => Ok(Statement::DisplayStatement {
+                    value: expr,
+                    line,
+                    column,
+                }),
             };
         };
 

--- a/src/transpiler/javascript.rs
+++ b/src/transpiler/javascript.rs
@@ -1794,6 +1794,16 @@ impl JavaScriptTranspiler {
                 let pid = self.transpile_expression(process_id)?;
                 Ok(format!("WFL.process.isRunning({})", pid))
             }
+
+            Expression::DatabaseQuery { line, column, .. } => {
+                // Same policy as the database statements: fail instead of
+                // silently emitting broken JS.
+                Err(TranspileError {
+                    message: "Database expressions are not supported in JavaScript transpilation. They require the WFL interpreter.".to_string(),
+                    line: *line,
+                    column: *column,
+                })
+            }
         }
     }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -3321,6 +3321,63 @@ impl TypeChecker {
             Expression::CurrentTimeMilliseconds { .. } => Type::Number,
             Expression::CurrentTimeFormatted { .. } => Type::Text,
             Expression::ProcessRunning { .. } => Type::Boolean,
+            Expression::DatabaseQuery {
+                db,
+                sql,
+                parameters,
+                kind,
+                line,
+                column,
+            } => {
+                let db_type = self.infer_expression_type(db);
+                if db_type != Type::Custom("Database".to_string())
+                    && db_type != Type::Unknown
+                    && db_type != Type::Error
+                {
+                    self.type_error(
+                        "Expected a Database connection".to_string(),
+                        Some(Type::Custom("Database".to_string())),
+                        Some(db_type),
+                        *line,
+                        *column,
+                    );
+                }
+
+                let sql_type = self.infer_expression_type(sql);
+                if sql_type != Type::Text && sql_type != Type::Unknown && sql_type != Type::Error {
+                    self.type_error(
+                        "SQL statement must be a text string".to_string(),
+                        Some(Type::Text),
+                        Some(sql_type),
+                        *line,
+                        *column,
+                    );
+                }
+
+                if let Some(params) = parameters {
+                    let params_type = self.infer_expression_type(params);
+                    if !matches!(params_type, Type::List(_))
+                        && params_type != Type::Unknown
+                        && params_type != Type::Error
+                    {
+                        self.type_error(
+                            "Query parameters must be a list".to_string(),
+                            Some(Type::List(Box::new(Type::Any))),
+                            Some(params_type),
+                            *line,
+                            *column,
+                        );
+                    }
+                }
+
+                // Same result typing as DatabaseQueryStatement: rows are
+                // text-keyed maps, execute results are one such map.
+                let row_type = Type::Map(Box::new(Type::Text), Box::new(Type::Any));
+                match kind {
+                    crate::parser::ast::DatabaseQueryKind::Query => Type::List(Box::new(row_type)),
+                    crate::parser::ast::DatabaseQueryKind::Execute => row_type,
+                }
+            }
         }
     }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1060,61 +1060,13 @@ impl TypeChecker {
                 parameters,
                 variable_name,
                 kind,
-                line: _line,
-                column: _column,
+                line,
+                column,
             } => {
-                let db_type = self.infer_expression_type(db);
-                if db_type != Type::Custom("Database".to_string())
-                    && db_type != Type::Unknown
-                    && db_type != Type::Error
-                {
-                    self.type_error(
-                        "Expected a Database connection".to_string(),
-                        Some(Type::Custom("Database".to_string())),
-                        Some(db_type),
-                        *_line,
-                        *_column,
-                    );
-                }
+                self.check_database_query_operands(db, sql, parameters.as_ref(), *line, *column);
 
-                let sql_type = self.infer_expression_type(sql);
-                if sql_type != Type::Text && sql_type != Type::Unknown && sql_type != Type::Error {
-                    self.type_error(
-                        "SQL statement must be a text string".to_string(),
-                        Some(Type::Text),
-                        Some(sql_type),
-                        *_line,
-                        *_column,
-                    );
-                }
-
-                if let Some(params) = parameters {
-                    let params_type = self.infer_expression_type(params);
-                    if !matches!(params_type, Type::List(_))
-                        && params_type != Type::Unknown
-                        && params_type != Type::Error
-                    {
-                        self.type_error(
-                            "Query parameters must be a list".to_string(),
-                            Some(Type::List(Box::new(Type::Any))),
-                            Some(params_type),
-                            *_line,
-                            *_column,
-                        );
-                    }
-                }
-
-                // Rows are objects keyed by column name; execute results are
-                // {affected_rows, last_insert_id}. Typing them as text-keyed
-                // maps lets downstream indexing typecheck cleanly.
-                let row_type = Type::Map(Box::new(Type::Text), Box::new(Type::Any));
                 if let Some(symbol) = self.analyzer.get_symbol_mut(variable_name) {
-                    symbol.symbol_type = Some(match kind {
-                        crate::parser::ast::DatabaseQueryKind::Query => {
-                            Type::List(Box::new(row_type))
-                        }
-                        crate::parser::ast::DatabaseQueryKind::Execute => row_type,
-                    });
+                    symbol.symbol_type = Some(Self::database_result_type(*kind));
                 }
             }
             Statement::CloseDatabaseStatement {
@@ -3329,55 +3281,74 @@ impl TypeChecker {
                 line,
                 column,
             } => {
-                let db_type = self.infer_expression_type(db);
-                if db_type != Type::Custom("Database".to_string())
-                    && db_type != Type::Unknown
-                    && db_type != Type::Error
-                {
-                    self.type_error(
-                        "Expected a Database connection".to_string(),
-                        Some(Type::Custom("Database".to_string())),
-                        Some(db_type),
-                        *line,
-                        *column,
-                    );
-                }
-
-                let sql_type = self.infer_expression_type(sql);
-                if sql_type != Type::Text && sql_type != Type::Unknown && sql_type != Type::Error {
-                    self.type_error(
-                        "SQL statement must be a text string".to_string(),
-                        Some(Type::Text),
-                        Some(sql_type),
-                        *line,
-                        *column,
-                    );
-                }
-
-                if let Some(params) = parameters {
-                    let params_type = self.infer_expression_type(params);
-                    if !matches!(params_type, Type::List(_))
-                        && params_type != Type::Unknown
-                        && params_type != Type::Error
-                    {
-                        self.type_error(
-                            "Query parameters must be a list".to_string(),
-                            Some(Type::List(Box::new(Type::Any))),
-                            Some(params_type),
-                            *line,
-                            *column,
-                        );
-                    }
-                }
-
-                // Same result typing as DatabaseQueryStatement: rows are
-                // text-keyed maps, execute results are one such map.
-                let row_type = Type::Map(Box::new(Type::Text), Box::new(Type::Any));
-                match kind {
-                    crate::parser::ast::DatabaseQueryKind::Query => Type::List(Box::new(row_type)),
-                    crate::parser::ast::DatabaseQueryKind::Execute => row_type,
-                }
+                self.check_database_query_operands(db, sql, parameters.as_deref(), *line, *column);
+                Self::database_result_type(*kind)
             }
+        }
+    }
+
+    /// Validate the operand types of a database query/execute form. Shared by
+    /// `DatabaseQueryStatement` and the `Expression::DatabaseQuery` arm so the
+    /// two paths cannot drift apart.
+    fn check_database_query_operands(
+        &mut self,
+        db: &Expression,
+        sql: &Expression,
+        parameters: Option<&Expression>,
+        line: usize,
+        column: usize,
+    ) {
+        let db_type = self.infer_expression_type(db);
+        if db_type != Type::Custom("Database".to_string())
+            && db_type != Type::Unknown
+            && db_type != Type::Error
+        {
+            self.type_error(
+                "Expected a Database connection".to_string(),
+                Some(Type::Custom("Database".to_string())),
+                Some(db_type),
+                line,
+                column,
+            );
+        }
+
+        let sql_type = self.infer_expression_type(sql);
+        if sql_type != Type::Text && sql_type != Type::Unknown && sql_type != Type::Error {
+            self.type_error(
+                "SQL statement must be a text string".to_string(),
+                Some(Type::Text),
+                Some(sql_type),
+                line,
+                column,
+            );
+        }
+
+        if let Some(params) = parameters {
+            let params_type = self.infer_expression_type(params);
+            if !matches!(params_type, Type::List(_))
+                && params_type != Type::Unknown
+                && params_type != Type::Error
+            {
+                self.type_error(
+                    "Query parameters must be a list".to_string(),
+                    Some(Type::List(Box::new(Type::Any))),
+                    Some(params_type),
+                    line,
+                    column,
+                );
+            }
+        }
+    }
+
+    /// Result type of a database query/execute. Rows are objects keyed by
+    /// column name; execute results are {affected_rows, last_insert_id}.
+    /// Typing them as text-keyed maps lets downstream indexing typecheck
+    /// cleanly.
+    fn database_result_type(kind: crate::parser::ast::DatabaseQueryKind) -> Type {
+        let row_type = Type::Map(Box::new(Type::Text), Box::new(Type::Any));
+        match kind {
+            crate::parser::ast::DatabaseQueryKind::Query => Type::List(Box::new(row_type)),
+            crate::parser::ast::DatabaseQueryKind::Execute => row_type,
         }
     }
 

--- a/tests/database_parser_test.rs
+++ b/tests/database_parser_test.rs
@@ -3,7 +3,7 @@
 
 use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
-use wfl::parser::ast::{DatabaseQueryKind, Statement};
+use wfl::parser::ast::{DatabaseQueryKind, Expression, Statement};
 
 fn parse(code: &str) -> Vec<Statement> {
     let tokens = lex_wfl_with_positions(code);
@@ -146,6 +146,121 @@ fn test_open_database_inside_wait_for() {
         }
         other => panic!("Expected WaitForStatement, got {other:?}"),
     }
+}
+
+// === Return-position database queries (issue #559) ===
+
+/// Extract the return value expression from a one-statement action body.
+fn return_value_of_action(code: &str) -> Expression {
+    let stmt = parse_single(code);
+    let Statement::ActionDefinition { body, .. } = stmt else {
+        panic!("Expected ActionDefinition, got {stmt:?}");
+    };
+    assert_eq!(body.len(), 1, "Expected one statement in action body");
+    let Statement::ReturnStatement {
+        value: Some(value), ..
+    } = &body[0]
+    else {
+        panic!("Expected ReturnStatement with a value, got {:?}", body[0]);
+    };
+    value.clone()
+}
+
+#[test]
+fn test_return_query_with_parameters() {
+    let value = return_value_of_action(
+        r#"define action called get_n with parameters conn and id:
+    return query conn with "SELECT n FROM t WHERE id = ?" and parameters [id]
+end action"#,
+    );
+    match value {
+        Expression::DatabaseQuery {
+            parameters, kind, ..
+        } => {
+            assert!(parameters.is_some());
+            assert_eq!(kind, DatabaseQueryKind::Query);
+        }
+        other => panic!("Expected DatabaseQuery expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_return_query_without_parameters() {
+    let value = return_value_of_action(
+        r#"define action called get_all with parameters conn:
+    return query conn with "SELECT n FROM t"
+end action"#,
+    );
+    match value {
+        Expression::DatabaseQuery {
+            parameters, kind, ..
+        } => {
+            assert!(parameters.is_none());
+            assert_eq!(kind, DatabaseQueryKind::Query);
+        }
+        other => panic!("Expected DatabaseQuery expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_return_execute_with_parameters() {
+    let value = return_value_of_action(
+        r#"define action called add_row with parameters conn and id:
+    return execute conn with "INSERT INTO t (id) VALUES (?)" and parameters [id]
+end action"#,
+    );
+    match value {
+        Expression::DatabaseQuery {
+            parameters, kind, ..
+        } => {
+            assert!(parameters.is_some());
+            assert_eq!(kind, DatabaseQueryKind::Execute);
+        }
+        other => panic!("Expected DatabaseQuery expression, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_give_back_query_with_parameters() {
+    let value = return_value_of_action(
+        r#"define action called get_n with parameters conn and id:
+    give back query conn with "SELECT n FROM t WHERE id = ?" and parameters [id]
+end action"#,
+    );
+    assert!(
+        matches!(value, Expression::DatabaseQuery { .. }),
+        "Expected DatabaseQuery expression, got {value:?}"
+    );
+}
+
+#[test]
+fn test_return_variable_named_query_still_works() {
+    // A plain variable named `query` (no handle) after return must keep
+    // parsing as an ordinary expression.
+    let value = return_value_of_action(
+        r#"define action called passthrough:
+    return query
+end action"#,
+    );
+    assert!(
+        matches!(&value, Expression::Variable(name, ..) if name == "query"),
+        "Expected Variable(\"query\"), got {value:?}"
+    );
+}
+
+#[test]
+fn test_return_query_concatenation_still_works() {
+    // `return query with "..."` has no db handle, so it must stay a
+    // concatenation of the variable `query`, not a database query.
+    let value = return_value_of_action(
+        r#"define action called label with parameters query:
+    return query with " suffix"
+end action"#,
+    );
+    assert!(
+        !matches!(value, Expression::DatabaseQuery { .. }),
+        "Expected non-database expression, got {value:?}"
+    );
 }
 
 // === Backward compatibility characterization ===

--- a/tests/database_parser_test.rs
+++ b/tests/database_parser_test.rs
@@ -221,6 +221,24 @@ end action"#,
 }
 
 #[test]
+fn test_return_execute_without_parameters() {
+    let value = return_value_of_action(
+        r#"define action called clear_rows with parameters conn:
+    return execute conn with "DELETE FROM t"
+end action"#,
+    );
+    match value {
+        Expression::DatabaseQuery {
+            parameters, kind, ..
+        } => {
+            assert!(parameters.is_none());
+            assert_eq!(kind, DatabaseQueryKind::Execute);
+        }
+        other => panic!("Expected DatabaseQuery expression, got {other:?}"),
+    }
+}
+
+#[test]
 fn test_give_back_query_with_parameters() {
     let value = return_value_of_action(
         r#"define action called get_n with parameters conn and id:

--- a/tests/database_test.rs
+++ b/tests/database_test.rs
@@ -221,6 +221,72 @@ close database db
     }
 
     #[tokio::test]
+    async fn test_return_query_with_parameters_from_action() {
+        // Issue #559: `return query ... and parameters [...]` failed to parse.
+        let code = r#"
+open database at "sqlite::memory:" as db
+store ig as execute db with "CREATE TABLE t (id INT, n INT)"
+store ig2 as execute db with "INSERT INTO t (id, n) VALUES (1, 5)"
+store ig3 as execute db with "INSERT INTO t (id, n) VALUES (2, 9)"
+
+define action called get_n with parameters conn and id:
+    return query conn with "SELECT n FROM t WHERE id = ?" and parameters [id]
+end action
+
+store rows as call get_n with db and 1
+close database db
+"#;
+        let interpreter = run_wfl(code).await.expect("program should run");
+        let rows = expect_list(&get_global(&interpreter, "rows"));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(expect_number(&expect_object_key(&rows[0], "n")), 5.0);
+    }
+
+    #[tokio::test]
+    async fn test_return_query_without_parameters_from_action() {
+        let code = r#"
+open database at "sqlite::memory:" as db
+store ig as execute db with "CREATE TABLE t (n INT)"
+store ig2 as execute db with "INSERT INTO t (n) VALUES (3)"
+
+define action called get_all with parameters conn:
+    return query conn with "SELECT n FROM t"
+end action
+
+store rows as call get_all with db
+close database db
+"#;
+        let interpreter = run_wfl(code).await.expect("program should run");
+        let rows = expect_list(&get_global(&interpreter, "rows"));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(expect_number(&expect_object_key(&rows[0], "n")), 3.0);
+    }
+
+    #[tokio::test]
+    async fn test_return_execute_with_parameters_from_action() {
+        let code = r#"
+open database at "sqlite::memory:" as db
+store ig as execute db with "CREATE TABLE t (id INT)"
+
+define action called add_row with parameters conn and id:
+    return execute conn with "INSERT INTO t (id) VALUES (?)" and parameters [id]
+end action
+
+store result as call add_row with db and 42
+store rows as query db with "SELECT id FROM t"
+close database db
+"#;
+        let interpreter = run_wfl(code).await.expect("program should run");
+        let result = get_global(&interpreter, "result");
+        assert_eq!(
+            expect_number(&expect_object_key(&result, "affected_rows")),
+            1.0
+        );
+        let rows = expect_list(&get_global(&interpreter, "rows"));
+        assert_eq!(expect_number(&expect_object_key(&rows[0], "id")), 42.0);
+    }
+
+    #[tokio::test]
     async fn test_connect_to_database_alias() {
         let code = r#"
 connect to database at "sqlite::memory:" as db

--- a/tests/database_test.rs
+++ b/tests/database_test.rs
@@ -287,6 +287,29 @@ close database db
     }
 
     #[tokio::test]
+    async fn test_return_execute_without_parameters_from_action() {
+        let code = r#"
+open database at "sqlite::memory:" as db
+store ig as execute db with "CREATE TABLE t (id INT)"
+store ig2 as execute db with "INSERT INTO t (id) VALUES (1)"
+store ig3 as execute db with "INSERT INTO t (id) VALUES (2)"
+
+define action called clear_rows with parameters conn:
+    return execute conn with "DELETE FROM t"
+end action
+
+store result as call clear_rows with db
+close database db
+"#;
+        let interpreter = run_wfl(code).await.expect("program should run");
+        let result = get_global(&interpreter, "result");
+        assert_eq!(
+            expect_number(&expect_object_key(&result, "affected_rows")),
+            2.0
+        );
+    }
+
+    #[tokio::test]
     async fn test_connect_to_database_alias() {
         let code = r#"
 connect to database at "sqlite::memory:" as db

--- a/tests/wflhash_security_test.rs
+++ b/tests/wflhash_security_test.rs
@@ -238,44 +238,71 @@ mod wflhash_security_tests {
             let _ = native_wflhash256(vec![Value::Text(Arc::from(input))]);
         }
 
-        let iterations = 50; // Reduced for faster testing
-        let mut timings = Vec::new();
+        // Timing tests are inherently unreliable in CI environments with
+        // shared resources: a single measurement round can spike well past any
+        // reasonable threshold when the runner gets descheduled. Instead of
+        // asserting on one round, run many rounds, log any round that exceeds
+        // the threshold, and fail only if the MEAN variation across all rounds
+        // does — a scheduling hiccup skews one round, a real timing leak skews
+        // the mean.
+        let rounds = 100;
+        let iterations = 50;
+        let threshold = 1.5; // 150% coefficient of variation
 
-        // Measure timing for multiple identical operations
-        for _ in 0..iterations {
-            let start = Instant::now();
-            let _ = native_wflhash256(vec![Value::Text(Arc::from(input))]);
-            let duration = start.elapsed();
-            timings.push(duration.as_nanos());
+        let mut round_cvs = Vec::with_capacity(rounds);
+        let mut round_means = Vec::with_capacity(rounds);
+
+        for round in 0..rounds {
+            let mut timings = Vec::with_capacity(iterations);
+
+            // Measure timing for multiple identical operations
+            for _ in 0..iterations {
+                let start = Instant::now();
+                let _ = native_wflhash256(vec![Value::Text(Arc::from(input))]);
+                let duration = start.elapsed();
+                timings.push(duration.as_nanos());
+            }
+
+            // Calculate timing statistics for this round
+            let mean = timings.iter().sum::<u128>() / timings.len() as u128;
+            let variance = timings
+                .iter()
+                .map(|&t| {
+                    let diff = t.abs_diff(mean);
+                    diff * diff
+                })
+                .sum::<u128>()
+                / timings.len() as u128;
+
+            let std_dev = (variance as f64).sqrt();
+            let coefficient_of_variation = std_dev / mean as f64;
+
+            if coefficient_of_variation >= threshold {
+                eprintln!(
+                    "Round {round}: timing variation {:.2}% exceeds {:.0}% (logged, not failing)",
+                    coefficient_of_variation * 100.0,
+                    threshold * 100.0
+                );
+            }
+
+            round_cvs.push(coefficient_of_variation);
+            round_means.push(mean);
         }
 
-        // Calculate timing statistics
-        let mean = timings.iter().sum::<u128>() / timings.len() as u128;
-        let variance = timings
-            .iter()
-            .map(|&t| {
-                let diff = t.abs_diff(mean);
-                diff * diff
-            })
-            .sum::<u128>()
-            / timings.len() as u128;
-
-        let std_dev = (variance as f64).sqrt();
-        let coefficient_of_variation = std_dev / mean as f64;
-
-        // With timing-safe measures, variation should be reasonable
-        // (Not perfect constant-time, but better than before)
-        // Note: Timing tests are inherently unreliable in CI environments with shared resources,
-        // so we use a generous threshold of 1.5 (150%) to reduce flakiness while still catching
-        // major timing variations that could indicate timing attacks
+        let mean_cv = round_cvs.iter().sum::<f64>() / round_cvs.len() as f64;
         assert!(
-            coefficient_of_variation < 1.5,
-            "Timing variation should be reasonable: got {:.2}%",
-            coefficient_of_variation * 100.0
+            mean_cv < threshold,
+            "Mean timing variation across {rounds} rounds should be under {:.0}%: got {:.2}%",
+            threshold * 100.0,
+            mean_cv * 100.0
         );
 
         // Test that function completes in reasonable time
-        assert!(mean < 10_000_000, "Hash should complete in reasonable time"); // 10ms
+        let mean_time = round_means.iter().sum::<u128>() / round_means.len() as u128;
+        assert!(
+            mean_time < 10_000_000,
+            "Hash should complete in reasonable time"
+        ); // 10ms
     }
 
     /// Test 7: FIXED - Strong G-Function Diffusion


### PR DESCRIPTION
## Summary
Adds support for using `query` and `execute` database operations directly in return expressions (e.g., `return query conn with "SELECT ..." and parameters [...]`), enabling concise data-access helper actions. Previously, database operations could only be used in statement form with `store ... as`.

## Key Changes

- **Parser Enhancement** (`src/parser/stmt/database.rs`):
  - Extracted database query/execute parsing logic into a new `parse_database_query_expression()` method
  - Updated `parse_database_query_statement()` to reuse the expression parser
  - Enables parsing `query`/`execute` in return position with full parameter support

- **AST Extension** (`src/parser/ast.rs`):
  - Added `Expression::DatabaseQuery` variant to represent database operations as expressions
  - Stores database handle, SQL statement, optional parameters, and query kind

- **Interpreter Support** (`src/interpreter/mod.rs`):
  - Extracted database query evaluation into shared `evaluate_database_query()` method
  - Updated `DatabaseQueryStatement` handler to use the shared method
  - Added `Expression::DatabaseQuery` case in `evaluate_expression()` to support return expressions
  - Updated `expr_type()` helper for debugging

- **Type Checker** (`src/typechecker/mod.rs`):
  - Added type checking for `Expression::DatabaseQuery`
  - Validates database handle is `Database` type
  - Validates SQL is `Text` type
  - Validates parameters (if present) is a `List`
  - Returns a list of text-keyed maps for queries, a single map for executes
  - Shared `check_database_query_operands()` / `database_result_type()` helpers keep the statement and expression arms in sync

- **Analyzer** (`src/analyzer/mod.rs`):
  - Added semantic analysis for `Expression::DatabaseQuery`
  - Recursively analyzes all sub-expressions

- **Action Parser** (`src/parser/stmt/actions.rs`):
  - Updated return statement parsing to recognize database query/execute forms
  - Allows `return query/execute ...` as valid return expressions
  - Diagnostics point at the `query`/`execute` expression, not the `return` keyword

- **JavaScript Transpiler** (`src/transpiler/javascript.rs`):
  - Added error handling for `Expression::DatabaseQuery` (not supported in JS)

- **I/O Parser** (`src/parser/stmt/io.rs`):
  - Added support for displaying database query results

## Tests & Documentation

- **Parser Tests** (`tests/database_parser_test.rs`):
  - `test_return_query_with_parameters()` - Validates parsing of parameterized queries
  - `test_return_query_without_parameters()` - Validates parsing of simple queries
  - `test_return_execute_with_parameters()` - Validates parsing of parameterized executes
  - `test_return_execute_without_parameters()` - Validates parsing of simple executes
  - `test_give_back_query_with_parameters()` - Validates `give back` variant
  - `test_return_variable_named_query_still_works()` - Ensures backward compatibility
  - `test_return_query_concatenation_still_works()` - Ensures string concatenation still works

- **Interpreter Tests** (`tests/database_test.rs`):
  - `test_return_query_with_parameters_from_action()` - End-to-end test with parameterized SELECT
  - `test_return_query_without_parameters_from_action()` - End-to-end test with simple SELECT
  - `test_return_execute_with_parameters_from_action()` - End-to-end test with parameterized INSERT
  - `test_return_execute_without_parameters_from_action()` - End-to-end test with plain DELETE

- **E2E Test** (`TestPrograms/database_sqlite_test.wfl`):
  - Tests 9-10: Validates returning parameterized queries and executes from actions

- **Documentation** (`Docs/04-advanced-features/databases.md`):
  - Added "Returning Results from Actions" section with example

## Out-of-Scope Change: WFLHASH Timing-Test Deflake (Maintainer-Requested)

`tests/wflhash_security_test.rs::test_constant_time_measures` failed this PR's CI run with a timing variation of 164.57% on a shared runner — unrelated to the database change. At the maintainer's request, the test methodology was changed **in this PR** to be statistical: it now runs 100 measurement rounds of 50 iterations each, logs any single round whose coefficient of variation exceeds 150%, and fails only if the **mean** variation across all rounds exceeds 150%. The 150% threshold and the 10ms mean-completion-time assertion are unchanged. Measured runtime for the full test file remains ~0.3s.

## Implementation Details

- The shared `evaluate_database_query()` method handles all database operation logic: evaluating expressions, type validation, parameter conversion, pool retrieval, and query/execute execution
- Database query expressions have the same type signatures as their statement counterparts
- Backward compatibility is maintained: `return query` (without a handle) still parses as a variable reference

https://claude.ai/code/session_01AVZX79bHtePpTnX6mH4jeZ

## Summary by CodeRabbit

* **New Features**
  * You can now return database queries and updates directly from actions, making small data-access helpers more compact.
  * Added support for using `return query` and `return execute` with optional parameters in action bodies.

* **Bug Fixes**
  * Improved handling of database expressions in parsing, type checking, and execution.
  * Better error reporting when database-style expressions are used in unsupported output contexts.

* **Tests**
  * Expanded database coverage for returning query results, executing inserts, and parameter passing.
