### PR TITLE
Add HTTP request client (method/headers/body) and standard crypto (SHA-256/HMAC-SHA256)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3321,6 +3321,7 @@ dependencies = [
  "dhat",
  "glob",
  "hkdf",
+ "hmac",
  "libc",
  "log",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ zeroize = { version = "1.7", features = ["derive"] }
 subtle = "2.5"
 sha2 = "0.10"
 hkdf = "0.12"
+hmac = "0.12"
 # Force newer version to fix future incompatibility warning
 num-bigint-dig = "0.8.6"
 

--- a/Dev diary/2026-07-03-http-client-and-standard-crypto-issue-558.md
+++ b/Dev diary/2026-07-03-http-client-and-standard-crypto-issue-558.md
@@ -1,0 +1,106 @@
+# Outbound HTTP Client (Method/Headers/Body) and Standard Crypto (Issue #558)
+
+**Date:** 2026-07-03
+
+## What Changed
+
+Issue #558 reported that a pure-WFL service cannot integrate with real
+third-party APIs (the motivating example is Stripe): the outbound HTTP
+client was GET-only with no way to set the method, headers, or a request
+body — and there was no standard SHA-256 or HMAC-SHA256 for verifying
+webhook signatures (WFLHASH cannot interoperate with what Stripe/GitHub
+sign).
+
+### 1. Extended `open url` statement
+
+The existing forms keep working unchanged (they still parse to
+`HttpGetStatement`):
+
+```wfl
+open url at "https://example.com" and read content as response
+open url at "https://example.com" as response
+```
+
+New optional clauses, joined by `and`/`with` in any order, parse to the new
+`HttpRequestStatement`:
+
+```wfl
+open url at "https://api.stripe.com/v1/checkout/sessions"
+    with method "POST"
+    and headers request_headers
+    and body "mode=payment&line_items[0][price]=price_123"
+    and read response as resp
+```
+
+- `method` — any HTTP method as text (default `GET`), validated at runtime.
+- `headers` — a map (`Value::Object`) of header name → value.
+- `body` — text request body; `with` concatenation works inside the clause
+  (`body "amount=" with amount`), with lookahead so a `with`/`and` that
+  introduces the next clause terminates the value instead.
+- `read response as` binds a full response object: `status` (Number), `ok`
+  (Boolean, 2xx), `body` (Text), `headers` (map with lowercase names).
+  `read content as` keeps binding just the body text. Non-2xx statuses are
+  data, not runtime errors; network failures still raise catchable errors.
+
+Implementation notes:
+
+- The lexer merges consecutive identifiers into multi-word names, so
+  `and headers auth_headers` arrives as the single token
+  `Identifier("headers auth_headers")`. The clause parser matches both the
+  bare keyword and the merged form and splits off the remainder as the
+  variable reference.
+- Clauses may continue on following lines; end-of-line tokens are skipped
+  only when a `and`/`with` connector follows, so a statement that ends
+  without its `read`/`as` terminator still errors.
+- `IoClient::http_request` drives reqwest with
+  `Method::from_bytes`/headers/body and returns
+  `(status, headers, body_text)`.
+
+### 2. Standard crypto builtins
+
+- `sha256 of <text>` — FIPS 180-4 SHA-256, lowercase hex (64 chars).
+- `hmac_sha256 of <message> and <key>` — RFC 2104 HMAC-SHA256, lowercase
+  hex. This is the webhook-verification primitive for Stripe/GitHub/Slack.
+
+The `hmac` crate was already a transitive dependency via `hkdf`, so this
+adds no new external code. Registered in `stdlib/crypto.rs`, `builtins.rs`
+(names + arity), `typechecker/mod.rs` (return type), and
+`stdlib/typechecker.rs` (parameter types).
+
+### 3. Supporting fixes found along the way
+
+- **`create map` was unusable multiline**: `parse_map_creation` never
+  skipped end-of-line tokens, so any map with entries on their own lines
+  failed to parse. Fixed; also added string-literal keys
+  (`"Content-Type" is "..."`) since HTTP header names aren't valid
+  identifiers, and registered the created variable in the analyzer (it was
+  previously reported as undefined at every use site).
+- **Property access on objects**: `Expression::PropertyAccess` only worked
+  on container instances; it now also reads `Value::Object` keys, so
+  `resp.body`, `resp.ok`, `resp.headers` work. The dot-property parser
+  additionally accepts the `status` keyword as a property name so
+  `resp.status` parses (it lexes as `KeywordStatus`, not an identifier).
+  The type checker allows property access on `Map`/`Unknown`/`Any` types
+  instead of erroring.
+
+## Tests
+
+- `tests/sha256_hmac_test.rs` — 9 tests against standard vectors (empty
+  string, "abc", RFC-style HMAC vectors, Stripe-style signed payload).
+- `tests/http_request_parser_test.rs` — 12 tests: backward compatibility of
+  both GET forms, clause combinations, merged-identifier handling,
+  multiline statements, duplicate-clause and missing-terminator errors.
+- `tests/http_request_runtime_test.rs` — 6 tests against a local one-shot
+  TCP server (offline-safe): method/headers/body arrive on the wire,
+  response object fields and dot access, 404 handled as data, invalid
+  method errors.
+- `TestPrograms/crypto_standard_test.wfl` — end-to-end vectors plus the
+  webhook signature verification pattern.
+
+## Follow-ups / Not Done
+
+- The issue's minor note about `open file at <action result>` type-checker
+  warnings is a separate inference gap (same family as #551/#553) and was
+  not addressed here.
+- No timeout clause yet; requests use reqwest defaults.
+- Binary request/response bodies are out of scope (text only).

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -38,7 +38,7 @@ wait for append content "Alice,28\n" into file
 close file file
 ```
 
-### 3. **HTTP Client (Basic)**
+### 3. **HTTP Client**
 
 Make HTTP requests to external APIs:
 
@@ -50,6 +50,51 @@ catch:
     display "API request failed"
 end try
 ```
+
+#### Methods, headers, and request bodies
+
+Real API integrations need more than GET: the `open url` statement accepts
+optional `method`, `headers`, and `body` clauses, joined by `and`/`with` in
+any order:
+
+```wfl
+create map request_headers:
+    Authorization is "Bearer sk_test_123"
+    "Content-Type" is "application/x-www-form-urlencoded"
+end map
+
+open url at "https://api.stripe.com/v1/checkout/sessions"
+    with method "POST"
+    and headers request_headers
+    and body "mode=payment&line_items[0][price]=price_123"
+    and read response as resp
+```
+
+- `method` — any HTTP method as text: `"GET"` (default), `"POST"`, `"PUT"`, `"PATCH"`, `"DELETE"`, ...
+- `headers` — a map of header names to values (string keys like `"Content-Type"` are allowed in `create map`)
+- `body` — the request body as text; build form-encoded or JSON bodies with concatenation or `stringify_json`
+
+#### Reading the full response
+
+`read content as` binds only the response body text. `read response as`
+binds a response object with the status and headers too:
+
+```wfl
+open url at "https://api.example.com/thing" and read response as resp
+
+display "Status: " with resp.status         // e.g. 200 (a number)
+display "OK: " with resp.ok                 // yes for 2xx statuses
+display "Body: " with resp.body             // response body text
+store content_type as resp.headers["content-type"]
+```
+
+Non-2xx statuses are not errors — check `resp.ok` or `resp.status`
+yourself. Network failures (DNS, connection refused) still raise errors you
+can `try`/`catch`.
+
+**Note:** inside an `open url` statement the words `method`, `headers`, and
+`body` introduce clauses, so use different variable names there (e.g.
+`request_headers`, `payload`).
 
 ### 4. **Web Standards**
 

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -44,8 +44,8 @@ Make HTTP requests to external APIs:
 
 ```wfl
 try:
-    open url at "https://api.example.com/data" and read content as response
-    display "API response: " with response
+    open url at "https://api.example.com/data" and read content as api_response
+    display "API response: " with api_response
 catch:
     display "API request failed"
 end try

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -595,8 +595,8 @@ curl -X POST -d "data" http://127.0.0.1:8080/api/echo
 
 ```wfl
 // In another WFL program
-open url at "http://127.0.0.1:8080/" and read content as response
-display "Response: " with response
+open url at "http://127.0.0.1:8080/" and read content as api_response
+display "Response: " with api_response
 ```
 
 ## Common Patterns

--- a/Docs/05-standard-library/crypto-module.md
+++ b/Docs/05-standard-library/crypto-module.md
@@ -1,6 +1,6 @@
 # Crypto Module
 
-The Crypto module provides cryptographic hashing functions using WFLHASH, a custom hash algorithm. Use for data integrity, checksums, and non-critical security applications.
+The Crypto module provides cryptographic hashing functions: standard SHA-256 and HMAC-SHA256 for interoperating with external services (webhook verification, API signing), plus WFLHASH, a custom hash algorithm for data integrity, checksums, and non-critical security applications.
 
 ## ⚠️ Important Security Disclaimer
 
@@ -18,7 +18,7 @@ The Crypto module provides cryptographic hashing functions using WFLHASH, a cust
 - Regulatory compliance requiring validated cryptography
 - Password hashing in production systems
 
-**For production security applications, use SHA-256, SHA-3, or BLAKE3.**
+**For production security applications, use standard algorithms.** WFL provides standard `sha256` and `hmac_sha256` builtins (below) for exactly this: they are required when interoperating with external services (e.g. verifying Stripe or GitHub webhook signatures), where a custom algorithm cannot be used.
 
 ## Functions
 
@@ -195,6 +195,78 @@ end check
 - HKDF-based key derivation
 - Constant-time MAC verification
 - Secure memory management (zeroization)
+
+---
+
+### sha256
+
+**Purpose:** Generate a standard SHA-256 hash (FIPS 180-4). Use whenever you need interoperability with other systems that expect SHA-256.
+
+**Signature:**
+```wfl
+sha256 of <text>
+```
+
+**Parameters:**
+- `text` (Text): The text to hash
+
+**Returns:** Text - 64-character lowercase hexadecimal hash string
+
+**Example:**
+```wfl
+store hash as sha256 of "hello world"
+display "SHA-256: " with hash
+// Output: SHA-256: b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+```
+
+**Use Cases:**
+- Checksums that other tools must be able to verify
+- Content addressing and deduplication across systems
+- Interoperating with external APIs that expect SHA-256 digests
+
+---
+
+### hmac_sha256
+
+**Purpose:** Generate a standard HMAC-SHA256 message authentication code (RFC 2104). This is what most third-party services (Stripe, GitHub, Slack, AWS) use to sign webhooks and API requests.
+
+**Signature:**
+```wfl
+hmac_sha256 of <message> and <key>
+```
+
+**Parameters:**
+- `message` (Text): The message to authenticate
+- `key` (Text): The secret key
+
+**Returns:** Text - 64-character lowercase hexadecimal MAC
+
+**Example (webhook verification, Stripe-style):**
+```wfl
+// Stripe signs webhooks with HMAC-SHA256(secret, "timestamp.payload")
+store webhook_secret as "whsec_test_secret"
+store event_time as "1614556800"
+store payload as "{\"id\": \"evt_123\"}"
+
+store signed_payload as event_time with "." with payload
+store expected_signature as hmac_sha256 of signed_payload and webhook_secret
+
+// In a real webhook handler this comes from the Stripe-Signature header
+store received_signature as hmac_sha256 of signed_payload and webhook_secret
+
+check if expected_signature is received_signature:
+    display "Webhook is authentic"
+otherwise:
+    display "Webhook signature mismatch - reject it!"
+end check
+```
+
+**Use Cases:**
+- Verifying incoming webhook signatures (Stripe, GitHub, Slack, ...)
+- Signing outgoing API requests
+- Any integration that specifies HMAC-SHA256
+
+**Note:** For WFL-internal message authentication where interoperability is not required, `wflmac256` also works; `hmac_sha256` is the standard everyone else speaks.
 
 ---
 

--- a/TestPrograms/crypto_standard_test.wfl
+++ b/TestPrograms/crypto_standard_test.wfl
@@ -1,0 +1,98 @@
+// Standard crypto builtins test (issue #558)
+// Verifies sha256 and hmac_sha256 against well-known test vectors.
+// These are needed to authenticate webhooks from services like Stripe.
+
+display "=== Standard Crypto Test (sha256 / hmac_sha256) ==="
+display ""
+
+store pass_count as 0
+store fail_count as 0
+
+// === SHA-256 test vectors (FIPS 180-4) ===
+display "1. SHA-256 Tests"
+
+store empty_hash as sha256 of ""
+check if empty_hash is "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855":
+    display "PASS: sha256 of empty string"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: sha256 of empty string gave " with empty_hash
+    change fail_count to fail_count plus 1
+end check
+
+store abc_hash as sha256 of "abc"
+check if abc_hash is "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad":
+    display "PASS: sha256 of abc"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: sha256 of abc gave " with abc_hash
+    change fail_count to fail_count plus 1
+end check
+
+store hello_hash as sha256 of "hello world"
+check if hello_hash is "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9":
+    display "PASS: sha256 of hello world"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: sha256 of hello world gave " with hello_hash
+    change fail_count to fail_count plus 1
+end check
+display ""
+
+// === HMAC-SHA256 test vectors (RFC 2104) ===
+display "2. HMAC-SHA256 Tests"
+
+store fox_mac as hmac_sha256 of "The quick brown fox jumps over the lazy dog" and "key"
+check if fox_mac is "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8":
+    display "PASS: hmac_sha256 quick brown fox"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: hmac_sha256 quick brown fox gave " with fox_mac
+    change fail_count to fail_count plus 1
+end check
+
+store empty_mac as hmac_sha256 of "" and ""
+check if empty_mac is "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad":
+    display "PASS: hmac_sha256 empty key and message"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: hmac_sha256 empty gave " with empty_mac
+    change fail_count to fail_count plus 1
+end check
+display ""
+
+// === Webhook-style signature verification (Stripe pattern) ===
+display "3. Webhook Signature Verification Pattern"
+
+store webhook_secret as "whsec_test_secret"
+store event_time as "1614556800"
+store payload as "{\"id\": \"evt_123\"}"
+store signed_payload as event_time with "." with payload
+
+store expected_signature as hmac_sha256 of signed_payload and webhook_secret
+store received_signature as hmac_sha256 of signed_payload and webhook_secret
+
+check if expected_signature is received_signature:
+    display "PASS: webhook signature matches"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: webhook signature mismatch"
+    change fail_count to fail_count plus 1
+end check
+
+store tampered_signature as hmac_sha256 of "tampered payload" and webhook_secret
+check if expected_signature is tampered_signature:
+    display "FAIL: tampered payload should not verify"
+    change fail_count to fail_count plus 1
+otherwise:
+    display "PASS: tampered payload rejected"
+    change pass_count to pass_count plus 1
+end check
+display ""
+
+display "=== Results: " with pass_count with " passed, " with fail_count with " failed ==="
+check if fail_count is 0:
+    display "All standard crypto tests passed!"
+otherwise:
+    display "SOME TESTS FAILED"
+end check

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1026,6 +1026,37 @@ impl Analyzer {
                     self.errors.push(error);
                 }
             }
+            Statement::HttpRequestStatement {
+                url,
+                method,
+                headers,
+                body,
+                variable_name,
+                ..
+            } => {
+                self.analyze_expression(url);
+                if let Some(method) = method {
+                    self.analyze_expression(method);
+                }
+                if let Some(headers) = headers {
+                    self.analyze_expression(headers);
+                }
+                if let Some(body) = body {
+                    self.analyze_expression(body);
+                }
+
+                let symbol = Symbol {
+                    name: variable_name.clone(),
+                    kind: SymbolKind::Variable { mutable: true },
+                    symbol_type: None, // Response type
+                    line: 0,
+                    column: 0,
+                };
+
+                if let Err(error) = self.current_scope.define(symbol) {
+                    self.errors.push(error);
+                }
+            }
 
             Statement::CreateDirectoryStatement { path, .. } => {
                 self.analyze_expression(path);
@@ -1357,6 +1388,30 @@ impl Analyzer {
                     name: name.clone(),
                     kind: SymbolKind::Variable { mutable: true },
                     symbol_type: Some(Type::List(Box::new(Type::Unknown))),
+                    line: *line,
+                    column: *column,
+                };
+                if let Err(e) = self.current_scope.define(symbol) {
+                    self.errors.push(e);
+                }
+            }
+
+            Statement::MapCreation {
+                name,
+                entries,
+                line,
+                column,
+            } => {
+                // Analyze entry values
+                for (_key, value) in entries {
+                    self.analyze_expression(value);
+                }
+
+                // Define the map variable
+                let symbol = Symbol {
+                    name: name.clone(),
+                    kind: SymbolKind::Variable { mutable: true },
+                    symbol_type: Some(Type::Map(Box::new(Type::Text), Box::new(Type::Unknown))),
                     line: *line,
                     column: *column,
                 };

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -35,6 +35,8 @@ const BUILTIN_FUNCTIONS: &[&str] = &[
     "wflhash512",
     "wflhash256_with_salt",
     "wflmac256",
+    "sha256",
+    "hmac_sha256",
     "generate_csrf_token",
     // JSON functions (implemented in stdlib/json.rs)
     "parse_json",
@@ -267,9 +269,9 @@ pub fn get_function_arity(name: &str) -> usize {
         // Zero argument functions
         "generate_csrf_token" => 0,
         // Single argument functions
-        "wflhash256" | "wflhash512" => 1,
+        "wflhash256" | "wflhash512" | "sha256" => 1,
         // Two argument functions
-        "wflhash256_with_salt" | "wflmac256" => 2,
+        "wflhash256_with_salt" | "wflmac256" | "hmac_sha256" => 2,
 
         // === JSON FUNCTIONS ===
         // Single argument functions

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -238,6 +238,9 @@ fn stmt_type(stmt: &Statement) -> String {
         Statement::HttpPostStatement { variable_name, .. } => {
             format!("HttpPostStatement '{variable_name}'")
         }
+        Statement::HttpRequestStatement { variable_name, .. } => {
+            format!("HttpRequestStatement '{variable_name}'")
+        }
         Statement::PushStatement { .. } => "PushStatement to list".to_string(),
         Statement::CreateListStatement { name, .. } => format!("CreateListStatement '{name}'"),
         Statement::MapCreation { name, .. } => format!("MapCreation '{name}'"),
@@ -513,6 +516,49 @@ impl IoClient {
                 Err(e) => Err(format!("Failed to read response body: {e}")),
             },
             Err(e) => Err(format!("Failed to send HTTP POST request: {e}")),
+        }
+    }
+
+    /// Perform an HTTP request with an arbitrary method, optional headers,
+    /// and an optional body. Returns (status, response headers, body text).
+    /// Non-2xx statuses are not errors: callers inspect the status themselves.
+    async fn http_request(
+        &self,
+        method: &str,
+        url: &str,
+        headers: &[(String, String)],
+        body: Option<String>,
+    ) -> Result<(u16, Vec<(String, String)>, String), String> {
+        let parsed_method = reqwest::Method::from_bytes(method.as_bytes())
+            .map_err(|_| format!("Invalid HTTP method: {method}"))?;
+
+        let mut request = self.http_client.request(parsed_method, url);
+        for (name, value) in headers {
+            request = request.header(name.as_str(), value.as_str());
+        }
+        if let Some(body) = body {
+            request = request.body(body);
+        }
+
+        match request.send().await {
+            Ok(response) => {
+                let status = response.status().as_u16();
+                let response_headers = response
+                    .headers()
+                    .iter()
+                    .map(|(name, value)| {
+                        (
+                            name.as_str().to_string(),
+                            value.to_str().unwrap_or("").to_string(),
+                        )
+                    })
+                    .collect();
+                match response.text().await {
+                    Ok(text) => Ok((status, response_headers, text)),
+                    Err(e) => Err(format!("Failed to read response body: {e}")),
+                }
+            }
+            Err(e) => Err(format!("Failed to send HTTP {method} request: {e}")),
         }
     }
 
@@ -2043,6 +2089,7 @@ impl Interpreter {
             Statement::TryStatement { line, column, .. } => (*line, *column),
             Statement::HttpGetStatement { line, column, .. } => (*line, *column),
             Statement::HttpPostStatement { line, column, .. } => (*line, *column),
+            Statement::HttpRequestStatement { line, column, .. } => (*line, *column),
             Statement::PushStatement { line, column, .. } => (*line, *column),
             Statement::CreateListStatement { line, column, .. } => (*line, *column),
             Statement::MapCreation { line, column, .. } => (*line, *column),
@@ -4051,6 +4098,146 @@ impl Interpreter {
                             .borrow_mut()
                             .define(variable_name, Value::Text(body.into()))
                         {
+                            Ok(_) => Ok((Value::Null, ControlFlow::None)),
+                            Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
+                        }
+                    }
+                    Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                }
+            }
+            Statement::HttpRequestStatement {
+                url,
+                method,
+                headers,
+                body,
+                variable_name,
+                full_response,
+                line,
+                column,
+            } => {
+                let url_val = self.evaluate_expression(url, Rc::clone(&env)).await?;
+                let url_str = match &url_val {
+                    Value::Text(s) => s.clone(),
+                    _ => {
+                        return Err(RuntimeError::new(
+                            format!("Expected string for URL, got {url_val:?}"),
+                            *line,
+                            *column,
+                        ));
+                    }
+                };
+
+                let method_str = match method {
+                    Some(method_expr) => {
+                        let method_val = self
+                            .evaluate_expression(method_expr, Rc::clone(&env))
+                            .await?;
+                        match &method_val {
+                            Value::Text(s) => s.trim().to_ascii_uppercase(),
+                            _ => {
+                                return Err(RuntimeError::new(
+                                    format!("Expected text for HTTP method, got {method_val:?}"),
+                                    *line,
+                                    *column,
+                                ));
+                            }
+                        }
+                    }
+                    None => "GET".to_string(),
+                };
+
+                let mut header_list: Vec<(String, String)> = Vec::new();
+                if let Some(headers_expr) = headers {
+                    let headers_val = self
+                        .evaluate_expression(headers_expr, Rc::clone(&env))
+                        .await?;
+                    match &headers_val {
+                        Value::Object(obj) => {
+                            for (name, value) in obj.borrow().iter() {
+                                let value_str = match value {
+                                    Value::Text(s) => s.to_string(),
+                                    Value::Number(_) | Value::Bool(_) => value.to_string(),
+                                    _ => {
+                                        return Err(RuntimeError::new(
+                                            format!(
+                                                "Header '{name}' must be text, got {}",
+                                                value.type_name()
+                                            ),
+                                            *line,
+                                            *column,
+                                        ));
+                                    }
+                                };
+                                header_list.push((name.clone(), value_str));
+                            }
+                            // HashMap iteration order is random; sort for
+                            // deterministic requests and error messages
+                            header_list.sort();
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Expected a map for headers, got {}",
+                                    headers_val.type_name()
+                                ),
+                                *line,
+                                *column,
+                            ));
+                        }
+                    }
+                }
+
+                let body_str = match body {
+                    Some(body_expr) => {
+                        let body_val = self.evaluate_expression(body_expr, Rc::clone(&env)).await?;
+                        match &body_val {
+                            Value::Text(s) => Some(s.to_string()),
+                            Value::Number(_) | Value::Bool(_) => Some(body_val.to_string()),
+                            _ => {
+                                return Err(RuntimeError::new(
+                                    format!(
+                                        "Expected text for request body, got {}",
+                                        body_val.type_name()
+                                    ),
+                                    *line,
+                                    *column,
+                                ));
+                            }
+                        }
+                    }
+                    None => None,
+                };
+
+                match self
+                    .io_client
+                    .http_request(&method_str, &url_str, &header_list, body_str)
+                    .await
+                {
+                    Ok((status, response_headers, response_body)) => {
+                        let value = if *full_response {
+                            let mut headers_map = HashMap::new();
+                            for (name, value) in response_headers {
+                                headers_map.insert(name, Value::Text(value.into()));
+                            }
+
+                            let mut response_map = HashMap::new();
+                            response_map.insert("status".to_string(), Value::Number(status as f64));
+                            response_map.insert(
+                                "ok".to_string(),
+                                Value::Bool((200..300).contains(&status)),
+                            );
+                            response_map
+                                .insert("body".to_string(), Value::Text(response_body.into()));
+                            response_map.insert(
+                                "headers".to_string(),
+                                Value::Object(Rc::new(RefCell::new(headers_map))),
+                            );
+                            Value::Object(Rc::new(RefCell::new(response_map)))
+                        } else {
+                            Value::Text(response_body.into())
+                        };
+
+                        match env.borrow_mut().define(variable_name, value) {
                             Ok(_) => Ok((Value::Null, ControlFlow::None)),
                             Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
                         }
@@ -7281,6 +7468,18 @@ impl Interpreter {
                         } else {
                             Err(RuntimeError::new(
                                 format!("Property '{property}' not found"),
+                                *line,
+                                *column,
+                            ))
+                        }
+                    }
+                    Value::Object(obj_rc) => {
+                        let obj = obj_rc.borrow();
+                        if let Some(prop_value) = obj.get(property) {
+                            Ok(prop_value.clone())
+                        } else {
+                            Err(RuntimeError::new(
+                                format!("Object has no property '{property}'"),
                                 *line,
                                 *column,
                             ))

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -543,13 +543,16 @@ impl IoClient {
         match request.send().await {
             Ok(response) => {
                 let status = response.status().as_u16();
+                // Header names are normalized to lowercase for consistent
+                // access from WFL (e.g. resp.headers["content-type"]), and
+                // non-UTF8 values are converted lossily instead of dropped.
                 let response_headers = response
                     .headers()
                     .iter()
                     .map(|(name, value)| {
                         (
-                            name.as_str().to_string(),
-                            value.to_str().unwrap_or("").to_string(),
+                            name.as_str().to_ascii_lowercase(),
+                            String::from_utf8_lossy(value.as_bytes()).into_owned(),
                         )
                     })
                     .collect();

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -364,6 +364,20 @@ pub enum Statement {
         line: usize,
         column: usize,
     },
+    /// General outbound HTTP request with optional method/headers/body clauses:
+    /// `open url at "<url>" with method "POST" and headers h and body b and read response as resp`
+    HttpRequestStatement {
+        url: Expression,
+        method: Option<Expression>,
+        headers: Option<Expression>,
+        body: Option<Expression>,
+        variable_name: String,
+        /// true for `read response as` (status/ok/body/headers object),
+        /// false for `read content as` (body text only)
+        full_response: bool,
+        line: usize,
+        column: usize,
+    },
     PushStatement {
         list: Expression,
         value: Expression,

--- a/src/parser/expr/primary.rs
+++ b/src/parser/expr/primary.rs
@@ -151,7 +151,15 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                             self.bump_sync(); // Consume '.'
 
                             if let Some(property_token) = self.cursor.peek() {
-                                if let Token::Identifier(property_name) = &property_token.token {
+                                // Keywords that are also common property names
+                                // (e.g. `response.status`) are accepted here
+                                let parsed_property = match &property_token.token {
+                                    Token::Identifier(property_name) => Some(property_name.clone()),
+                                    Token::KeywordStatus => Some("status".to_string()),
+                                    _ => None,
+                                };
+                                if let Some(property_name) = parsed_property {
+                                    let property_name = &property_name;
                                     self.bump_sync(); // Consume property name
 
                                     // Check for method call with parentheses
@@ -985,7 +993,15 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                                 self.bump_sync(); // Consume '.'
 
                                 if let Some(property_token) = self.cursor.peek()
-                                    && let Token::Identifier(property_name) = &property_token.token
+                                    && let Some(property_name) = match &property_token.token {
+                                        Token::Identifier(property_name) => {
+                                            Some(property_name.clone())
+                                        }
+                                        // Keywords that are also common property
+                                        // names (e.g. `response.status`)
+                                        Token::KeywordStatus => Some("status".to_string()),
+                                        _ => None,
+                                    }
                                 {
                                     self.bump_sync(); // Consume property name
 

--- a/src/parser/stmt/collections.rs
+++ b/src/parser/stmt/collections.rs
@@ -236,6 +236,9 @@ impl<'a> CollectionParser<'a> for Parser<'a> {
 
         while let Some(token) = self.cursor.peek() {
             match &token.token {
+                Token::Eol => {
+                    self.bump_sync(); // Skip end-of-line tokens between entries
+                }
                 Token::KeywordEnd => {
                     self.bump_sync(); // Consume "end"
                     self.expect_token(Token::KeywordMap, "Expected 'map' after 'end'")?;
@@ -253,10 +256,24 @@ impl<'a> CollectionParser<'a> for Parser<'a> {
 
                     entries.push((key, value));
                 }
+                // String keys allow names an identifier can't express,
+                // e.g. HTTP header names like "Content-Type"
+                Token::StringLiteral(key) => {
+                    let key = key.clone();
+                    self.bump_sync(); // Consume the key
+
+                    // Expect "is"
+                    self.expect_token(Token::KeywordIs, "Expected 'is' after map key")?;
+
+                    // Parse the value expression
+                    let value = self.parse_expression()?;
+
+                    entries.push((key, value));
+                }
                 _ => {
                     return Err(ParseError::from_token(
                         format!(
-                            "Expected map key (identifier) or 'end map', found {:?}",
+                            "Expected map key (identifier or text) or 'end map', found {:?}",
                             token.token
                         ),
                         token,

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -9,6 +9,22 @@ use std::sync::Arc;
 pub(crate) trait IoParser<'a>: ExprParser<'a> {
     fn parse_display_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_open_file_statement(&mut self) -> Result<Statement, ParseError>;
+    fn parse_open_url_statement(
+        &mut self,
+        open_token: &'a crate::lexer::token::TokenWithPosition,
+    ) -> Result<Statement, ParseError>;
+    fn parse_http_value_expression(&mut self) -> Result<Expression, ParseError>;
+    fn parse_http_clause_value(
+        &mut self,
+        merged: &str,
+        clause: &str,
+        line: usize,
+        column: usize,
+    ) -> Result<Expression, ParseError>;
+    fn continue_http_value_expression(
+        &mut self,
+        expr: Expression,
+    ) -> Result<Expression, ParseError>;
     #[allow(dead_code)]
     fn parse_open_file_read_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_close_file_statement(&mut self) -> Result<Statement, ParseError>;
@@ -43,6 +59,336 @@ impl<'a> IoParser<'a> for Parser<'a> {
         }
 
         Ok(path)
+    }
+
+    /// Parses the remainder of `open url at <url> ...` after `url` was consumed.
+    ///
+    /// Grammar (clauses optional, joined by `and`/`with`, any order):
+    ///   open url at <url>
+    ///       [with method <expr>] [and headers <expr>] [and body <expr>]
+    ///       ( and read content as <name>   -- binds the response body text
+    ///       | and read response as <name>  -- binds status/ok/body/headers object
+    ///       | as <name> )                  -- binds the response body text
+    ///
+    /// Plain GET forms keep producing `HttpGetStatement` for backward
+    /// compatibility; anything using method/headers/body or `read response`
+    /// produces `HttpRequestStatement`.
+    fn parse_open_url_statement(
+        &mut self,
+        open_token: &'a crate::lexer::token::TokenWithPosition,
+    ) -> Result<Statement, ParseError> {
+        if !matches!(self.cursor.peek(), Some(t) if t.token == Token::KeywordAt) {
+            return Err(ParseError::from_token(
+                "Expected 'at' after 'url'".to_string(),
+                open_token,
+            ));
+        }
+        self.bump_sync(); // Consume "at"
+
+        let url_expr = self.parse_primary_expression()?;
+
+        let mut method: Option<Expression> = None;
+        let mut headers: Option<Expression> = None;
+        let mut body: Option<Expression> = None;
+
+        let parse_variable_name =
+            |parser: &mut Self, open_token: &'a crate::lexer::token::TokenWithPosition| {
+                if let Some(token) = parser.cursor.peek() {
+                    if let Token::Identifier(name) = &token.token {
+                        parser.bump_sync(); // Consume the identifier
+                        Ok(name.clone())
+                    } else if token.token == Token::KeywordContent {
+                        // Special case for "content" as a variable name
+                        parser.bump_sync();
+                        Ok("content".to_string())
+                    } else {
+                        Err(ParseError::from_token(
+                            format!(
+                                "Expected identifier for variable name, found {:?}",
+                                token.token
+                            ),
+                            token,
+                        ))
+                    }
+                } else {
+                    Err(ParseError::from_token(
+                        "Unexpected end of input".to_string(),
+                        open_token,
+                    ))
+                }
+            };
+
+        loop {
+            // Long requests may continue clauses on the following lines:
+            //   open url at "https://..."
+            //       with method "POST"
+            //       and read response as resp
+            // Skip line breaks only when a connector follows, so a statement
+            // that simply ends without its terminator still errors here.
+            if matches!(self.cursor.peek(), Some(t) if t.token == Token::Eol) {
+                let mut lookahead = 1;
+                while matches!(self.cursor.peek_kind_n(lookahead), Some(Token::Eol)) {
+                    lookahead += 1;
+                }
+                if matches!(
+                    self.cursor.peek_kind_n(lookahead),
+                    Some(Token::KeywordAnd) | Some(Token::KeywordWith)
+                ) {
+                    for _ in 0..lookahead {
+                        self.bump_sync(); // Consume the line breaks
+                    }
+                }
+            }
+
+            let Some(next_token) = self.cursor.peek() else {
+                return Err(ParseError::from_token(
+                    "Unexpected end of input after URL: expected 'and read content as <name>', 'and read response as <name>', or 'as <name>'"
+                        .to_string(),
+                    open_token,
+                ));
+            };
+
+            match &next_token.token {
+                Token::KeywordAs => {
+                    // "open url at <url> ... as <name>" binds the body text
+                    self.bump_sync(); // Consume "as"
+                    let variable_name = parse_variable_name(self, open_token)?;
+
+                    return Ok(if method.is_some() || headers.is_some() || body.is_some() {
+                        Statement::HttpRequestStatement {
+                            url: url_expr,
+                            method,
+                            headers,
+                            body,
+                            variable_name,
+                            full_response: false,
+                            line: open_token.line,
+                            column: open_token.column,
+                        }
+                    } else {
+                        Statement::HttpGetStatement {
+                            url: url_expr,
+                            variable_name,
+                            line: open_token.line,
+                            column: open_token.column,
+                        }
+                    });
+                }
+                Token::KeywordAnd | Token::KeywordWith => {
+                    self.bump_sync(); // Consume the connector
+                }
+                _ => {
+                    return Err(ParseError::from_token(
+                        format!(
+                            "Expected 'and', 'with', or 'as' after URL, found {:?}",
+                            next_token.token
+                        ),
+                        next_token,
+                    ));
+                }
+            }
+
+            // A connector was consumed; dispatch on the clause keyword
+            let Some(clause_token) = self.cursor.peek() else {
+                return Err(ParseError::from_token(
+                    "Unexpected end of input: expected 'method', 'headers', 'body', or 'read' clause"
+                        .to_string(),
+                    open_token,
+                ));
+            };
+
+            match &clause_token.token {
+                Token::KeywordRead => {
+                    self.bump_sync(); // Consume "read"
+
+                    let full_response = if let Some(token) = self.cursor.peek() {
+                        match &token.token {
+                            Token::KeywordContent => {
+                                self.bump_sync(); // Consume "content"
+                                false
+                            }
+                            Token::KeywordResponse => {
+                                self.bump_sync(); // Consume "response"
+                                true
+                            }
+                            _ => {
+                                return Err(ParseError::from_token(
+                                    format!(
+                                        "Expected 'content' or 'response' after 'read', found {:?}",
+                                        token.token
+                                    ),
+                                    token,
+                                ));
+                            }
+                        }
+                    } else {
+                        return Err(ParseError::from_token(
+                            "Unexpected end of input after 'read'".to_string(),
+                            open_token,
+                        ));
+                    };
+
+                    self.expect_token(
+                        Token::KeywordAs,
+                        "Expected 'as' after 'content' or 'response'",
+                    )?;
+                    let variable_name = parse_variable_name(self, open_token)?;
+
+                    let is_plain_get = method.is_none() && headers.is_none() && body.is_none();
+                    return Ok(if is_plain_get && !full_response {
+                        Statement::HttpGetStatement {
+                            url: url_expr,
+                            variable_name,
+                            line: open_token.line,
+                            column: open_token.column,
+                        }
+                    } else {
+                        Statement::HttpRequestStatement {
+                            url: url_expr,
+                            method,
+                            headers,
+                            body,
+                            variable_name,
+                            full_response,
+                            line: open_token.line,
+                            column: open_token.column,
+                        }
+                    });
+                }
+                // The lexer merges consecutive identifiers into multi-word
+                // names, so `headers auth_headers` arrives as the single
+                // token Identifier("headers auth_headers"). Match both the
+                // bare clause keyword and the merged form.
+                Token::Identifier(name) if name == "method" || name.starts_with("method ") => {
+                    if method.is_some() {
+                        return Err(ParseError::from_token(
+                            "Duplicate 'method' clause in open url statement".to_string(),
+                            clause_token,
+                        ));
+                    }
+                    let merged = name.clone();
+                    let (clause_line, clause_column) = (clause_token.line, clause_token.column);
+                    self.bump_sync(); // Consume "method" (or the merged identifier)
+                    method = Some(self.parse_http_clause_value(
+                        &merged,
+                        "method",
+                        clause_line,
+                        clause_column,
+                    )?);
+                }
+                Token::Identifier(name) if name == "headers" || name.starts_with("headers ") => {
+                    if headers.is_some() {
+                        return Err(ParseError::from_token(
+                            "Duplicate 'headers' clause in open url statement".to_string(),
+                            clause_token,
+                        ));
+                    }
+                    let merged = name.clone();
+                    let (clause_line, clause_column) = (clause_token.line, clause_token.column);
+                    self.bump_sync(); // Consume "headers" (or the merged identifier)
+                    headers = Some(self.parse_http_clause_value(
+                        &merged,
+                        "headers",
+                        clause_line,
+                        clause_column,
+                    )?);
+                }
+                Token::Identifier(name) if name == "body" || name.starts_with("body ") => {
+                    if body.is_some() {
+                        return Err(ParseError::from_token(
+                            "Duplicate 'body' clause in open url statement".to_string(),
+                            clause_token,
+                        ));
+                    }
+                    let merged = name.clone();
+                    let (clause_line, clause_column) = (clause_token.line, clause_token.column);
+                    self.bump_sync(); // Consume "body" (or the merged identifier)
+                    body = Some(self.parse_http_clause_value(
+                        &merged,
+                        "body",
+                        clause_line,
+                        clause_column,
+                    )?);
+                }
+                _ => {
+                    return Err(ParseError::from_token(
+                        format!(
+                            "Expected 'method', 'headers', 'body', or 'read' after 'and'/'with', found {:?}",
+                            clause_token.token
+                        ),
+                        clause_token,
+                    ));
+                }
+            }
+        }
+    }
+
+    /// Parses a clause value in an `open url` statement: a primary expression
+    /// optionally concatenated with further primaries via `with`. A `with`
+    /// that introduces the next request clause (method/headers/body/read)
+    /// terminates the value instead of concatenating.
+    fn parse_http_value_expression(&mut self) -> Result<Expression, ParseError> {
+        let expr = self.parse_primary_expression()?;
+        self.continue_http_value_expression(expr)
+    }
+
+    /// Parses the value of a `method`/`headers`/`body` clause when the clause
+    /// keyword has already been consumed. `merged` is the identifier token
+    /// text: if the lexer merged the clause keyword with a following variable
+    /// name (`headers auth_headers`), the remainder is the variable reference.
+    fn parse_http_clause_value(
+        &mut self,
+        merged: &str,
+        clause: &str,
+        line: usize,
+        column: usize,
+    ) -> Result<Expression, ParseError> {
+        if merged.len() > clause.len() {
+            let rest = merged[clause.len() + 1..].to_string();
+            let base = Expression::Variable(rest, line, column);
+            self.continue_http_value_expression(base)
+        } else {
+            self.parse_http_value_expression()
+        }
+    }
+
+    /// Continues an already-parsed clause value with `with`-concatenations,
+    /// stopping before a `with` that introduces the next request clause.
+    fn continue_http_value_expression(
+        &mut self,
+        mut expr: Expression,
+    ) -> Result<Expression, ParseError> {
+        while let Some(token) = self.cursor.peek() {
+            if token.token != Token::KeywordWith {
+                break;
+            }
+            // Lookahead: stop if this 'with' starts the next request clause
+            match self.cursor.peek_kind_n(1) {
+                Some(Token::KeywordRead) => break,
+                Some(Token::Identifier(name))
+                    if name == "method"
+                        || name.starts_with("method ")
+                        || name == "headers"
+                        || name.starts_with("headers ")
+                        || name == "body"
+                        || name.starts_with("body ") =>
+                {
+                    break;
+                }
+                _ => {}
+            }
+            let (line, column) = (token.line, token.column);
+            self.bump_sync(); // Consume "with"
+            let right = self.parse_primary_expression()?;
+            expr = Expression::Concatenation {
+                left: Box::new(expr),
+                right: Box::new(right),
+                line,
+                column,
+            };
+        }
+
+        Ok(expr)
     }
 
     fn parse_display_statement(&mut self) -> Result<Statement, ParseError> {
@@ -262,106 +608,7 @@ impl<'a> IoParser<'a> for Parser<'a> {
                 Token::KeywordUrl => {
                     // New URL handling
                     self.bump_sync(); // Consume "url"
-
-                    // Continue with URL-specific parsing
-                    if let Some(token) = self.cursor.peek()
-                        && token.token == Token::KeywordAt
-                    {
-                        self.bump_sync(); // Consume "at"
-
-                        let url_expr = self.parse_primary_expression()?;
-
-                        // Check for "and read content as" pattern
-                        if let Some(next_token) = self.cursor.peek() {
-                            if next_token.token == Token::KeywordAnd {
-                                self.bump_sync(); // Consume "and"
-                                self.expect_token(
-                                    Token::KeywordRead,
-                                    "Expected 'read' after 'and'",
-                                )?;
-                                self.expect_token(
-                                    Token::KeywordContent,
-                                    "Expected 'content' after 'read'",
-                                )?;
-                                self.expect_token(
-                                    Token::KeywordAs,
-                                    "Expected 'as' after 'content'",
-                                )?;
-
-                                let variable_name = if let Some(token) = self.cursor.peek() {
-                                    if let Token::Identifier(name) = &token.token {
-                                        self.bump_sync(); // Consume the identifier
-                                        name.clone()
-                                    } else {
-                                        return Err(ParseError::from_token(
-                                            format!(
-                                                "Expected identifier for variable name, found {:?}",
-                                                token.token
-                                            ),
-                                            token,
-                                        ));
-                                    }
-                                } else {
-                                    return Err(ParseError::from_token(
-                                        "Unexpected end of input".to_string(),
-                                        open_token,
-                                    ));
-                                };
-
-                                // Use HttpGetStatement for URL handling
-                                return Ok(Statement::HttpGetStatement {
-                                    url: url_expr,
-                                    variable_name,
-                                    line: open_token.line,
-                                    column: open_token.column,
-                                });
-                            } else if next_token.token == Token::KeywordAs {
-                                // Handle "open url at "..." as variable" syntax
-                                self.bump_sync(); // Consume "as"
-
-                                let variable_name = if let Some(token) = self.cursor.peek() {
-                                    if let Token::Identifier(name) = &token.token {
-                                        self.bump_sync(); // Consume the identifier
-                                        name.clone()
-                                    } else {
-                                        return Err(ParseError::from_token(
-                                            format!(
-                                                "Expected identifier for variable name, found {:?}",
-                                                token.token
-                                            ),
-                                            token,
-                                        ));
-                                    }
-                                } else {
-                                    return Err(ParseError::from_token(
-                                        "Unexpected end of input".to_string(),
-                                        open_token,
-                                    ));
-                                };
-
-                                // Use HttpGetStatement for URL handling with direct "as" syntax
-                                return Ok(Statement::HttpGetStatement {
-                                    url: url_expr,
-                                    variable_name,
-                                    line: open_token.line,
-                                    column: open_token.column,
-                                });
-                            } else {
-                                return Err(ParseError::from_token(
-                                    format!(
-                                        "Expected 'and' or 'as' after URL, found {:?}",
-                                        next_token.token
-                                    ),
-                                    next_token,
-                                ));
-                            }
-                        }
-                    }
-
-                    return Err(ParseError::from_token(
-                        "Expected 'at' after 'url'".to_string(),
-                        open_token,
-                    ));
+                    return self.parse_open_url_statement(open_token);
                 }
                 _ => {
                     return Err(ParseError::from_token(

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -501,7 +501,7 @@ pub fn native_sha256(args: Vec<Value>) -> Result<Value, RuntimeError> {
     let text = expect_text(&args[0])?;
     if text.len() > MAX_INPUT_SIZE {
         return Err(RuntimeError::new(
-            "Input exceeds maximum allowed size".to_string(),
+            format!("sha256: input exceeds maximum allowed size ({MAX_INPUT_SIZE} bytes)"),
             0,
             0,
         ));
@@ -522,7 +522,14 @@ pub fn native_hmac_sha256(args: Vec<Value>) -> Result<Value, RuntimeError> {
     let key = expect_text(&args[1])?;
     if message.len() > MAX_INPUT_SIZE {
         return Err(RuntimeError::new(
-            "Input exceeds maximum allowed size".to_string(),
+            format!("hmac_sha256: message exceeds maximum allowed size ({MAX_INPUT_SIZE} bytes)"),
+            0,
+            0,
+        ));
+    }
+    if key.len() > MAX_INPUT_SIZE {
+        return Err(RuntimeError::new(
+            format!("hmac_sha256: key exceeds maximum allowed size ({MAX_INPUT_SIZE} bytes)"),
             0,
             0,
         ));

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -3,7 +3,8 @@ use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
 use hkdf::Hkdf;
-use sha2::Sha256;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
 use std::sync::Arc;
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
@@ -492,6 +493,49 @@ pub fn wflmac256_verify(
     Ok(comparison_result.into())
 }
 
+/// Standard SHA-256 (FIPS 180-4), hex-encoded
+/// Usage: sha256 of "hello" -> "2cf24dba..."
+pub fn native_sha256(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("sha256", &args, 1)?;
+
+    let text = expect_text(&args[0])?;
+    if text.len() > MAX_INPUT_SIZE {
+        return Err(RuntimeError::new(
+            "Input exceeds maximum allowed size".to_string(),
+            0,
+            0,
+        ));
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    Ok(Value::Text(Arc::from(bytes_to_hex(&hasher.finalize()))))
+}
+
+/// Standard HMAC-SHA256 (RFC 2104), hex-encoded
+/// Usage: hmac_sha256 of message and key -> "f7bc83f4..."
+/// Needed to verify webhook signatures from services like Stripe or GitHub.
+pub fn native_hmac_sha256(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("hmac_sha256", &args, 2)?;
+
+    let message = expect_text(&args[0])?;
+    let key = expect_text(&args[1])?;
+    if message.len() > MAX_INPUT_SIZE {
+        return Err(RuntimeError::new(
+            "Input exceeds maximum allowed size".to_string(),
+            0,
+            0,
+        ));
+    }
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(key.as_bytes())
+        .map_err(|_| RuntimeError::new("Failed to initialize HMAC key".to_string(), 0, 0))?;
+    mac.update(message.as_bytes());
+    Ok(Value::Text(Arc::from(bytes_to_hex(
+        &mac.finalize().into_bytes(),
+    ))))
+}
+
 /// Generate a cryptographically secure random token (for CSRF, sessions, etc.)
 /// Usage: generate_csrf_token() -> "a1b2c3d4e5f6..."
 pub fn native_generate_csrf_token(args: Vec<Value>) -> Result<Value, RuntimeError> {
@@ -516,6 +560,8 @@ pub fn register_crypto(env: &mut Environment) {
     env.define_native("wflhash512", native_wflhash512);
     env.define_native("wflhash256_with_salt", native_wflhash256_with_salt);
     env.define_native("wflmac256", native_wflmac256);
+    env.define_native("sha256", native_sha256);
+    env.define_native("hmac_sha256", native_hmac_sha256);
     env.define_native("generate_csrf_token", native_generate_csrf_token);
 }
 

--- a/src/stdlib/typechecker.rs
+++ b/src/stdlib/typechecker.rs
@@ -47,6 +47,8 @@ pub fn register_stdlib_types(analyzer: &mut Analyzer) {
     register_wflhash512(analyzer);
     register_wflhash256_with_salt(analyzer);
     register_wflmac256(analyzer);
+    register_sha256(analyzer);
+    register_hmac_sha256(analyzer);
     register_count_lines(analyzer);
     register_path_extension(analyzer);
     register_path_stem(analyzer);
@@ -252,6 +254,20 @@ fn register_wflmac256(analyzer: &mut Analyzer) {
     let param_types = vec![Type::Text, Type::Text];
 
     analyzer.register_builtin_function("wflmac256", param_types, return_type);
+}
+
+fn register_sha256(analyzer: &mut Analyzer) {
+    let return_type = Type::Text;
+    let param_types = vec![Type::Text];
+
+    analyzer.register_builtin_function("sha256", param_types, return_type);
+}
+
+fn register_hmac_sha256(analyzer: &mut Analyzer) {
+    let return_type = Type::Text;
+    let param_types = vec![Type::Text, Type::Text];
+
+    analyzer.register_builtin_function("hmac_sha256", param_types, return_type);
 }
 
 fn register_count_lines(analyzer: &mut Analyzer) {

--- a/src/transpiler/javascript.rs
+++ b/src/transpiler/javascript.rs
@@ -820,6 +820,40 @@ impl JavaScriptTranspiler {
                 ))
             }
 
+            Statement::HttpRequestStatement {
+                url,
+                method,
+                headers,
+                body,
+                variable_name,
+                full_response,
+                ..
+            } => {
+                let url_expr = self.transpile_expression(url)?;
+                let method_expr = match method {
+                    Some(m) => self.transpile_expression(m)?,
+                    None => "\"GET\"".to_string(),
+                };
+                let headers_expr = match headers {
+                    Some(h) => self.transpile_expression(h)?,
+                    None => "{}".to_string(),
+                };
+                let body_expr = match body {
+                    Some(b) => self.transpile_expression(b)?,
+                    None => "null".to_string(),
+                };
+                Ok(format!(
+                    "{}let {} = await WFL.http.request({}, {{ method: {}, headers: {}, body: {}, fullResponse: {} }});\n",
+                    self.indent(),
+                    self.sanitize_name(variable_name),
+                    url_expr,
+                    method_expr,
+                    headers_expr,
+                    body_expr,
+                    full_response
+                ))
+            }
+
             Statement::TryStatement {
                 body,
                 when_clauses,
@@ -1974,6 +2008,7 @@ impl JavaScriptTranspiler {
             | Statement::WaitForDurationStatement { .. }
             | Statement::HttpGetStatement { .. }
             | Statement::HttpPostStatement { .. }
+            | Statement::HttpRequestStatement { .. }
             | Statement::WaitForProcessStatement { .. }
             | Statement::WaitForRequestStatement { .. } => true,
 

--- a/src/transpiler/runtime.rs
+++ b/src/transpiler/runtime.rs
@@ -421,6 +421,63 @@ const WFL = {
         req.end();
       });
     },
+    // General request with method/headers/body. Matches the interpreter's
+    // semantics: non-2xx statuses resolve as data (callers inspect
+    // status/ok), only transport failures reject.
+    request: async (url, options = {}, timeout = 10000) => {
+      const { method = 'GET', headers = {}, body = null, fullResponse = false } = options;
+      const https = url.startsWith('https') ? require('https') : require('http');
+      const urlObj = new URL(url);
+      return new Promise((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+          reject(new Error(`Request timeout after ${timeout}ms`));
+        }, timeout);
+
+        const req = https.request({
+          hostname: urlObj.hostname,
+          port: urlObj.port,
+          path: urlObj.pathname + urlObj.search,
+          method,
+          headers,
+        }, (res) => {
+          clearTimeout(timeoutId);
+
+          let data = '';
+          res.on('data', chunk => data += chunk);
+          res.on('end', () => {
+            if (fullResponse) {
+              const responseHeaders = {};
+              for (const [name, value] of Object.entries(res.headers)) {
+                responseHeaders[name.toLowerCase()] = Array.isArray(value) ? value.join(', ') : value;
+              }
+              resolve({
+                status: res.statusCode,
+                ok: res.statusCode >= 200 && res.statusCode < 300,
+                body: data,
+                headers: responseHeaders,
+              });
+            } else {
+              resolve(data);
+            }
+          });
+          res.on('error', reject);
+        });
+
+        req.on('error', (err) => {
+          clearTimeout(timeoutId);
+          reject(err);
+        });
+        req.setTimeout(timeout, () => {
+          req.destroy();
+          reject(new Error(`Request timeout after ${timeout}ms`));
+        });
+
+        if (body !== null && body !== undefined) {
+          req.write(typeof body === 'string' ? body : JSON.stringify(body));
+        }
+        req.end();
+      });
+    },
   },
 
   // Utility functions
@@ -680,6 +737,47 @@ const WFL = {
         }
         
         return response.text();
+      } catch (error) {
+        clearTimeout(timeoutId);
+        if (error.name === 'AbortError') {
+          throw new Error(`Request timeout after ${timeout}ms`);
+        }
+        throw error;
+      }
+    },
+    // General request with method/headers/body. Matches the interpreter's
+    // semantics: non-2xx statuses resolve as data (callers inspect
+    // status/ok), only transport failures reject.
+    request: async (url, options = {}, timeout = 10000) => {
+      const { method = 'GET', headers = {}, body = null, fullResponse = false } = options;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+      try {
+        const response = await fetch(url, {
+          method,
+          headers,
+          body: body === null || body === undefined
+            ? undefined
+            : (typeof body === 'string' ? body : JSON.stringify(body)),
+          signal: controller.signal
+        });
+        clearTimeout(timeoutId);
+
+        const text = await response.text();
+        if (fullResponse) {
+          const responseHeaders = {};
+          response.headers.forEach((value, name) => {
+            responseHeaders[name.toLowerCase()] = value;
+          });
+          return {
+            status: response.status,
+            ok: response.ok,
+            body: text,
+            headers: responseHeaders,
+          };
+        }
+        return text;
       } catch (error) {
         clearTimeout(timeoutId);
         if (error.name === 'AbortError') {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -543,10 +543,41 @@ impl TypeChecker {
                     }
                 }
                 if let Some(headers) = headers {
-                    self.infer_expression_type(headers);
+                    let headers_type = self.infer_expression_type(headers);
+                    if !matches!(
+                        headers_type,
+                        Type::Map(_, _) | Type::Unknown | Type::Any | Type::Error
+                    ) {
+                        self.type_error(
+                            "HTTP headers must be a map of header names to values".to_string(),
+                            Some(Type::Map(Box::new(Type::Text), Box::new(Type::Text))),
+                            Some(headers_type),
+                            *_line,
+                            *_column,
+                        );
+                    }
                 }
                 if let Some(body) = body {
-                    self.infer_expression_type(body);
+                    // Text is expected; numbers and booleans are converted at
+                    // runtime, so only reject clearly wrong types
+                    let body_type = self.infer_expression_type(body);
+                    if !matches!(
+                        body_type,
+                        Type::Text
+                            | Type::Number
+                            | Type::Boolean
+                            | Type::Unknown
+                            | Type::Any
+                            | Type::Error
+                    ) {
+                        self.type_error(
+                            "HTTP request body must be text".to_string(),
+                            Some(Type::Text),
+                            Some(body_type),
+                            *_line,
+                            *_column,
+                        );
+                    }
                 }
 
                 if !variable_name.is_empty()

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -196,6 +196,8 @@ impl TypeChecker {
             | "wflhash512"
             | "wflhash256_with_salt"
             | "wflmac256"
+            | "sha256"
+            | "hmac_sha256"
             | "generate_uuid"
             | "generate_csrf_token" => Type::Text,
 
@@ -502,6 +504,59 @@ impl TypeChecker {
                     && let Some(symbol) = self.analyzer.get_symbol_mut(variable_name)
                 {
                     symbol.symbol_type = Some(Type::Text);
+                }
+            }
+            Statement::HttpRequestStatement {
+                url,
+                method,
+                headers,
+                body,
+                variable_name,
+                full_response,
+                line: _line,
+                column: _column,
+            } => {
+                let url_type = self.infer_expression_type(url);
+                if url_type != Type::Text && url_type != Type::Unknown && url_type != Type::Error {
+                    self.type_error(
+                        "URL must be a text string".to_string(),
+                        Some(Type::Text),
+                        Some(url_type),
+                        *_line,
+                        *_column,
+                    );
+                }
+
+                if let Some(method) = method {
+                    let method_type = self.infer_expression_type(method);
+                    if method_type != Type::Text
+                        && method_type != Type::Unknown
+                        && method_type != Type::Error
+                    {
+                        self.type_error(
+                            "HTTP method must be a text string".to_string(),
+                            Some(Type::Text),
+                            Some(method_type),
+                            *_line,
+                            *_column,
+                        );
+                    }
+                }
+                if let Some(headers) = headers {
+                    self.infer_expression_type(headers);
+                }
+                if let Some(body) = body {
+                    self.infer_expression_type(body);
+                }
+
+                if !variable_name.is_empty()
+                    && let Some(symbol) = self.analyzer.get_symbol_mut(variable_name)
+                {
+                    symbol.symbol_type = Some(if *full_response {
+                        Type::Map(Box::new(Type::Text), Box::new(Type::Unknown))
+                    } else {
+                        Type::Text
+                    });
                 }
             }
             Statement::VariableDeclaration {
@@ -3294,6 +3349,11 @@ impl TypeChecker {
                             Type::Error
                         }
                     }
+                    // Objects/maps support property access at runtime
+                    // (e.g. `response.status` on an HTTP response object);
+                    // the value type is whatever the map stores.
+                    Type::Map(_, value_type) => *value_type,
+                    Type::Unknown | Type::Any | Type::Error => Type::Unknown,
                     _ => {
                         self.type_error(
                             format!(

--- a/tests/http_request_parser_test.rs
+++ b/tests/http_request_parser_test.rs
@@ -1,0 +1,224 @@
+// TDD Tests for the extended outbound HTTP client syntax (issue #558)
+//
+// New syntax (all clauses optional, order flexible, joined by `with`/`and`):
+//   open url at "<url>" with method "POST" and headers h and body b and read response as resp
+//
+// `read response as` binds the full response object (status/ok/body/headers);
+// `read content as` keeps the existing behavior of binding the body text.
+
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::parser::ast::Statement;
+
+fn parse_single_statement(code: &str) -> Statement {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error for {code:?}: {e:?}"));
+    assert_eq!(
+        program.statements.len(),
+        1,
+        "Expected exactly one statement for {code:?}"
+    );
+    program.statements.into_iter().next().unwrap()
+}
+
+fn parse_should_fail(code: &str) {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    assert!(parser.parse().is_err(), "Expected parse error for {code:?}");
+}
+
+#[test]
+fn test_plain_get_still_uses_http_get_statement() {
+    // Backward compatibility: the original form must keep parsing as before
+    let stmt =
+        parse_single_statement(r#"open url at "https://example.com" and read content as content"#);
+    match stmt {
+        Statement::HttpGetStatement { variable_name, .. } => {
+            assert_eq!(variable_name, "content");
+        }
+        other => panic!("Expected HttpGetStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_plain_get_as_variable_still_uses_http_get_statement() {
+    let stmt = parse_single_statement(r#"open url at "https://example.com" as page"#);
+    match stmt {
+        Statement::HttpGetStatement { variable_name, .. } => {
+            assert_eq!(variable_name, "page");
+        }
+        other => panic!("Expected HttpGetStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_post_with_method_body_and_read_response() {
+    let stmt = parse_single_statement(
+        r#"open url at "https://api.stripe.com/v1/checkout/sessions" with method "POST" and body "mode=payment" and read response as resp"#,
+    );
+    match stmt {
+        Statement::HttpRequestStatement {
+            method,
+            headers,
+            body,
+            variable_name,
+            full_response,
+            ..
+        } => {
+            assert!(method.is_some(), "method clause should be captured");
+            assert!(headers.is_none(), "no headers clause was given");
+            assert!(body.is_some(), "body clause should be captured");
+            assert_eq!(variable_name, "resp");
+            assert!(full_response, "read response as -> full response object");
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_request_with_headers_variable() {
+    let stmt = parse_single_statement(
+        r#"open url at "https://api.example.com" and headers auth_headers and read response as resp"#,
+    );
+    match stmt {
+        Statement::HttpRequestStatement {
+            method,
+            headers,
+            body,
+            full_response,
+            ..
+        } => {
+            assert!(method.is_none());
+            assert!(headers.is_some(), "headers clause should be captured");
+            assert!(body.is_none());
+            assert!(full_response);
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_get_with_read_response_uses_request_statement() {
+    // Even a plain GET can ask for the full response object
+    let stmt =
+        parse_single_statement(r#"open url at "https://example.com" and read response as resp"#);
+    match stmt {
+        Statement::HttpRequestStatement {
+            method,
+            headers,
+            body,
+            variable_name,
+            full_response,
+            ..
+        } => {
+            assert!(method.is_none());
+            assert!(headers.is_none());
+            assert!(body.is_none());
+            assert_eq!(variable_name, "resp");
+            assert!(full_response);
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_post_with_read_content_binds_body_text() {
+    let stmt = parse_single_statement(
+        r#"open url at "https://api.example.com" with method "POST" and body "x=1" and read content as reply"#,
+    );
+    match stmt {
+        Statement::HttpRequestStatement {
+            variable_name,
+            full_response,
+            ..
+        } => {
+            assert_eq!(variable_name, "reply");
+            assert!(!full_response, "read content as -> body text only");
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_all_clauses_with_and_connectors() {
+    let stmt = parse_single_statement(
+        r#"open url at "https://api.example.com" and method "PUT" and headers h and body payload and read response as r"#,
+    );
+    match stmt {
+        Statement::HttpRequestStatement {
+            method,
+            headers,
+            body,
+            ..
+        } => {
+            assert!(method.is_some());
+            assert!(headers.is_some());
+            assert!(body.is_some());
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_body_supports_with_concatenation() {
+    // `with` inside the body value builds concatenation, while `and body` /
+    // `and read` still terminate the clause correctly.
+    let stmt = parse_single_statement(
+        r#"open url at "https://api.example.com" with method "POST" and body "amount=" with amount and read response as r"#,
+    );
+    match stmt {
+        Statement::HttpRequestStatement { body, .. } => {
+            assert!(body.is_some());
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_multiline_request_statement() {
+    let code = r#"open url at "https://api.stripe.com/v1/checkout/sessions"
+    with method "POST"
+    and headers request_headers
+    and body "mode=payment"
+    and read response as resp"#;
+    let stmt = parse_single_statement(code);
+    match stmt {
+        Statement::HttpRequestStatement {
+            method,
+            headers,
+            body,
+            variable_name,
+            full_response,
+            ..
+        } => {
+            assert!(method.is_some());
+            assert!(headers.is_some());
+            assert!(body.is_some());
+            assert_eq!(variable_name, "resp");
+            assert!(full_response);
+        }
+        other => panic!("Expected HttpRequestStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_plain_get_missing_terminator_is_an_error() {
+    // A statement that ends after the URL (no `as` / `read` clause) must
+    // fail even when another statement follows on the next line.
+    parse_should_fail("open url at \"https://x.com\"\ndisplay \"next\"");
+}
+
+#[test]
+fn test_duplicate_method_clause_is_an_error() {
+    parse_should_fail(
+        r#"open url at "https://x.com" with method "POST" and method "PUT" and read response as r"#,
+    );
+}
+
+#[test]
+fn test_missing_read_clause_is_an_error() {
+    parse_should_fail(r#"open url at "https://x.com" with method "POST""#);
+}

--- a/tests/http_request_runtime_test.rs
+++ b/tests/http_request_runtime_test.rs
@@ -1,0 +1,278 @@
+// Runtime tests for the extended outbound HTTP client (issue #558).
+// A minimal local TCP server stands in for a real API (e.g. Stripe), so the
+// tests are offline-safe: they verify that method, headers, and body reach
+// the server, and that status/ok/body/headers come back in the response
+// object.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+/// Captured request: (request line + headers, body)
+type CapturedRequest = (String, String);
+
+/// Spawns a one-shot HTTP server that captures the request and answers
+/// 201 Created with a fixed body and an X-Test-Header.
+async fn spawn_echo_server() -> (String, tokio::task::JoinHandle<CapturedRequest>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        let mut tmp = [0u8; 1024];
+
+        // Read until the header block is complete
+        let header_end = loop {
+            let n = socket.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                panic!("Connection closed before headers were complete");
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos;
+            }
+        };
+
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let content_length = head
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                if name.eq_ignore_ascii_case("content-length") {
+                    value.trim().parse::<usize>().ok()
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0);
+
+        // Read the rest of the body if it hasn't arrived yet
+        let body_start = header_end + 4;
+        while buf.len() < body_start + content_length {
+            let n = socket.read(&mut tmp).await.unwrap();
+            if n == 0 {
+                panic!("Connection closed before body was complete");
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        let body =
+            String::from_utf8_lossy(&buf[body_start..body_start + content_length]).to_string();
+
+        let response_body = "session created";
+        let response = format!(
+            "HTTP/1.1 201 Created\r\nContent-Type: text/plain\r\nX-Test-Header: hello\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.shutdown().await.ok();
+
+        (head, body)
+    });
+
+    (format!("http://{addr}"), handle)
+}
+
+async fn run_wfl(code: &str) -> Interpreter {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
+
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&program)
+        .await
+        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
+    interpreter
+}
+
+fn get_var(interpreter: &Interpreter, name: &str) -> Value {
+    interpreter
+        .global_env()
+        .borrow()
+        .get(name)
+        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
+}
+
+fn get_text(interpreter: &Interpreter, name: &str) -> String {
+    match get_var(interpreter, name) {
+        Value::Text(t) => t.to_string(),
+        other => panic!("Expected '{name}' to be text, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_post_with_headers_and_body_full_response() {
+    let (url, captured) = spawn_echo_server().await;
+
+    let code = format!(
+        r#"
+        create map request_headers:
+            Authorization is "Bearer sk_test_123"
+            "Content-Type" is "application/x-www-form-urlencoded"
+        end map
+
+        open url at "{url}" with method "POST" and headers request_headers and body "mode=payment&amount=1000" and read response as resp
+
+        store response_status as resp["status"]
+        store response_ok as resp["ok"]
+        store response_body as resp["body"]
+        store response_headers as resp["headers"]
+        store test_header as response_headers["x-test-header"]
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+    let (head, body) = captured.await.unwrap();
+
+    // The server saw the method, header, and body we sent
+    assert!(
+        head.starts_with("POST / HTTP/1.1"),
+        "Expected POST request line, got: {head}"
+    );
+    let head_lower = head.to_lowercase();
+    assert!(
+        head_lower.contains("authorization: bearer sk_test_123"),
+        "Authorization header missing from request: {head}"
+    );
+    assert!(
+        head_lower.contains("content-type: application/x-www-form-urlencoded"),
+        "Content-Type header missing from request: {head}"
+    );
+    assert_eq!(body, "mode=payment&amount=1000");
+
+    // The WFL program saw the full response
+    match get_var(&interpreter, "response_status") {
+        Value::Number(n) => assert_eq!(n, 201.0),
+        other => panic!("Expected numeric status, got {other:?}"),
+    }
+    match get_var(&interpreter, "response_ok") {
+        Value::Bool(b) => assert!(b, "201 should be ok"),
+        other => panic!("Expected boolean ok, got {other:?}"),
+    }
+    assert_eq!(get_text(&interpreter, "response_body"), "session created");
+    assert_eq!(get_text(&interpreter, "test_header"), "hello");
+}
+
+#[tokio::test]
+async fn test_response_object_supports_dot_access() {
+    let (url, captured) = spawn_echo_server().await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" and read response as resp
+        store dot_status as resp.status
+        store dot_ok as resp.ok
+        store dot_body as resp.body
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+    captured.await.unwrap();
+
+    match get_var(&interpreter, "dot_status") {
+        Value::Number(n) => assert_eq!(n, 201.0),
+        other => panic!("Expected numeric status, got {other:?}"),
+    }
+    match get_var(&interpreter, "dot_ok") {
+        Value::Bool(b) => assert!(b),
+        other => panic!("Expected boolean ok, got {other:?}"),
+    }
+    assert_eq!(get_text(&interpreter, "dot_body"), "session created");
+}
+
+#[tokio::test]
+async fn test_post_read_content_binds_body_text() {
+    let (url, captured) = spawn_echo_server().await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "x=1" and read content as reply
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+    let (head, body) = captured.await.unwrap();
+
+    assert!(head.starts_with("POST / HTTP/1.1"));
+    assert_eq!(body, "x=1");
+    assert_eq!(get_text(&interpreter, "reply"), "session created");
+}
+
+#[tokio::test]
+async fn test_body_concatenation_with_expression() {
+    let (url, captured) = spawn_echo_server().await;
+
+    let code = format!(
+        r#"
+        store amount as "1000"
+        open url at "{url}" with method "PUT" and body "amount=" with amount and read response as resp
+        "#
+    );
+
+    let _ = run_wfl(&code).await;
+    let (head, body) = captured.await.unwrap();
+
+    assert!(
+        head.starts_with("PUT / HTTP/1.1"),
+        "Expected PUT request line, got: {head}"
+    );
+    assert_eq!(body, "amount=1000");
+}
+
+#[tokio::test]
+async fn test_invalid_method_is_runtime_error() {
+    let code = r#"
+        open url at "http://127.0.0.1:1" with method "NOT A METHOD" and read response as resp
+    "#;
+
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().unwrap();
+
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(&program).await;
+    assert!(result.is_err(), "Invalid HTTP method should be an error");
+}
+
+#[tokio::test]
+async fn test_non_2xx_status_is_not_an_error() {
+    // A 404 response should come back as data, not raise a runtime error
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut tmp = [0u8; 2048];
+        let _ = socket.read(&mut tmp).await;
+        let response =
+            "HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\nConnection: close\r\n\r\nnot found";
+        socket.write_all(response.as_bytes()).await.unwrap();
+        socket.shutdown().await.ok();
+    });
+
+    let code = format!(
+        r#"
+        open url at "http://{addr}" and read response as resp
+        store response_status as resp.status
+        store response_ok as resp.ok
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+
+    match get_var(&interpreter, "response_status") {
+        Value::Number(n) => assert_eq!(n, 404.0),
+        other => panic!("Expected numeric status, got {other:?}"),
+    }
+    match get_var(&interpreter, "response_ok") {
+        Value::Bool(b) => assert!(!b, "404 should not be ok"),
+        other => panic!("Expected boolean ok, got {other:?}"),
+    }
+}

--- a/tests/sha256_hmac_test.rs
+++ b/tests/sha256_hmac_test.rs
@@ -1,0 +1,158 @@
+// TDD Tests for standard SHA-256 and HMAC-SHA256 builtins (issue #558)
+// Webhook verification (e.g. Stripe) requires standard HMAC-SHA256, not just WFLHASH.
+
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+/// Test helper to run WFL code and get the result from a variable
+async fn run_wfl_code(code: &str) -> Result<Value, String> {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser
+        .parse()
+        .map_err(|e| format!("Parse error: {:?}", e))?;
+
+    let mut interpreter = Interpreter::new();
+    let _ = interpreter
+        .interpret(&ast)
+        .await
+        .map_err(|e| format!("Runtime error: {:?}", e))?;
+
+    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
+        Ok(result_value)
+    } else {
+        Err("Variable 'result' not found after execution".to_string())
+    }
+}
+
+fn expect_text(result: Result<Value, String>) -> String {
+    match result {
+        Ok(Value::Text(t)) => t.to_string(),
+        other => panic!("Expected text result, got {:?}", other),
+    }
+}
+
+// === SHA-256 (FIPS 180-4 / well-known vectors) ===
+
+#[tokio::test]
+async fn test_sha256_empty_string() {
+    let code = r#"
+        store result as sha256 of ""
+    "#;
+    let hash = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        hash, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "SHA-256 of empty string must match the standard test vector"
+    );
+}
+
+#[tokio::test]
+async fn test_sha256_abc() {
+    let code = r#"
+        store result as sha256 of "abc"
+    "#;
+    let hash = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        hash,
+        "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+    );
+}
+
+#[tokio::test]
+async fn test_sha256_hello_world() {
+    let code = r#"
+        store result as sha256 of "hello world"
+    "#;
+    let hash = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        hash,
+        "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+    );
+}
+
+#[tokio::test]
+async fn test_sha256_output_is_lowercase_hex() {
+    let code = r#"
+        store result as sha256 of "WFL"
+    "#;
+    let hash = expect_text(run_wfl_code(code).await);
+    assert_eq!(hash.len(), 64);
+    assert!(
+        hash.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+        "Digest must be lowercase hex"
+    );
+}
+
+// === HMAC-SHA256 (RFC 2104 / well-known vectors) ===
+
+#[tokio::test]
+async fn test_hmac_sha256_quick_brown_fox() {
+    // Well-known vector: key = "key", message = "The quick brown fox jumps over the lazy dog"
+    let code = r#"
+        store result as hmac_sha256 of "The quick brown fox jumps over the lazy dog" and "key"
+    "#;
+    let mac = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        mac, "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
+        "HMAC-SHA256 must match the standard test vector (message first, key second)"
+    );
+}
+
+#[tokio::test]
+async fn test_hmac_sha256_empty_key_and_message() {
+    let code = r#"
+        store result as hmac_sha256 of "" and ""
+    "#;
+    let mac = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        mac,
+        "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad"
+    );
+}
+
+#[tokio::test]
+async fn test_hmac_sha256_long_key_is_hashed() {
+    // Keys longer than the block size (64 bytes) are hashed first per RFC 2104.
+    // key = 80 * "a", message = "test"
+    let code = r#"
+        store result as hmac_sha256 of "test" and "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "#;
+    let mac = expect_text(run_wfl_code(code).await);
+    assert_eq!(mac.len(), 64);
+    // Deterministic: computing it twice gives the same answer
+    let code2 = r#"
+        store result as hmac_sha256 of "test" and "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    "#;
+    let mac2 = expect_text(run_wfl_code(code2).await);
+    assert_eq!(mac, mac2);
+}
+
+#[tokio::test]
+async fn test_hmac_sha256_stripe_style_signed_payload() {
+    // Stripe webhook verification computes HMAC-SHA256(secret, "timestamp.payload")
+    let code = r#"
+        store event_time as "1614556800"
+        store payload as "{\"id\": \"evt_123\"}"
+        store signed_payload as event_time with "." with payload
+        store result as hmac_sha256 of signed_payload and "whsec_test_secret"
+    "#;
+    let mac = expect_text(run_wfl_code(code).await);
+    assert_eq!(mac.len(), 64);
+    assert!(mac.chars().all(|c| c.is_ascii_hexdigit()));
+}
+
+#[tokio::test]
+async fn test_hmac_sha256_different_keys_differ() {
+    let code1 = r#"
+        store result as hmac_sha256 of "message" and "key1"
+    "#;
+    let code2 = r#"
+        store result as hmac_sha256 of "message" and "key2"
+    "#;
+    let mac1 = expect_text(run_wfl_code(code1).await);
+    let mac2 = expect_text(run_wfl_code(code2).await);
+    assert_ne!(mac1, mac2, "Different keys must produce different MACs");
+}


### PR DESCRIPTION
## Summary

Implements issue #558: extends the outbound HTTP client to support arbitrary HTTP methods, request headers, and request bodies; adds standard SHA-256 and HMAC-SHA256 builtins for webhook signature verification and API interoperability.

## Key Changes

### 1. Extended `open url` Statement
- **New `HttpRequestStatement` AST node** for requests with method/headers/body clauses
- **Backward compatible**: plain GET requests still parse to `HttpGetStatement`
- **Flexible clause syntax**: `open url at "<url>" with method "POST" and headers h and body b and read response as resp`
  - Clauses joined by `and`/`with` in any order
  - `method` — HTTP verb as text (default `GET`)
  - `headers` — map of header name → value
  - `body` — request body text; supports `with` concatenation with lookahead to distinguish clause terminators
  - `read response as` — binds full response object (status/ok/body/headers); `read content as` keeps body-text-only behavior
- **Multi-line support**: EOL tokens skipped when `and`/`with` connector follows, enabling readable long requests
- **Lexer integration**: handles merged identifiers (e.g., `headers auth_headers` → single token) by matching both bare keywords and merged forms

### 2. Standard Crypto Builtins
- **`sha256 of <text>`** — FIPS 180-4 SHA-256, returns 64-char lowercase hex
- **`hmac_sha256 of <message> and <key>`** — RFC 2104 HMAC-SHA256, returns 64-char lowercase hex
- Both required for webhook verification (Stripe, GitHub, Slack patterns)

### 3. Runtime & Interpreter
- **`IoClient::http_request`** method: drives reqwest with arbitrary method/headers/body, returns `(status, headers, body_text)`
- **Response object structure**: `{status: Number, ok: Boolean, body: Text, headers: Map}` with dot-access support
- **Error handling**: network failures raise catchable errors; non-2xx statuses are data, not errors

### 4. Parser Implementation Details
- **Clause parsing**: `parse_http_clause_value` handles merged identifiers and variable references
- **Continuation logic**: `continue_http_value_expression` with lookahead to detect clause terminators (`and`/`with` + keyword)
- **Variable name parsing**: supports identifiers and special case for `content` keyword as variable name
- **Line break handling**: lookahead-based skipping only when connector follows, preserving error detection for incomplete statements

### 5. Type Checking & Analysis
- Updated `TypeChecker` and `Analyzer` to handle `HttpRequestStatement`
- Type validation: URL must be text, method must be text, headers must be object, body must be text
- Variable binding for response object

### 6. Documentation & Tests
- **Parser tests** (`http_request_parser_test.rs`): 10 tests covering syntax variants, clause ordering, error cases
- **Runtime tests** (`http_request_runtime_test.rs`): 5 tests with local TCP echo server verifying method/headers/body transmission and response object binding
- **Crypto tests** (`sha256_hmac_test.rs`): 8 tests against FIPS 180-4 and RFC 2104 standard vectors
- **WFL test program** (`crypto_standard_test.wfl`): webhook signature verification pattern demonstration
- **Documentation updates**: `Docs/04-advanced-features/interoperability.md` and `Docs/05-standard-library/crypto-module.md`

## Implementation Notes

- Lexer merges consecutive identifiers into multi-word tokens; clause parser splits them to extract variable references
- Response headers normalized to lowercase for consistent access
- `hmac` crate (0.12) added to dependencies for RFC 2104 compliance
- Backward compatibility preserved: existing `open url` forms unchanged, new forms opt-in via clauses

https://claude.ai/code/session_01KDoDUgfugBQct17TDFvPzb