### PR TITLE
Add HTTPS/TLS support for the built-in web server

### DIFF
--- a/.wflcfg
+++ b/.wflcfg
@@ -7,3 +7,8 @@ log_level = info
 # The IP address the web server will bind to (default: 127.0.0.1)
 # Use 0.0.0.0 to listen on all interfaces
 web_server_bind_address = 127.0.0.1
+
+# Default TLS certificate/key (PEM) for `listen ... secured` statements
+# that do not name their own files (no default; uncomment to use)
+# web_server_tls_cert_file = /etc/wfl/tls/cert.pem
+# web_server_tls_key_file = /etc/wfl/tls/key.pem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- HTTPS support for the built-in web server: `listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as server` (PEM files; paths may be expressions)
+- Bare `secured` form takes certificate/key paths from new `.wflcfg` settings `web_server_tls_cert_file` / `web_server_tls_key_file`; in-language paths always win, and a plain `listen` never becomes HTTPS via config
+- HTTP→HTTPS auto-redirect servers: `listen on port 8080 redirecting to port 8443 as redirect_server` answers every request natively with `301 Moved Permanently`, preserving host, path, and query (target port omitted when 443)
+- Certificate/key files are validated at `listen` time; missing or malformed files are reported with the offending path and a hint for generating dev certificates
+- `secured`, `certificate`, `key`, and `redirecting` are positional marker words, not reserved keywords — existing programs using them as variable names are unaffected
+- HTTPS section in `Docs/04-advanced-features/web-servers.md` (dev-cert generation, redirect and dual HTTP+HTTPS patterns, production notes); new settings documented in `Docs/reference/configuration-reference.md`
 - New `execute file` statement for running WFL files in-process: `execute [wfl] file at <path> [with <request>] [and read output as <variable>]`
 - Web servers can now serve dynamic WFL pages PHP-style: execute a `.wfl` file per request, pass it the HTTP request context (`method`, `path`, `client_ip`, `body`, `headers`), capture its display output, and respond with it
 - Output capture mechanism (`display`/`print` redirection) for nested interpreter runs, with correct nesting semantics

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,7 @@ dependencies = [
  "rcgen",
  "regex",
  "reqwest",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile 2.2.0",
  "rustyline",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1249,7 +1249,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1676,6 +1676,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1915,6 +1925,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,7 +2000,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2092,7 +2115,21 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2104,7 +2141,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2119,12 +2156,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2453,7 +2510,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.35",
  "serde",
  "serde_json",
  "sha2",
@@ -2709,7 +2766,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2876,6 +2933,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
  "tokio",
 ]
 
@@ -3192,11 +3260,13 @@ dependencies = [
  "multer",
  "percent-encoding",
  "pin-project",
+ "rustls-pemfile 2.2.0",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite",
  "tokio-util",
  "tower-service",
@@ -3328,8 +3398,10 @@ dependencies = [
  "num-bigint-dig",
  "once_cell",
  "rand 0.9.3",
+ "rcgen",
  "regex",
  "reqwest",
+ "rustls-pemfile 1.0.4",
  "rustyline",
  "serde_json",
  "sha2",
@@ -3409,7 +3481,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3738,6 +3810,15 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix 1.1.2",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,8 @@ tokio = { version = "1.35.1", features = ["full"] }
 reqwest = { version = "0.11.24", features = ["json"] }
 sqlx = { version = "0.8.1", features = ["runtime-tokio-rustls", "sqlite", "mysql", "postgres", "chrono"] }
 serde_json = "1.0.114"
-warp = "0.3.7"
+warp = { version = "0.3.7", features = ["tls"] }
+rustls-pemfile = "1"
 uuid = { version = "1.6.1", features = ["v4"] }
 bytes = "1.11.1"
 codespan-reporting = "0.11.1"
@@ -75,6 +76,7 @@ dhat-ad-hoc = ["dhat"]  # if you are doing ad hoc profiling
 
 [dev-dependencies]
 tempfile = "3.19.1"
+rcgen = "0.13"
 libc = "0.2.152"
 criterion = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ reqwest = { version = "0.11.24", features = ["json"] }
 sqlx = { version = "0.8.1", features = ["runtime-tokio-rustls", "sqlite", "mysql", "postgres", "chrono"] }
 serde_json = "1.0.114"
 warp = { version = "0.3.7", features = ["tls"] }
-rustls-pemfile = "1"
+rustls-pemfile = "2"
 uuid = { version = "1.6.1", features = ["v4"] }
 bytes = "1.11.1"
 codespan-reporting = "0.11.1"

--- a/Dev diary/2026-07-04-https-tls-web-server.md
+++ b/Dev diary/2026-07-04-https-tls-web-server.md
@@ -53,9 +53,10 @@ the HTTP half of a dual-server setup.
 ### warp TLS plumbing
 
 - `warp` is now built with `features = ["tls"]`. That pulls in tokio-rustls
-  0.24 → **rustls 0.21**, which coexists with the **rustls 0.23** already in
-  the tree via sqlx's `runtime-tokio-rustls`. Two rustls majors compile fine
-  side by side; unifying them means upgrading warp (or replacing it) some day.
+  0.25 → **rustls 0.22.4**, which coexists with the **rustls 0.23.35** already
+  in the tree via sqlx's `runtime-tokio-rustls`. Two rustls minors compile
+  fine side by side; unifying them means upgrading warp (or replacing it)
+  some day.
 - warp's `TlsServer` has no `try_bind_ephemeral`, and its `bind_ephemeral`
   panics *inside the spawned task* on a bad certificate or occupied port. The
   interpreter therefore uses `try_bind_with_graceful_shutdown` with a

--- a/Dev diary/2026-07-04-https-tls-web-server.md
+++ b/Dev diary/2026-07-04-https-tls-web-server.md
@@ -1,0 +1,100 @@
+# HTTPS/TLS support for the built-in web server
+
+**Date:** 2026-07-04
+
+## What was added
+
+The `listen` statement grew two optional clauses:
+
+```wfl
+// HTTPS, paths in the code
+listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as secure_server
+
+// HTTPS, paths from .wflcfg (web_server_tls_cert_file / web_server_tls_key_file)
+listen on port 8443 secured as secure_server
+
+// Native HTTP -> HTTPS 301 redirect server
+listen on port 8080 redirecting to port 8443 as redirect_server
+```
+
+Plain `listen` is untouched, and running an HTTP server *alongside* an HTTPS one
+(instead of redirecting) works by simply issuing two `listen` statements.
+
+## Design decisions worth remembering
+
+### No new keywords
+
+`secured`, `certificate`, `key`, and `redirecting` are **plain identifiers**
+matched positionally by the parser, not lexer tokens. `key` in particular is
+used as a variable in existing programs (`TestPrograms/hash_security_test.wfl`
+does `store key as "secret_key_456"`), so reserving it would have broken
+backward compatibility. The keyword count stays at 178.
+
+The cost is dealing with the lexer's multi-word identifier merging: adjacent
+identifiers fuse into one token, so `port my_port secured` arrives as
+`Identifier("my_port secured")` and `certificate cert_var` as
+`Identifier("certificate cert_var")`. The parser splits these apart with the
+same strip-prefix/suffix approach `respond ... and content_type` already uses.
+One subtlety: the merged `... secured` detection must happen *before* the port
+expression is parsed, because `with` is a concatenation operator and
+`parse_expression` would swallow `with certificate "..."` into the port
+expression.
+
+`redirecting to` (rather than `and redirect to`) avoids the same trap: `and`
+is a boolean operator and would be absorbed by the port expression.
+
+### Config precedence
+
+TLS intent always lives in the program; `.wflcfg` only supplies default file
+paths for the bare `secured` form. A plain `listen` never becomes HTTPS via
+config — otherwise dropping cert paths into `.wflcfg` would silently convert
+the HTTP half of a dual-server setup.
+
+### warp TLS plumbing
+
+- `warp` is now built with `features = ["tls"]`. That pulls in tokio-rustls
+  0.24 → **rustls 0.21**, which coexists with the **rustls 0.23** already in
+  the tree via sqlx's `runtime-tokio-rustls`. Two rustls majors compile fine
+  side by side; unifying them means upgrading warp (or replacing it) some day.
+- warp's `TlsServer` has no `try_bind_ephemeral`, and its `bind_ephemeral`
+  panics *inside the spawned task* on a bad certificate or occupied port. The
+  interpreter therefore uses `try_bind_with_graceful_shutdown` with a
+  never-completing signal (`std::future::pending()`), which returns both TLS
+  config errors and bind errors synchronously as `Result`. On top of that,
+  certificate/key files are pre-validated with `rustls-pemfile` (now a direct
+  dependency; it was already in the lockfile) so a missing or malformed file
+  produces an actionable message naming the path.
+
+### Redirect servers are native
+
+The redirect listener answers 301 inside warp itself — requests never enter
+the WFL request loop, so `wait for request` on a redirect server never fires
+(documented). This sidesteps the fact that `respond` can't set custom headers
+yet (the `Location` header requirement). The Location URL preserves host
+(port stripped, IPv6 brackets kept), path, and query, and omits the target
+port when it's 443. The server is still registered in `web_servers` so
+`close server` works.
+
+## Testing
+
+- `tests/web_server_tls_parser_test.rs` — 14 parser cases incl. all merged
+  identifier forms and error cases.
+- `tests/web_server_tls_test.rs` — end-to-end with rcgen-generated
+  self-signed certs (localhost + 127.0.0.1 SANs; reqwest needs
+  `danger_accept_invalid_certs`): HTTPS round-trip, HTTP-to-TLS-port failure,
+  redirect Location assertion, config-driven bare `secured`, dual HTTP+HTTPS,
+  and both actionable error paths.
+- `scripts/run_web_tests.sh` / `.ps1` — new TLS section generating a cert
+  with openssl and driving `TestPrograms/web_server_tls.wfl` (CI-SKIP'd in
+  the plain integration run) with curl. Readiness is probed via the redirect
+  port so the probe doesn't consume the program's single `wait for request`.
+
+## Known limitations
+
+- Application-level responses remain sequential per server (existing
+  behavior); TLS handshakes are concurrent inside warp.
+- The JS transpiler emits a warning for `secured`/`redirecting` listens and
+  generates a plain `http` server.
+- Exotic merged-identifier shapes (e.g. a port expression like
+  `base_port plus offset secured`) aren't recognized; use a simple variable
+  or literal port with the `secured` clause.

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -627,7 +627,7 @@ listen on port 8443 secured as secure_server
 
 Then set the defaults in `.wflcfg`:
 
-```
+```ini
 web_server_tls_cert_file = /etc/wfl/tls/cert.pem
 web_server_tls_key_file = /etc/wfl/tls/key.pem
 ```

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -599,6 +599,101 @@ open url at "http://127.0.0.1:8080/" and read content as api_response
 display "Response: " with api_response
 ```
 
+## HTTPS / TLS
+
+WFL's web server can terminate TLS itself — no reverse proxy required. Add `secured` to a `listen` statement:
+
+```wfl
+listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as secure_server
+```
+
+The certificate and private key are PEM files. Both values are ordinary expressions, so variables work too:
+
+```wfl
+store cert_file as "/etc/wfl/tls/cert.pem"
+store key_file as "/etc/wfl/tls/key.pem"
+listen on port 8443 secured with certificate cert_file and key key_file as secure_server
+```
+
+Everything else — `wait for request`, `respond to` — works exactly as for plain HTTP.
+
+### Certificate paths from configuration
+
+For deployments where certificate locations differ per machine, leave the paths out of the code and use the bare `secured` form:
+
+```wfl
+listen on port 8443 secured as secure_server
+```
+
+Then set the defaults in `.wflcfg`:
+
+```
+web_server_tls_cert_file = /etc/wfl/tls/cert.pem
+web_server_tls_key_file = /etc/wfl/tls/key.pem
+```
+
+Paths written in the `listen` statement always win over the configuration file. A plain `listen` (without `secured`) always serves HTTP, no matter what the configuration contains — adding certificate paths to `.wflcfg` never silently converts an HTTP server to HTTPS.
+
+If a server is marked `secured` but no certificate can be found — in the statement or the configuration — the program stops at startup with an error explaining both options.
+
+### Redirecting HTTP to HTTPS
+
+To send visitors who arrive over plain HTTP to your secure server, start a redirect server:
+
+```wfl
+listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as secure_server
+listen on port 8080 redirecting to port 8443 as redirect_server
+```
+
+The redirect server answers **every** request natively with `301 Moved Permanently`, pointing at the same host, path, and query string on the HTTPS port (the port is omitted from the `Location` URL when the target is 443). Requests to a redirect server never reach your `wait for request` loop — you don't write any handler code for it. `close server redirect_server` shuts it down like any other server.
+
+### Serving HTTP and HTTPS side by side
+
+If you'd rather serve different content on HTTP (instead of redirecting), just start two servers — each `listen` creates an independent server:
+
+```wfl
+listen on port 8080 as http_server
+listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as secure_server
+
+wait for request comes in on http_server as plain_request
+respond to plain_request with "This is the plain HTTP page"
+
+wait for request comes in on secure_server as tls_request
+respond to tls_request with "This is the secure page"
+```
+
+Note that `wait for request` listens to one named server at a time, and responses are handled sequentially (see Limitations below). TLS handshakes themselves are concurrent.
+
+### Certificates for local development
+
+Create a self-signed certificate with openssl:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj "/CN=localhost"
+```
+
+Or, for a certificate your browser trusts without warnings, use [mkcert](https://github.com/FiloSottile/mkcert):
+
+```bash
+mkcert -install
+mkcert localhost 127.0.0.1
+```
+
+Test with curl (`-k` skips certificate validation for self-signed certs):
+
+```bash
+curl -k https://localhost:8443/
+```
+
+⚠️ Self-signed certificates are for development only. In production, use a certificate from a real authority (e.g. Let's Encrypt via certbot).
+
+### Production notes
+
+- The private key file must be readable by the WFL process — protect it with file permissions (`chmod 600 key.pem`).
+- Certificate and key files are validated at `listen` time; a missing or malformed file is reported with the offending path before the server starts.
+- Terminating TLS at a reverse proxy (Caddy, nginx) or CDN in front of a plain-HTTP WFL server remains a perfectly good deployment option — use whichever fits your infrastructure.
+- Remember to set `web_server_bind_address = 0.0.0.0` in `.wflcfg` if the server must be reachable from other machines.
+
 ## Common Patterns
 
 ### API Endpoint
@@ -651,10 +746,9 @@ end check
 ### Current Limitations
 
 - **Single request handling:** Each `wait for request` handles one request
-- **Blocking:** Server handles requests sequentially
+- **Blocking:** Server handles requests sequentially (TLS handshakes are concurrent, but your responses are serialized)
 - **No middleware system** (yet) - Implement manually
 - **No built-in session management** - Implement yourself
-- **No HTTPS** (yet) - HTTP only for now
 
 ### Workarounds
 
@@ -688,6 +782,8 @@ end repeat
 In this section, you learned:
 
 ✅ **Starting servers** - `listen on port`
+✅ **HTTPS** - `listen on port ... secured with certificate ... and key ...`
+✅ **HTTP→HTTPS redirects** - `listen on port ... redirecting to port ...`
 ✅ **Accepting requests** - `wait for request`
 ✅ **Sending responses** - `respond to`
 ✅ **Routing** - Using conditionals to handle different paths

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -278,6 +278,26 @@ The IP address the web server binds to when using `listen on port` statements.
 
 **Security Note:** Setting this to `0.0.0.0` exposes your web server to the network. Only use this when you intend to accept external connections.
 
+#### web_server_tls_cert_file
+
+Default TLS certificate file used by `listen on port ... secured` statements that do not name a certificate themselves.
+
+- **Type:** File path string (PEM format)
+- **Default:** none
+- **Example:** `web_server_tls_cert_file = /etc/wfl/tls/cert.pem`
+
+Paths written directly in a `listen ... secured with certificate ... and key ...` statement take precedence over this setting. A plain `listen` statement (without `secured`) always serves HTTP regardless of this setting.
+
+#### web_server_tls_key_file
+
+Default TLS private key file used by `listen on port ... secured` statements that do not name a key themselves.
+
+- **Type:** File path string (PEM format)
+- **Default:** none
+- **Example:** `web_server_tls_key_file = /etc/wfl/tls/key.pem`
+
+**Security Note:** Protect the private key with restrictive file permissions (e.g. `chmod 600`). WFL validates both files at `listen` time and reports missing or malformed files with the offending path.
+
 ## Example Configuration Files
 
 ### Development Configuration
@@ -326,6 +346,10 @@ kill_on_shutdown = true
 
 # Localhost only web server
 web_server_bind_address = 127.0.0.1
+
+# TLS defaults for `listen ... secured`
+web_server_tls_cert_file = /etc/wfl/tls/cert.pem
+web_server_tls_key_file = /etc/wfl/tls/key.pem
 ```
 
 ### Minimal Configuration

--- a/Docs/reference/keyword-reference.md
+++ b/Docs/reference/keyword-reference.md
@@ -366,6 +366,9 @@ connect to database at "sqlite://app.db" as db
 - 24 contextual keywords CAN be used as variables in certain contexts
 - 5 appear contextual but are actually always reserved
 
+### "What about `secured`, `certificate`, `key`, `redirecting`, `content_type`?" → Not keywords
+These words are recognized purely by position inside `listen` / `respond` statements and are **never reserved** — use them as variable names freely. See [Marker Words That Are Not Keywords](reserved-keywords.md#marker-words-that-are-not-keywords-at-all).
+
 ---
 
 ## Related Documentation

--- a/Docs/reference/reserved-keywords.md
+++ b/Docs/reference/reserved-keywords.md
@@ -91,6 +91,23 @@ create list called items     // ✅ 'list' is a type keyword here
 
 **Why the overlap?** The parser checks structural keywords first. Even though these keywords are listed as contextual in the source code, the structural check takes precedence, making them always reserved.
 
+### Marker Words That Are Not Keywords at All
+
+A few words have special meaning in exactly one statement position but are **not reserved in any way** — they are ordinary identifiers that the parser recognizes purely by position. They do not count toward the 178 keywords, and you can freely use them as variable names everywhere:
+
+- `secured` - HTTPS marker in `listen on port 8443 secured ... as server`
+- `certificate` - certificate path marker in `secured with certificate "cert.pem"`
+- `key` - private key path marker in `secured with ... and key "key.pem"`
+- `redirecting` - redirect marker in `listen on port 8080 redirecting to port 8443 as server`
+- `content_type` - response content type marker in `respond to req with ... and content_type "text/html"`
+
+```wfl
+// All perfectly valid — these words are not reserved:
+store key as "secret_key_456"
+store certificate as "diploma"
+store secured as yes
+```
+
 ### Why Some Keywords Appear in Multiple Lists
 
 You might notice keywords like `push`, `zero`, and `than` appear in both the structural and contextual keyword lists in the compiler source code. This isn't a bug—it's by design:

--- a/TestPrograms/web_server_tls.wfl
+++ b/TestPrograms/web_server_tls.wfl
@@ -1,0 +1,31 @@
+// CI-SKIP: starts an HTTPS web server and needs certificate files plus an HTTP client to drive it (covered by run_web_tests)
+# WFL HTTPS Web Server Example
+# Demonstrates TLS support on the built-in web server.
+#
+# Before running, create a self-signed certificate for local development:
+#   openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj "/CN=localhost"
+
+display "=== WFL HTTPS Web Server ==="
+
+store cert_file as "cert.pem"
+store key_file as "key.pem"
+
+// HTTPS server with in-language certificate paths
+listen on port 8443 secured with certificate cert_file and key key_file as secure_server
+
+display "✓ Secure server started on port 8443"
+
+// HTTP -> HTTPS redirect: answers every plain-HTTP request with a
+// 301 redirect to the same path on port 8443. No request loop needed.
+listen on port 8090 redirecting to port 8443 as redirect_server
+
+display "✓ Redirect server started on port 8090"
+
+// Serve one HTTPS request, then shut down
+wait for request comes in on secure_server as incoming_request with timeout 30000
+respond to incoming_request with "Hello over HTTPS!" and content_type "text/plain"
+
+close server redirect_server
+close server secure_server
+
+display "✓ Servers closed"

--- a/TestPrograms/web_server_tls.wfl.ast.txt
+++ b/TestPrograms/web_server_tls.wfl.ast.txt
@@ -1,0 +1,203 @@
+AST output for: TestPrograms/web_server_tls.wfl
+==============================================
+
+Program with 12 statements:
+
+Statement #1: DisplayStatement {
+    value: Literal(
+        String(
+            "=== WFL HTTPS Web Server ===",
+        ),
+        8,
+        9,
+    ),
+    line: 8,
+    column: 39,
+}
+
+Statement #2: VariableDeclaration {
+    name: "cert_file",
+    value: Literal(
+        String(
+            "cert.pem",
+        ),
+        10,
+        20,
+    ),
+    is_constant: false,
+    line: 10,
+    column: 1,
+}
+
+Statement #3: VariableDeclaration {
+    name: "key_file",
+    value: Literal(
+        String(
+            "key.pem",
+        ),
+        11,
+        19,
+    ),
+    is_constant: false,
+    line: 11,
+    column: 1,
+}
+
+Statement #4: ListenStatement {
+    port: Literal(
+        Integer(
+            8443,
+        ),
+        14,
+        16,
+    ),
+    server_name: "secure_server",
+    tls: Some(
+        TlsListenConfig {
+            cert_path: Some(
+                Variable(
+                    "cert_file",
+                    14,
+                    34,
+                ),
+            ),
+            key_path: Some(
+                Variable(
+                    "key_file",
+                    14,
+                    60,
+                ),
+            ),
+        },
+    ),
+    redirect_to_port: None,
+    line: 14,
+    column: 1,
+}
+
+Statement #5: DisplayStatement {
+    value: Literal(
+        String(
+            "✓ Secure server started on port 8443",
+        ),
+        16,
+        9,
+    ),
+    line: 16,
+    column: 49,
+}
+
+Statement #6: ListenStatement {
+    port: Literal(
+        Integer(
+            8090,
+        ),
+        20,
+        16,
+    ),
+    server_name: "redirect_server",
+    tls: None,
+    redirect_to_port: Some(
+        Literal(
+            Integer(
+                8443,
+            ),
+            20,
+            41,
+        ),
+    ),
+    line: 20,
+    column: 1,
+}
+
+Statement #7: DisplayStatement {
+    value: Literal(
+        String(
+            "✓ Redirect server started on port 8090",
+        ),
+        22,
+        9,
+    ),
+    line: 22,
+    column: 51,
+}
+
+Statement #8: WaitForRequestStatement {
+    server: Variable(
+        "secure_server",
+        25,
+        30,
+    ),
+    request_name: "incoming_request",
+    timeout: Some(
+        Literal(
+            Integer(
+                30000,
+            ),
+            25,
+            77,
+        ),
+    ),
+    line: 25,
+    column: 1,
+}
+
+Statement #9: RespondStatement {
+    request: Variable(
+        "incoming_request",
+        26,
+        12,
+    ),
+    content: Literal(
+        String(
+            "Hello over HTTPS!",
+        ),
+        26,
+        34,
+    ),
+    status: None,
+    content_type: Some(
+        Literal(
+            String(
+                "text/plain",
+            ),
+            26,
+            71,
+        ),
+    ),
+    line: 26,
+    column: 1,
+}
+
+Statement #10: CloseServerStatement {
+    server: Variable(
+        "redirect_server",
+        28,
+        14,
+    ),
+    line: 28,
+    column: 1,
+}
+
+Statement #11: CloseServerStatement {
+    server: Variable(
+        "secure_server",
+        29,
+        14,
+    ),
+    line: 29,
+    column: 1,
+}
+
+Statement #12: DisplayStatement {
+    value: Literal(
+        String(
+            "✓ Servers closed",
+        ),
+        31,
+        9,
+    ),
+    line: 31,
+    column: 29,
+}
+

--- a/scripts/run_web_tests.ps1
+++ b/scripts/run_web_tests.ps1
@@ -198,6 +198,93 @@ if (Test-Path "TestPrograms\web_route_params_test.wfl") {
     }
 }
 
+# Test 4: web_server_tls.wfl (HTTPS + HTTP->HTTPS redirect)
+if (Test-Path "TestPrograms\web_server_tls.wfl") {
+    $openssl = Get-Command openssl -ErrorAction SilentlyContinue
+    if (-not $openssl) {
+        Write-Host "[SKIP] web_server_tls.wfl - openssl not available to generate a test certificate" -ForegroundColor Yellow
+    } else {
+        $totalTests++
+        Write-Host ""
+        Write-Host "[INFO] Testing: web_server_tls.wfl on ports 8443 (https) and 8090 (redirect)" -ForegroundColor Blue
+
+        $tlsDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $tlsDir | Out-Null
+        & openssl req -x509 -newkey rsa:2048 -nodes -keyout "$tlsDir\key.pem" -out "$tlsDir\cert.pem" -days 1 -subj "/CN=localhost" 2>&1 | Out-Null
+
+        # The test program uses relative cert paths, so run it from the temp dir
+        $absBinary = Join-Path (Get-Location) $BinaryPath
+        $absTest = Join-Path (Get-Location) "TestPrograms\web_server_tls.wfl"
+        $tlsProcess = Start-Process -FilePath $absBinary -ArgumentList $absTest -WorkingDirectory $tlsDir -NoNewWindow -PassThru -RedirectStandardOutput "NUL" -RedirectStandardError "NUL"
+
+        try {
+            # Probe readiness via the redirect port: it answers natively and does
+            # not consume the program's single `wait for request`
+            $serverReady = $false
+            $retries = 0
+            $maxRetries = $Timeout * 2
+            while (-not $serverReady -and $retries -lt $maxRetries) {
+                Start-Sleep -Milliseconds 500
+                $retries++
+                try {
+                    Invoke-WebRequest -Uri "http://localhost:8090/" -TimeoutSec 2 -UseBasicParsing -MaximumRedirection 0 -ErrorAction Stop | Out-Null
+                    $serverReady = $true
+                } catch {
+                    if ($_.Exception.Response -and [int]$_.Exception.Response.StatusCode -eq 301) {
+                        $serverReady = $true
+                    }
+                }
+            }
+
+            $tlsOk = $true
+            if (-not $serverReady) {
+                Write-Host "[ERROR] TIMEOUT: TLS server did not start within ${Timeout}s" -ForegroundColor Red
+                $tlsOk = $false
+            } else {
+                # Redirect server: 301 with Location preserving path/query on the HTTPS port
+                $location = $null
+                try {
+                    $redirectResponse = Invoke-WebRequest -Uri "http://localhost:8090/some/path?x=1" -TimeoutSec 2 -UseBasicParsing -MaximumRedirection 0 -ErrorAction Stop
+                    $location = $redirectResponse.Headers["Location"]
+                } catch {
+                    if ($_.Exception.Response) {
+                        $location = $_.Exception.Response.Headers["Location"]
+                    }
+                }
+                if ($location -eq "https://localhost:8443/some/path?x=1") {
+                    Write-Host "[SUCCESS] PASS: redirect returns 301 to $location" -ForegroundColor Green
+                } else {
+                    Write-Host "[ERROR] FAIL: redirect Location was '$location'" -ForegroundColor Red
+                    $tlsOk = $false
+                }
+
+                # HTTPS request with certificate validation disabled (self-signed)
+                try {
+                    $httpsResponse = Invoke-WebRequest -Uri "https://localhost:8443/" -TimeoutSec 3 -UseBasicParsing -SkipCertificateCheck -ErrorAction Stop
+                    if ($httpsResponse.Content -like "*Hello over HTTPS!*") {
+                        Write-Host "[SUCCESS] PASS: HTTPS response '$($httpsResponse.Content)'" -ForegroundColor Green
+                    } else {
+                        Write-Host "[ERROR] FAIL: HTTPS request returned '$($httpsResponse.Content)'" -ForegroundColor Red
+                        $tlsOk = $false
+                    }
+                } catch {
+                    Write-Host "[ERROR] FAIL: HTTPS request failed: $_" -ForegroundColor Red
+                    Write-Host "[INFO] Note: -SkipCertificateCheck requires PowerShell 6+" -ForegroundColor Gray
+                    $tlsOk = $false
+                }
+            }
+
+            if ($tlsOk) { $passedTests++ }
+        } finally {
+            if (-not $tlsProcess.HasExited) {
+                $tlsProcess.Kill()
+                Write-Host "[INFO] Server process terminated" -ForegroundColor Gray
+            }
+            Remove-Item -Recurse -Force $tlsDir -ErrorAction SilentlyContinue
+        }
+    }
+}
+
 # Summary
 Write-Host ""
 Write-Host "[INFO] ============================" -ForegroundColor Blue

--- a/scripts/run_web_tests.ps1
+++ b/scripts/run_web_tests.ps1
@@ -258,19 +258,24 @@ if (Test-Path "TestPrograms\web_server_tls.wfl") {
                     $tlsOk = $false
                 }
 
-                # HTTPS request with certificate validation disabled (self-signed)
-                try {
-                    $httpsResponse = Invoke-WebRequest -Uri "https://localhost:8443/" -TimeoutSec 3 -UseBasicParsing -SkipCertificateCheck -ErrorAction Stop
-                    if ($httpsResponse.Content -like "*Hello over HTTPS!*") {
-                        Write-Host "[SUCCESS] PASS: HTTPS response '$($httpsResponse.Content)'" -ForegroundColor Green
-                    } else {
-                        Write-Host "[ERROR] FAIL: HTTPS request returned '$($httpsResponse.Content)'" -ForegroundColor Red
+                # HTTPS request with certificate validation disabled (self-signed).
+                # -SkipCertificateCheck only exists in PowerShell 6+; on Windows
+                # PowerShell 5.1 skip this check gracefully instead of failing.
+                if ($PSVersionTable.PSVersion.Major -ge 6) {
+                    try {
+                        $httpsResponse = Invoke-WebRequest -Uri "https://localhost:8443/" -TimeoutSec 3 -UseBasicParsing -SkipCertificateCheck -ErrorAction Stop
+                        if ($httpsResponse.Content -like "*Hello over HTTPS!*") {
+                            Write-Host "[SUCCESS] PASS: HTTPS response '$($httpsResponse.Content)'" -ForegroundColor Green
+                        } else {
+                            Write-Host "[ERROR] FAIL: HTTPS request returned '$($httpsResponse.Content)'" -ForegroundColor Red
+                            $tlsOk = $false
+                        }
+                    } catch {
+                        Write-Host "[ERROR] FAIL: HTTPS request failed: $_" -ForegroundColor Red
                         $tlsOk = $false
                     }
-                } catch {
-                    Write-Host "[ERROR] FAIL: HTTPS request failed: $_" -ForegroundColor Red
-                    Write-Host "[INFO] Note: -SkipCertificateCheck requires PowerShell 6+" -ForegroundColor Gray
-                    $tlsOk = $false
+                } else {
+                    Write-Host "[SKIP] HTTPS request check requires PowerShell 6+ (-SkipCertificateCheck); redirect check still ran" -ForegroundColor Yellow
                 }
             }
 

--- a/scripts/run_web_tests.sh
+++ b/scripts/run_web_tests.sh
@@ -233,6 +233,73 @@ if [ -f "TestPrograms/web_route_params_test.wfl" ]; then
     fi
 fi
 
+# Test 4: web_server_tls.wfl (HTTPS + HTTP->HTTPS redirect)
+if [ -f "TestPrograms/web_server_tls.wfl" ]; then
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo -e "${YELLOW}[SKIP]${NC} web_server_tls.wfl - openssl not available to generate a test certificate"
+    else
+        total_tests=$((total_tests + 1))
+        echo ""
+        echo -e "${BLUE}[INFO]${NC} Testing: web_server_tls.wfl on ports 8443 (https) and 8090 (redirect)"
+
+        tls_dir=$(mktemp -d)
+        openssl req -x509 -newkey rsa:2048 -nodes -keyout "$tls_dir/key.pem" \
+            -out "$tls_dir/cert.pem" -days 1 -subj "/CN=localhost" >/dev/null 2>&1
+
+        # The test program uses relative cert paths, so run it from the temp dir
+        abs_binary="$(pwd)/$BINARY_PATH"
+        abs_test="$(pwd)/TestPrograms/web_server_tls.wfl"
+        (cd "$tls_dir" && "$abs_binary" "$abs_test" > /dev/null 2>&1) &
+        tls_pid=$!
+
+        # Probe readiness via the redirect port: it answers natively and does
+        # not consume the program's single `wait for request`
+        tls_ready=false
+        retries=0
+        max_retries=$((TIMEOUT * 2))
+        while [ "$tls_ready" = false ] && [ $retries -lt $max_retries ]; do
+            sleep 0.5
+            retries=$((retries + 1))
+            if curl -ks --max-time 2 -o /dev/null "http://localhost:8090/" 2>/dev/null; then
+                tls_ready=true
+            fi
+        done
+
+        tls_ok=true
+        if [ "$tls_ready" = false ]; then
+            echo -e "${RED}[ERROR]${NC} TIMEOUT: TLS server did not start within ${TIMEOUT}s"
+            tls_ok=false
+        else
+            # Redirect server: 301 with Location preserving path/query on the HTTPS port
+            redirect_out=$(curl -ks -o /dev/null -w '%{http_code} %{redirect_url}' --max-time 2 "http://localhost:8090/some/path?x=1")
+            if [[ "$redirect_out" == "301 https://localhost:8443/some/path?x=1" ]]; then
+                echo -e "${GREEN}[SUCCESS]${NC} PASS: redirect returns 301 to https://localhost:8443/some/path?x=1"
+            else
+                echo -e "${RED}[ERROR]${NC} FAIL: redirect returned '$redirect_out'"
+                tls_ok=false
+            fi
+
+            # HTTPS request (consumes the program's single request, then it exits)
+            https_resp=$(curl -ks --max-time 3 "https://localhost:8443/")
+            if [[ "$https_resp" == *"Hello over HTTPS!"* ]]; then
+                echo -e "${GREEN}[SUCCESS]${NC} PASS: HTTPS response '$https_resp'"
+            else
+                echo -e "${RED}[ERROR]${NC} FAIL: HTTPS request returned '$https_resp'"
+                tls_ok=false
+            fi
+        fi
+
+        if kill -0 $tls_pid 2>/dev/null; then
+            kill $tls_pid 2>/dev/null || true
+        fi
+        rm -rf "$tls_dir"
+
+        if [ "$tls_ok" = true ]; then
+            passed_tests=$((passed_tests + 1))
+        fi
+    fi
+fi
+
 # Summary
 echo ""
 echo -e "${BLUE}[INFO]${NC} ============================"

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1491,11 +1491,28 @@ impl Analyzer {
             Statement::ListenStatement {
                 port,
                 server_name,
+                tls,
+                redirect_to_port,
                 line,
                 column,
             } => {
                 // Analyze the port expression
                 self.analyze_expression(port);
+
+                // Analyze TLS certificate/key path expressions if present
+                if let Some(tls_config) = tls {
+                    if let Some(cert_path) = &tls_config.cert_path {
+                        self.analyze_expression(cert_path);
+                    }
+                    if let Some(key_path) = &tls_config.key_path {
+                        self.analyze_expression(key_path);
+                    }
+                }
+
+                // Analyze the redirect target port expression if present
+                if let Some(target_port) = redirect_to_port {
+                    self.analyze_expression(target_port);
+                }
 
                 // Define the server variable
                 let server_symbol = Symbol {

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,10 @@ pub struct WflConfig {
     pub subprocess_config: SubprocessConfig,
     // Web server network binding
     pub web_server_bind_address: String,
+    // Web server TLS defaults: used by `listen ... secured` when the listen
+    // statement does not name certificate/key files itself
+    pub web_server_tls_cert_file: Option<String>,
+    pub web_server_tls_key_file: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,6 +119,10 @@ impl Default for WflConfig {
             subprocess_config: SubprocessConfig::default(),
             // Web server network binding default
             web_server_bind_address: "127.0.0.1".to_string(),
+            // No TLS defaults: a `listen ... secured` statement must either
+            // name its certificate/key files or these must be set in .wflcfg
+            web_server_tls_cert_file: None,
+            web_server_tls_key_file: None,
         }
     }
 }
@@ -575,6 +583,40 @@ fn parse_config_text(config: &mut WflConfig, text: &str, file: &Path) {
                         );
                     }
                 }
+                "web_server_tls_cert_file" => {
+                    let path = value.trim().to_string();
+                    if path.is_empty() {
+                        log::warn!(
+                            "Empty web_server_tls_cert_file in {}: ignoring",
+                            file.display()
+                        );
+                    } else {
+                        // Existence is checked at listen time so relative
+                        // paths resolve against the script's working directory
+                        config.web_server_tls_cert_file = Some(path);
+                        log::debug!(
+                            "Loaded web_server_tls_cert_file: {:?} from {}",
+                            config.web_server_tls_cert_file,
+                            file.display()
+                        );
+                    }
+                }
+                "web_server_tls_key_file" => {
+                    let path = value.trim().to_string();
+                    if path.is_empty() {
+                        log::warn!(
+                            "Empty web_server_tls_key_file in {}: ignoring",
+                            file.display()
+                        );
+                    } else {
+                        config.web_server_tls_key_file = Some(path);
+                        log::debug!(
+                            "Loaded web_server_tls_key_file: {:?} from {}",
+                            config.web_server_tls_key_file,
+                            file.display()
+                        );
+                    }
+                }
                 _ => {
                     log::warn!("Unknown configuration key: {} in {}", key, file.display());
                 }
@@ -995,6 +1037,83 @@ mod tests {
         assert_eq!(
             config.web_server_bind_address, "127.0.0.1",
             "Default web_server_bind_address should be 127.0.0.1"
+        );
+    }
+
+    #[test]
+    fn test_web_server_tls_files_default_none() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let config = with_test_global_path(|| {
+            set_test_env_var(Some("/non/existent/path"));
+            load_config(temp_dir.path())
+        });
+
+        assert_eq!(
+            config.web_server_tls_cert_file, None,
+            "Default web_server_tls_cert_file should be None"
+        );
+        assert_eq!(
+            config.web_server_tls_key_file, None,
+            "Default web_server_tls_key_file should be None"
+        );
+    }
+
+    #[test]
+    fn test_web_server_tls_files_custom() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join(".wflcfg");
+
+        let config_content = r#"
+        web_server_tls_cert_file = /etc/wfl/cert.pem
+        web_server_tls_key_file = /etc/wfl/key.pem
+        "#;
+
+        let mut file = fs::File::create(&config_path).unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let config = with_test_global_path(|| {
+            set_test_env_var(Some("/non/existent/path"));
+            load_config(temp_dir.path())
+        });
+
+        assert_eq!(
+            config.web_server_tls_cert_file.as_deref(),
+            Some("/etc/wfl/cert.pem"),
+            "web_server_tls_cert_file should be loaded"
+        );
+        assert_eq!(
+            config.web_server_tls_key_file.as_deref(),
+            Some("/etc/wfl/key.pem"),
+            "web_server_tls_key_file should be loaded"
+        );
+    }
+
+    #[test]
+    fn test_web_server_tls_files_empty_values_ignored() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join(".wflcfg");
+
+        let config_content = r#"
+        web_server_tls_cert_file =
+        web_server_tls_key_file =
+        "#;
+
+        let mut file = fs::File::create(&config_path).unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let config = with_test_global_path(|| {
+            set_test_env_var(Some("/non/existent/path"));
+            load_config(temp_dir.path())
+        });
+
+        assert_eq!(
+            config.web_server_tls_cert_file, None,
+            "Empty web_server_tls_cert_file should stay None"
+        );
+        assert_eq!(
+            config.web_server_tls_key_file, None,
+            "Empty web_server_tls_key_file should stay None"
         );
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5166,12 +5166,16 @@ impl Interpreter {
                     let target_val = self
                         .evaluate_expression(target_port_expr, Rc::clone(&env))
                         .await?;
+                    // Reject non-integer and out-of-range values instead of
+                    // letting the float->u16 cast saturate to a wrong port
                     let target_port = match &target_val {
-                        Value::Number(n) => *n as u16,
+                        Value::Number(n) if n.fract() == 0.0 && *n >= 1.0 && *n <= 65535.0 => {
+                            *n as u16
+                        }
                         _ => {
                             return Err(RuntimeError::new(
                                 format!(
-                                    "Expected number for redirect target port, got {target_val:?}"
+                                    "Expected a whole number between 1 and 65535 for redirect target port, got {target_val:?}"
                                 ),
                                 *line,
                                 *column,

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -99,6 +99,59 @@ pub struct ServerError(String);
 
 impl warp::reject::Reject for ServerError {}
 
+/// Strips the port from an HTTP Host header value, preserving IPv6 brackets
+/// (`example.com:8080` -> `example.com`, `[::1]:8080` -> `[::1]`).
+fn strip_host_port(host: &str) -> &str {
+    if let Some(end) = host.rfind(']') {
+        // Bracketed IPv6 literal, with or without a trailing :port
+        &host[..=end]
+    } else if let Some(idx) = host.rfind(':') {
+        &host[..idx]
+    } else {
+        host
+    }
+}
+
+/// Validates TLS certificate/key files before handing them to warp, which
+/// would otherwise panic inside the spawned server task on a bad file. Returns
+/// an actionable message naming the offending file.
+fn validate_tls_pem_files(cert_path: &str, key_path: &str) -> Result<(), String> {
+    let cert_file = std::fs::File::open(cert_path).map_err(|e| {
+        format!(
+            "Cannot open TLS certificate file '{cert_path}': {e}. For local development you can create a self-signed certificate with: openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj \"/CN=localhost\""
+        )
+    })?;
+    let cert_items = rustls_pemfile::read_all(&mut std::io::BufReader::new(cert_file))
+        .map_err(|e| format!("TLS certificate file '{cert_path}' is not valid PEM: {e}"))?;
+    if !cert_items
+        .iter()
+        .any(|item| matches!(item, rustls_pemfile::Item::X509Certificate(_)))
+    {
+        return Err(format!(
+            "TLS certificate file '{cert_path}' contains no certificates. Expected at least one PEM 'CERTIFICATE' block"
+        ));
+    }
+
+    let key_file = std::fs::File::open(key_path)
+        .map_err(|e| format!("Cannot open TLS private key file '{key_path}': {e}"))?;
+    let key_items = rustls_pemfile::read_all(&mut std::io::BufReader::new(key_file))
+        .map_err(|e| format!("TLS private key file '{key_path}' is not valid PEM: {e}"))?;
+    if !key_items.iter().any(|item| {
+        matches!(
+            item,
+            rustls_pemfile::Item::RSAKey(_)
+                | rustls_pemfile::Item::PKCS8Key(_)
+                | rustls_pemfile::Item::ECKey(_)
+        )
+    }) {
+        return Err(format!(
+            "TLS private key file '{key_path}' contains no private key. Expected a PEM 'PRIVATE KEY', 'RSA PRIVATE KEY', or 'EC PRIVATE KEY' block"
+        ));
+    }
+
+    Ok(())
+}
+
 /// RAII guard that ensures module loading context is restored on scope exit.
 /// Automatically pops loading_stack and restores current_source_file when dropped.
 struct ModuleLoadGuard<'a> {
@@ -4959,6 +5012,8 @@ impl Interpreter {
             Statement::ListenStatement {
                 port,
                 server_name,
+                tls,
+                redirect_to_port,
                 line,
                 column,
             } => {
@@ -5103,45 +5158,256 @@ impl Interpreter {
                     }
                 };
 
-                // Start the server
-                let server_task = warp::serve(routes).try_bind_ephemeral((bind_addr, port_num));
-
-                match server_task {
-                    Ok((addr, server)) => {
-                        // Spawn the server in the background
-                        let server_handle = tokio::spawn(server);
-
-                        // Create WFL web server object
-                        let wfl_server = WflWebServer {
-                            request_receiver: request_receiver.clone(),
-                            request_sender: request_sender.clone(),
-                            server_handle: Some(server_handle),
-                        };
-
-                        // Store the server in the interpreter
-                        self.web_servers
-                            .borrow_mut()
-                            .insert(server_name.clone(), wfl_server);
-
-                        // Create a server value with the actual address
-                        let server_value = Value::Text(Arc::from(format!(
-                            "WebServer::{}:{}",
-                            addr.ip(),
-                            addr.port()
-                        )));
-
-                        println!("Server is listening on port {}", addr.port());
-
-                        match env.borrow_mut().define(server_name, server_value) {
-                            Ok(_) => Ok((Value::Null, ControlFlow::None)),
-                            Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
+                if let Some(target_port_expr) = redirect_to_port {
+                    // Redirect server: answers every request natively with a
+                    // 301 to the HTTPS port. Requests never reach the WFL
+                    // request loop, so `wait for request` on this server
+                    // never fires.
+                    let target_val = self
+                        .evaluate_expression(target_port_expr, Rc::clone(&env))
+                        .await?;
+                    let target_port = match &target_val {
+                        Value::Number(n) => *n as u16,
+                        _ => {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Expected number for redirect target port, got {target_val:?}"
+                                ),
+                                *line,
+                                *column,
+                            ));
                         }
+                    };
+
+                    let fallback_host = match bind_addr {
+                        IpAddr::V6(v6) => format!("[{v6}]"),
+                        IpAddr::V4(v4) => v4.to_string(),
+                    };
+                    let redirect_routes = warp::any()
+                        .and(warp::header::optional::<String>("host"))
+                        .and(warp::path::full())
+                        .and(warp::query::raw().or(warp::any().map(String::new)).unify())
+                        .map(
+                            move |host: Option<String>,
+                                  path: warp::path::FullPath,
+                                  query: String| {
+                                let host_value = host.unwrap_or_else(|| fallback_host.clone());
+                                let mut location =
+                                    format!("https://{}", strip_host_port(&host_value));
+                                if target_port != 443 {
+                                    location.push_str(&format!(":{target_port}"));
+                                }
+                                location.push_str(path.as_str());
+                                if !query.is_empty() {
+                                    location.push('?');
+                                    location.push_str(&query);
+                                }
+                                warp::http::Response::builder()
+                                    .status(warp::http::StatusCode::MOVED_PERMANENTLY)
+                                    .header("Location", location)
+                                    .header("Content-Length", 0)
+                                    .body(Vec::new())
+                                    .unwrap_or_else(|_| {
+                                        let mut resp = warp::http::Response::new(Vec::new());
+                                        *resp.status_mut() =
+                                            warp::http::StatusCode::INTERNAL_SERVER_ERROR;
+                                        resp
+                                    })
+                            },
+                        );
+
+                    match warp::serve(redirect_routes).try_bind_ephemeral((bind_addr, port_num)) {
+                        Ok((addr, server)) => {
+                            let server_handle = tokio::spawn(server);
+
+                            // Registered like any other server so `close server`
+                            // works; its request channels are never fed.
+                            let wfl_server = WflWebServer {
+                                request_receiver: request_receiver.clone(),
+                                request_sender: request_sender.clone(),
+                                server_handle: Some(server_handle),
+                            };
+                            self.web_servers
+                                .borrow_mut()
+                                .insert(server_name.clone(), wfl_server);
+
+                            let server_value = Value::Text(Arc::from(format!(
+                                "WebServer::{}:{}",
+                                addr.ip(),
+                                addr.port()
+                            )));
+
+                            println!(
+                                "Redirect server is listening on port {} (redirecting to HTTPS port {})",
+                                addr.port(),
+                                target_port
+                            );
+
+                            match env.borrow_mut().define(server_name, server_value) {
+                                Ok(_) => Ok((Value::Null, ControlFlow::None)),
+                                Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
+                            }
+                        }
+                        Err(e) => Err(RuntimeError::new(
+                            format!("Failed to start web server on port {}: {}", port_num, e),
+                            *line,
+                            *column,
+                        )),
                     }
-                    Err(e) => Err(RuntimeError::new(
-                        format!("Failed to start web server on port {}: {}", port_num, e),
-                        *line,
-                        *column,
-                    )),
+                } else if let Some(tls_config) = tls {
+                    // HTTPS server. Certificate/key paths come from the listen
+                    // statement itself, falling back to .wflcfg for the bare
+                    // `secured` form.
+                    let cert_path = match &tls_config.cert_path {
+                        Some(expr) => {
+                            let v = self.evaluate_expression(expr, Rc::clone(&env)).await?;
+                            match &v {
+                                Value::Text(t) => t.to_string(),
+                                _ => {
+                                    return Err(RuntimeError::new(
+                                        format!(
+                                            "Expected text for TLS certificate path, got {v:?}"
+                                        ),
+                                        *line,
+                                        *column,
+                                    ));
+                                }
+                            }
+                        }
+                        None => match &self.config.web_server_tls_cert_file {
+                            Some(path) => path.clone(),
+                            None => {
+                                return Err(RuntimeError::new(
+                                    "This listen statement is marked 'secured' but no certificate is configured. Either write 'secured with certificate \"cert.pem\" and key \"key.pem\"' or set web_server_tls_cert_file and web_server_tls_key_file in .wflcfg".to_string(),
+                                    *line,
+                                    *column,
+                                ));
+                            }
+                        },
+                    };
+                    let key_path = match &tls_config.key_path {
+                        Some(expr) => {
+                            let v = self.evaluate_expression(expr, Rc::clone(&env)).await?;
+                            match &v {
+                                Value::Text(t) => t.to_string(),
+                                _ => {
+                                    return Err(RuntimeError::new(
+                                        format!(
+                                            "Expected text for TLS private key path, got {v:?}"
+                                        ),
+                                        *line,
+                                        *column,
+                                    ));
+                                }
+                            }
+                        }
+                        None => match &self.config.web_server_tls_key_file {
+                            Some(path) => path.clone(),
+                            None => {
+                                return Err(RuntimeError::new(
+                                    "This listen statement is marked 'secured' but no private key is configured. Either write 'secured with certificate \"cert.pem\" and key \"key.pem\"' or set web_server_tls_cert_file and web_server_tls_key_file in .wflcfg".to_string(),
+                                    *line,
+                                    *column,
+                                ));
+                            }
+                        },
+                    };
+
+                    // Validate up front for actionable errors; warp would
+                    // otherwise surface a bad certificate as a generic
+                    // bind-time failure.
+                    if let Err(msg) = validate_tls_pem_files(&cert_path, &key_path) {
+                        return Err(RuntimeError::new(msg, *line, *column));
+                    }
+
+                    // try_bind_with_graceful_shutdown is the only TlsServer
+                    // constructor that returns bind/TLS errors instead of
+                    // panicking inside the spawned task; the never-completing
+                    // signal keeps the server running until `close server`
+                    // aborts its task.
+                    match warp::serve(routes)
+                        .tls()
+                        .cert_path(&cert_path)
+                        .key_path(&key_path)
+                        .try_bind_with_graceful_shutdown(
+                            (bind_addr, port_num),
+                            std::future::pending::<()>(),
+                        ) {
+                        Ok((addr, server)) => {
+                            let server_handle = tokio::spawn(server);
+
+                            let wfl_server = WflWebServer {
+                                request_receiver: request_receiver.clone(),
+                                request_sender: request_sender.clone(),
+                                server_handle: Some(server_handle),
+                            };
+                            self.web_servers
+                                .borrow_mut()
+                                .insert(server_name.clone(), wfl_server);
+
+                            let server_value = Value::Text(Arc::from(format!(
+                                "WebServer::{}:{}",
+                                addr.ip(),
+                                addr.port()
+                            )));
+
+                            println!("Secure server is listening on port {}", addr.port());
+
+                            match env.borrow_mut().define(server_name, server_value) {
+                                Ok(_) => Ok((Value::Null, ControlFlow::None)),
+                                Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
+                            }
+                        }
+                        Err(e) => Err(RuntimeError::new(
+                            format!(
+                                "Failed to start secure web server on port {}: {}",
+                                port_num, e
+                            ),
+                            *line,
+                            *column,
+                        )),
+                    }
+                } else {
+                    // Plain HTTP server (unchanged behavior)
+                    let server_task = warp::serve(routes).try_bind_ephemeral((bind_addr, port_num));
+
+                    match server_task {
+                        Ok((addr, server)) => {
+                            // Spawn the server in the background
+                            let server_handle = tokio::spawn(server);
+
+                            // Create WFL web server object
+                            let wfl_server = WflWebServer {
+                                request_receiver: request_receiver.clone(),
+                                request_sender: request_sender.clone(),
+                                server_handle: Some(server_handle),
+                            };
+
+                            // Store the server in the interpreter
+                            self.web_servers
+                                .borrow_mut()
+                                .insert(server_name.clone(), wfl_server);
+
+                            // Create a server value with the actual address
+                            let server_value = Value::Text(Arc::from(format!(
+                                "WebServer::{}:{}",
+                                addr.ip(),
+                                addr.port()
+                            )));
+
+                            println!("Server is listening on port {}", addr.port());
+
+                            match env.borrow_mut().define(server_name, server_value) {
+                                Ok(_) => Ok((Value::Null, ControlFlow::None)),
+                                Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
+                            }
+                        }
+                        Err(e) => Err(RuntimeError::new(
+                            format!("Failed to start web server on port {}: {}", port_num, e),
+                            *line,
+                            *column,
+                        )),
+                    }
                 }
             }
             Statement::WaitForRequestStatement {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -121,8 +121,10 @@ fn validate_tls_pem_files(cert_path: &str, key_path: &str) -> Result<(), String>
             "Cannot open TLS certificate file '{cert_path}': {e}. For local development you can create a self-signed certificate with: openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 365 -subj \"/CN=localhost\""
         )
     })?;
-    let cert_items = rustls_pemfile::read_all(&mut std::io::BufReader::new(cert_file))
-        .map_err(|e| format!("TLS certificate file '{cert_path}' is not valid PEM: {e}"))?;
+    let cert_items: Vec<rustls_pemfile::Item> =
+        rustls_pemfile::read_all(&mut std::io::BufReader::new(cert_file))
+            .collect::<Result<_, _>>()
+            .map_err(|e| format!("TLS certificate file '{cert_path}' is not valid PEM: {e}"))?;
     if !cert_items
         .iter()
         .any(|item| matches!(item, rustls_pemfile::Item::X509Certificate(_)))
@@ -134,14 +136,16 @@ fn validate_tls_pem_files(cert_path: &str, key_path: &str) -> Result<(), String>
 
     let key_file = std::fs::File::open(key_path)
         .map_err(|e| format!("Cannot open TLS private key file '{key_path}': {e}"))?;
-    let key_items = rustls_pemfile::read_all(&mut std::io::BufReader::new(key_file))
-        .map_err(|e| format!("TLS private key file '{key_path}' is not valid PEM: {e}"))?;
+    let key_items: Vec<rustls_pemfile::Item> =
+        rustls_pemfile::read_all(&mut std::io::BufReader::new(key_file))
+            .collect::<Result<_, _>>()
+            .map_err(|e| format!("TLS private key file '{key_path}' is not valid PEM: {e}"))?;
     if !key_items.iter().any(|item| {
         matches!(
             item,
-            rustls_pemfile::Item::RSAKey(_)
-                | rustls_pemfile::Item::PKCS8Key(_)
-                | rustls_pemfile::Item::ECKey(_)
+            rustls_pemfile::Item::Pkcs1Key(_)
+                | rustls_pemfile::Item::Pkcs8Key(_)
+                | rustls_pemfile::Item::Sec1Key(_)
         )
     }) {
         return Err(format!(

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -91,6 +91,15 @@ pub struct EventDefinition {
     pub column: usize,
 }
 
+/// TLS settings on a `listen` statement. Both paths `None` means the bare
+/// `secured` form: certificate and key paths come from .wflcfg at runtime
+/// (`web_server_tls_cert_file` / `web_server_tls_key_file`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct TlsListenConfig {
+    pub cert_path: Option<Expression>,
+    pub key_path: Option<Expression>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Statement {
     VariableDeclaration {
@@ -488,6 +497,10 @@ pub enum Statement {
     ListenStatement {
         port: Expression,
         server_name: String,
+        /// `secured [with certificate <expr> and key <expr>]` — HTTPS listener.
+        tls: Option<TlsListenConfig>,
+        /// `redirecting to port <expr>` — native HTTP->HTTPS 301 redirect server.
+        redirect_to_port: Option<Expression>,
         line: usize,
         column: usize,
     },

--- a/src/parser/stmt/web.rs
+++ b/src/parser/stmt/web.rs
@@ -2,10 +2,12 @@
 
 use super::super::{Expression, ParseError, Parser, Statement};
 use crate::lexer::token::Token;
+use crate::parser::ast::TlsListenConfig;
 use crate::parser::expr::{ExprParser, PrimaryExprParser};
 
 pub(crate) trait WebParser<'a>: ExprParser<'a> + PrimaryExprParser<'a> {
     fn parse_listen_statement(&mut self) -> Result<Statement, ParseError>;
+    fn parse_tls_path_value(&mut self, marker: &str) -> Result<Expression, ParseError>;
     fn parse_respond_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_register_signal_handler_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_stop_accepting_connections_statement(&mut self) -> Result<Statement, ParseError>;
@@ -22,8 +24,107 @@ impl<'a> WebParser<'a> for Parser<'a> {
         // Expect "port"
         self.expect_token(Token::KeywordPort, "Expected 'port' after 'listen on'")?;
 
-        // Parse port expression
-        let port = self.parse_expression()?;
+        // Optional clause markers. `secured` and `redirecting` are contextual
+        // identifiers, not keywords, so existing programs can still use them
+        // as variable names. The lexer merges adjacent identifiers, so a
+        // variable port arrives glued to the marker (`my_port secured` lexes
+        // as Identifier("my_port secured")). Detect that BEFORE parsing the
+        // port expression: `with` is a concatenation operator, so
+        // parse_expression would otherwise swallow a following
+        // `with certificate ...` clause into the port expression.
+        let mut marker: Option<&str> = None;
+        let mut merged_port: Option<Expression> = None;
+        if let Some(token) = self.cursor.peek()
+            && let Token::Identifier(id) = &token.token
+        {
+            for candidate in ["secured", "redirecting"] {
+                if let Some(stripped) = id.strip_suffix(&format!(" {candidate}")) {
+                    merged_port = Some(Expression::Variable(
+                        stripped.to_string(),
+                        token.line,
+                        token.column,
+                    ));
+                    marker = Some(candidate);
+                    break;
+                }
+            }
+            if marker.is_some() {
+                self.bump_sync(); // Consume the merged port variable + marker
+            }
+        }
+
+        // Parse port expression (unless already extracted from a merged token)
+        let port = match merged_port {
+            Some(port) => port,
+            None => self.parse_expression()?,
+        };
+        if marker.is_none()
+            && let Some(token) = self.cursor.peek()
+            && let Token::Identifier(id) = &token.token
+        {
+            match id.as_str() {
+                "secured" => {
+                    self.bump_sync();
+                    marker = Some("secured");
+                }
+                "redirecting" => {
+                    self.bump_sync();
+                    marker = Some("redirecting");
+                }
+                _ => {}
+            }
+        }
+
+        let mut tls: Option<TlsListenConfig> = None;
+        let mut redirect_to_port: Option<Expression> = None;
+
+        match marker {
+            Some("secured") => {
+                if let Some(token) = self.cursor.peek()
+                    && token.token == Token::KeywordWith
+                {
+                    // `secured with certificate <expr> and key <expr>`
+                    self.bump_sync(); // Consume "with"
+                    let cert_path = self.parse_tls_path_value("certificate")?;
+                    self.expect_token(
+                        Token::KeywordAnd,
+                        "Expected 'and key ...' after certificate path",
+                    )?;
+                    let key_path = self.parse_tls_path_value("key")?;
+                    tls = Some(TlsListenConfig {
+                        cert_path: Some(cert_path),
+                        key_path: Some(key_path),
+                    });
+                } else {
+                    // Bare `secured` — certificate and key paths come from
+                    // .wflcfg at runtime.
+                    tls = Some(TlsListenConfig {
+                        cert_path: None,
+                        key_path: None,
+                    });
+                }
+
+                // Reject `secured ... redirecting ...` explicitly: a listener
+                // either terminates TLS or redirects to one, never both.
+                if let Some(token) = self.cursor.peek()
+                    && let Token::Identifier(id) = &token.token
+                    && (id == "redirecting" || id.starts_with("redirecting "))
+                {
+                    return Err(ParseError::from_token(
+                        "'secured' and 'redirecting to port' cannot be combined on one listen statement"
+                            .to_string(),
+                        token,
+                    ));
+                }
+            }
+            Some("redirecting") => {
+                self.expect_token(Token::KeywordTo, "Expected 'to' after 'redirecting'")?;
+                self.expect_token(Token::KeywordPort, "Expected 'port' after 'redirecting to'")?;
+                // Primary expression only, so the following "as" stays available.
+                redirect_to_port = Some(self.parse_primary_expression()?);
+            }
+            _ => {}
+        }
 
         // Expect "as"
         self.expect_token(Token::KeywordAs, "Expected 'as' after port")?;
@@ -34,9 +135,54 @@ impl<'a> WebParser<'a> for Parser<'a> {
         Ok(Statement::ListenStatement {
             port,
             server_name,
+            tls,
+            redirect_to_port,
             line: listen_token.line,
             column: listen_token.column,
         })
+    }
+
+    /// Parses `<marker> <expr>` inside a `secured with ...` clause, where
+    /// marker is `certificate` or `key`. The marker is a contextual
+    /// identifier, so a variable value arrives merged with it
+    /// (`certificate cert_path` lexes as Identifier("certificate cert_path"))
+    /// while a string literal follows a lone marker token.
+    fn parse_tls_path_value(&mut self, marker: &str) -> Result<Expression, ParseError> {
+        let Some(token) = self.cursor.peek() else {
+            return Err(ParseError::from_span(
+                format!("Expected '{marker}' followed by a file path, found end of input"),
+                crate::diagnostics::Span { start: 0, end: 0 },
+                0,
+                0,
+            ));
+        };
+
+        if let Token::Identifier(id) = &token.token {
+            if id == marker {
+                self.bump_sync(); // Consume the marker
+                // Primary expression only, so a following "and"/"as" clause
+                // stays available.
+                self.parse_primary_expression()
+            } else if let Some(rest) = id.strip_prefix(&format!("{marker} ")) {
+                let rest = rest.to_string();
+                let (line, column) = (token.line, token.column);
+                self.bump_sync(); // Consume the merged marker + variable
+                Ok(Expression::Variable(rest, line, column))
+            } else {
+                Err(ParseError::from_token(
+                    format!("Expected '{marker}' before file path, found '{id}'"),
+                    token,
+                ))
+            }
+        } else {
+            Err(ParseError::from_token(
+                format!(
+                    "Expected '{marker}' before file path, found {:?}",
+                    token.token
+                ),
+                token,
+            ))
+        }
     }
 
     fn parse_respond_statement(&mut self) -> Result<Statement, ParseError> {

--- a/src/transpiler/javascript.rs
+++ b/src/transpiler/javascript.rs
@@ -1237,15 +1237,23 @@ impl JavaScriptTranspiler {
             Statement::ListenStatement {
                 port,
                 server_name,
+                tls,
+                redirect_to_port,
                 line,
                 column,
-                ..
             } => {
                 self.warn(
                     "Server functionality has limitations: WFL's web server statements are transpiled to basic Node.js http setup. Features like middleware, routing, and request handling require manual implementation in JS",
                     *line,
                     *column,
                 );
+                if tls.is_some() || redirect_to_port.is_some() {
+                    self.warn(
+                        "HTTPS ('secured') and redirect ('redirecting to port') listen options are not supported by the JavaScript transpiler; the generated code uses a plain Node.js http server",
+                        *line,
+                        *column,
+                    );
+                }
                 let port_expr = self.transpile_expression(port)?;
                 Ok(format!(
                     "{}// Note: Basic server setup only - implement request handlers manually\n{}const {} = require('http').createServer(); {}.listen({});\n",

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1809,6 +1809,8 @@ impl TypeChecker {
             Statement::ListenStatement {
                 port,
                 server_name: _server_name,
+                tls,
+                redirect_to_port,
                 line: _line,
                 column: _column,
             } => {
@@ -1824,6 +1826,47 @@ impl TypeChecker {
                         *_line,
                         *_column,
                     );
+                }
+
+                // Certificate and key paths must be text
+                if let Some(tls_config) = tls {
+                    for (path_expr, what) in [
+                        (tls_config.cert_path.as_ref(), "Certificate path"),
+                        (tls_config.key_path.as_ref(), "Key path"),
+                    ] {
+                        if let Some(expr) = path_expr {
+                            let path_type = self.infer_expression_type(expr);
+                            if path_type != Type::Text
+                                && path_type != Type::Unknown
+                                && path_type != Type::Error
+                            {
+                                self.type_error(
+                                    format!("{what} must be text"),
+                                    Some(Type::Text),
+                                    Some(path_type),
+                                    *_line,
+                                    *_column,
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Redirect target must be a number
+                if let Some(target_port) = redirect_to_port {
+                    let target_type = self.infer_expression_type(target_port);
+                    if target_type != Type::Number
+                        && target_type != Type::Unknown
+                        && target_type != Type::Error
+                    {
+                        self.type_error(
+                            "Redirect target port must be a number".to_string(),
+                            Some(Type::Number),
+                            Some(target_type),
+                            *_line,
+                            *_column,
+                        );
+                    }
                 }
             }
             Statement::WaitForRequestStatement {

--- a/src/wfl_config/checker.rs
+++ b/src/wfl_config/checker.rs
@@ -460,6 +460,34 @@ impl ConfigChecker {
             },
         );
 
+        expected_settings.insert(
+            "web_server_tls_cert_file".to_string(),
+            ExpectedSetting {
+                name: "web_server_tls_cert_file".to_string(),
+                config_type: ConfigType::String,
+                required: false,
+                default_value: None,
+                description: "Default TLS certificate file (PEM) for 'listen ... secured'"
+                    .to_string(),
+                valid_values: None,
+                category: "Web Server".to_string(),
+            },
+        );
+
+        expected_settings.insert(
+            "web_server_tls_key_file".to_string(),
+            ExpectedSetting {
+                name: "web_server_tls_key_file".to_string(),
+                config_type: ConfigType::String,
+                required: false,
+                default_value: None,
+                description: "Default TLS private key file (PEM) for 'listen ... secured'"
+                    .to_string(),
+                valid_values: None,
+                category: "Web Server".to_string(),
+            },
+        );
+
         Self { expected_settings }
     }
 

--- a/tests/web_server_tls_parser_test.rs
+++ b/tests/web_server_tls_parser_test.rs
@@ -1,0 +1,296 @@
+// Parser tests for HTTPS/TLS listen syntax:
+//   listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as server
+//   listen on port 8443 secured as server                      (paths from .wflcfg)
+//   listen on port 8080 redirecting to port 8443 as server     (native 301 redirect)
+//   listen on port 8080 as server                              (plain HTTP, unchanged)
+//
+// `secured`, `certificate`, `key`, and `redirecting` are contextual identifiers,
+// NOT reserved keywords — existing programs using them as variable names (e.g.
+// `store key as "secret"` in TestPrograms/hash_security_test.wfl) must keep
+// working. Because the lexer merges adjacent identifiers into one token, the
+// parser must also handle merged forms like Identifier("my_port secured") and
+// Identifier("certificate cert_path").
+
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::parser::ast::{Expression, Literal, Statement};
+
+fn parse_listen(code: &str) -> Statement {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Failed to parse {code:?}: {e:?}"));
+    program
+        .statements
+        .into_iter()
+        .find(|s| matches!(s, Statement::ListenStatement { .. }))
+        .expect("No ListenStatement found")
+}
+
+fn parse_should_fail(code: &str) {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    assert!(parser.parse().is_err(), "Expected parse error for {code:?}");
+}
+
+fn assert_string(expr: &Expression, expected: &str, what: &str) {
+    match expr {
+        Expression::Literal(Literal::String(s), ..) => {
+            assert_eq!(s.as_ref(), expected, "{what} literal mismatch")
+        }
+        other => panic!("{what} should be a string literal, got {other:?}"),
+    }
+}
+
+fn assert_integer(expr: &Expression, expected: i64, what: &str) {
+    match expr {
+        Expression::Literal(Literal::Integer(n), ..) => {
+            assert_eq!(*n, expected, "{what} literal mismatch")
+        }
+        other => panic!("{what} should be an integer literal, got {other:?}"),
+    }
+}
+
+fn assert_variable(expr: &Expression, expected: &str, what: &str) {
+    match expr {
+        Expression::Variable(name, ..) => {
+            assert_eq!(name, expected, "{what} variable name mismatch")
+        }
+        other => panic!("{what} should be a variable, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_plain_listen_unchanged() {
+    let stmt = parse_listen("listen on port 8080 as web_server");
+    match stmt {
+        Statement::ListenStatement {
+            server_name,
+            tls,
+            redirect_to_port,
+            ..
+        } => {
+            assert_eq!(server_name, "web_server");
+            assert!(tls.is_none(), "plain listen must not have TLS config");
+            assert!(redirect_to_port.is_none());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_secured_with_certificate_and_key_literals() {
+    let stmt = parse_listen(
+        r#"listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as secure_server"#,
+    );
+    match stmt {
+        Statement::ListenStatement {
+            port,
+            server_name,
+            tls,
+            redirect_to_port,
+            ..
+        } => {
+            assert_integer(&port, 8443, "port");
+            assert_eq!(server_name, "secure_server");
+            let tls = tls.expect("TLS config missing");
+            assert_string(
+                tls.cert_path.as_ref().expect("cert_path missing"),
+                "cert.pem",
+                "cert_path",
+            );
+            assert_string(
+                tls.key_path.as_ref().expect("key_path missing"),
+                "key.pem",
+                "key_path",
+            );
+            assert!(redirect_to_port.is_none());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_bare_secured_uses_config_paths() {
+    let stmt = parse_listen("listen on port 8443 secured as secure_server");
+    match stmt {
+        Statement::ListenStatement {
+            server_name, tls, ..
+        } => {
+            assert_eq!(server_name, "secure_server");
+            let tls = tls.expect("TLS config missing");
+            assert!(tls.cert_path.is_none(), "bare secured has no cert path");
+            assert!(tls.key_path.is_none(), "bare secured has no key path");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_secured_with_variable_paths_merged_identifiers() {
+    // `certificate cert_path` and `key key_path` lex as single merged
+    // identifiers; the parser must split the marker word off.
+    let stmt = parse_listen(
+        r#"
+store cert_path as "cert.pem"
+store key_path as "key.pem"
+listen on port 8443 secured with certificate cert_path and key key_path as secure_server
+"#,
+    );
+    match stmt {
+        Statement::ListenStatement { tls, .. } => {
+            let tls = tls.expect("TLS config missing");
+            assert_variable(
+                tls.cert_path.as_ref().expect("cert_path missing"),
+                "cert_path",
+                "cert_path",
+            );
+            assert_variable(
+                tls.key_path.as_ref().expect("key_path missing"),
+                "key_path",
+                "key_path",
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_secured_with_variable_port_merged_identifier() {
+    // `my_port secured` lexes as one merged identifier; the parser must split
+    // the trailing marker off the port variable.
+    let stmt = parse_listen(
+        r#"
+store my_port as 8443
+listen on port my_port secured with certificate "cert.pem" and key "key.pem" as secure_server
+"#,
+    );
+    match stmt {
+        Statement::ListenStatement { port, tls, .. } => {
+            assert_variable(&port, "my_port", "port");
+            assert!(tls.is_some(), "TLS config missing");
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_bare_secured_with_variable_port() {
+    let stmt = parse_listen(
+        r#"
+store my_port as 8443
+listen on port my_port secured as secure_server
+"#,
+    );
+    match stmt {
+        Statement::ListenStatement { port, tls, .. } => {
+            assert_variable(&port, "my_port", "port");
+            let tls = tls.expect("TLS config missing");
+            assert!(tls.cert_path.is_none());
+            assert!(tls.key_path.is_none());
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_redirecting_to_port() {
+    let stmt = parse_listen("listen on port 8080 redirecting to port 8443 as redirect_server");
+    match stmt {
+        Statement::ListenStatement {
+            port,
+            server_name,
+            tls,
+            redirect_to_port,
+            ..
+        } => {
+            assert_integer(&port, 8080, "port");
+            assert_eq!(server_name, "redirect_server");
+            assert!(tls.is_none());
+            assert_integer(
+                &redirect_to_port.expect("redirect target missing"),
+                8443,
+                "redirect target port",
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_redirecting_with_variable_port_merged_identifier() {
+    let stmt = parse_listen(
+        r#"
+store http_port as 8080
+store https_port as 8443
+listen on port http_port redirecting to port https_port as redirect_server
+"#,
+    );
+    match stmt {
+        Statement::ListenStatement {
+            port,
+            redirect_to_port,
+            ..
+        } => {
+            assert_variable(&port, "http_port", "port");
+            assert_variable(
+                &redirect_to_port.expect("redirect target missing"),
+                "https_port",
+                "redirect target port",
+            );
+        }
+        _ => unreachable!(),
+    }
+}
+
+#[test]
+fn test_key_still_usable_as_variable_name() {
+    // Backward compatibility: `key` must remain a valid identifier.
+    let code = r#"
+store key as "secret_key_456"
+display key
+"#;
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    parser
+        .parse()
+        .unwrap_or_else(|e| panic!("'key' as a variable must keep parsing: {e:?}"));
+}
+
+#[test]
+fn test_secured_and_certificate_still_usable_as_variable_names() {
+    let code = r#"
+store secured as "yes"
+store certificate as "mycert"
+display secured
+display certificate
+"#;
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    parser.parse().unwrap_or_else(|e| {
+        panic!("'secured'/'certificate' as variables must keep parsing: {e:?}")
+    });
+}
+
+#[test]
+fn test_error_missing_key_clause() {
+    parse_should_fail(r#"listen on port 8443 secured with certificate "cert.pem" as s"#);
+}
+
+#[test]
+fn test_error_key_without_certificate() {
+    parse_should_fail(r#"listen on port 8443 secured with key "key.pem" as s"#);
+}
+
+#[test]
+fn test_error_redirecting_without_port_keyword() {
+    parse_should_fail("listen on port 8080 redirecting to 8443 as s");
+}
+
+#[test]
+fn test_error_secured_and_redirecting_combined() {
+    parse_should_fail(
+        r#"listen on port 8080 secured with certificate "c.pem" and key "k.pem" redirecting to port 8443 as s"#,
+    );
+}

--- a/tests/web_server_tls_test.rs
+++ b/tests/web_server_tls_test.rs
@@ -5,7 +5,7 @@
 //
 // Self-signed certificates are generated per test with rcgen (localhost +
 // 127.0.0.1 SANs); reqwest clients accept them via
-// danger_accept_invalid_certs. Ports 8210-8216 (the bind-address tests use
+// danger_accept_invalid_certs. Ports 8210-8219 (the bind-address tests use
 // 8200-8203).
 
 use std::sync::Arc;
@@ -27,9 +27,12 @@ fn write_self_signed_cert(dir: &std::path::Path) -> (String, String) {
     std::fs::write(&cert_path, certified.cert.pem()).expect("Failed to write cert.pem");
     std::fs::write(&key_path, certified.key_pair.serialize_pem()).expect("Failed to write key.pem");
 
+    // Forward slashes: these paths are embedded in WFL string literals, and
+    // Windows backslashes would be rejected by the WFL lexer. Windows file
+    // APIs accept forward-slash paths.
     (
-        cert_path.to_string_lossy().into_owned(),
-        key_path.to_string_lossy().into_owned(),
+        cert_path.to_string_lossy().replace('\\', "/"),
+        key_path.to_string_lossy().replace('\\', "/"),
     )
 }
 
@@ -228,6 +231,24 @@ async fn test_bare_secured_without_config_is_actionable_error() {
     assert!(
         message.contains("web_server_tls_cert_file"),
         "Error should point at the .wflcfg settings, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_out_of_range_redirect_target_port_is_error() {
+    let code = r#"listen on port 8219 redirecting to port 0 as bad_redirect"#;
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser.parse().expect("Failed to parse");
+
+    let mut interpreter = Interpreter::with_config(Arc::new(WflConfig::default()));
+    let result = interpreter.interpret(&ast).await;
+
+    let errors = result.expect_err("Out-of-range redirect target port should be a runtime error");
+    let message = format!("{errors:?}");
+    assert!(
+        message.contains("between 1 and 65535"),
+        "Error should explain the valid port range, got: {message}"
     );
 }
 

--- a/tests/web_server_tls_test.rs
+++ b/tests/web_server_tls_test.rs
@@ -1,0 +1,277 @@
+// Integration tests for HTTPS/TLS web server support:
+//   listen on port N secured with certificate "..." and key "..." as server
+//   listen on port N secured as server           (paths from config)
+//   listen on port N redirecting to port M as server
+//
+// Self-signed certificates are generated per test with rcgen (localhost +
+// 127.0.0.1 SANs); reqwest clients accept them via
+// danger_accept_invalid_certs. Ports 8210-8216 (the bind-address tests use
+// 8200-8203).
+
+use std::sync::Arc;
+use std::time::Duration;
+use wfl::Interpreter;
+use wfl::config::WflConfig;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+/// Writes a fresh self-signed certificate + key pair into `dir` and returns
+/// their paths.
+fn write_self_signed_cert(dir: &std::path::Path) -> (String, String) {
+    let certified =
+        rcgen::generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("Failed to generate self-signed certificate");
+
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+    std::fs::write(&cert_path, certified.cert.pem()).expect("Failed to write cert.pem");
+    std::fs::write(&key_path, certified.key_pair.serialize_pem()).expect("Failed to write key.pem");
+
+    (
+        cert_path.to_string_lossy().into_owned(),
+        key_path.to_string_lossy().into_owned(),
+    )
+}
+
+/// Runs a WFL program in its own thread + runtime, like the bind-address tests.
+fn start_server_with_config(code: String, config: WflConfig) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("Failed to parse WFL code");
+            let mut interpreter = Interpreter::with_config(Arc::new(config));
+            let _ = interpreter.interpret(&ast).await;
+        });
+    })
+}
+
+fn insecure_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("Failed to build client")
+}
+
+#[tokio::test]
+async fn test_https_server_serves_requests() {
+    let port = 8210;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) = write_self_signed_cert(temp_dir.path());
+
+    let server_code = format!(
+        r#"
+        listen on port {port} secured with certificate "{cert_path}" and key "{key_path}" as secure_server
+        wait for request comes in on secure_server as req with timeout 5000
+        respond to req with "Hello over HTTPS"
+        close server secure_server
+    "#
+    );
+
+    let server_handle = start_server_with_config(server_code, WflConfig::default());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = insecure_client()
+        .get(format!("https://127.0.0.1:{port}/"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await;
+
+    let response = response.expect("HTTPS request to secured server should succeed");
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.text().await.unwrap(), "Hello over HTTPS");
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_plain_http_to_tls_port_fails() {
+    let port = 8211;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) = write_self_signed_cert(temp_dir.path());
+
+    let server_code = format!(
+        r#"
+        listen on port {port} secured with certificate "{cert_path}" and key "{key_path}" as secure_server
+        wait for request comes in on secure_server as req with timeout 3000
+        respond to req with "unreachable"
+        close server secure_server
+    "#
+    );
+
+    let server_handle = start_server_with_config(server_code, WflConfig::default());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = insecure_client()
+        .get(format!("http://127.0.0.1:{port}/"))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await;
+
+    assert!(
+        response.is_err(),
+        "Plain HTTP request to a TLS port should fail"
+    );
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_redirect_server_returns_301_with_location() {
+    let http_port = 8212;
+    let https_port = 8213;
+
+    // The redirect is answered natively by the server, so the program never
+    // sees a request; the timed-out wait just keeps the server alive long
+    // enough for the test to hit it.
+    let server_code = format!(
+        r#"
+        listen on port {http_port} redirecting to port {https_port} as redirect_server
+        wait for request comes in on redirect_server as req with timeout 4000
+        close server redirect_server
+    "#
+    );
+
+    let server_handle = start_server_with_config(server_code, WflConfig::default());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = insecure_client()
+        .get(format!("http://127.0.0.1:{http_port}/some/path?x=1&y=2"))
+        .timeout(Duration::from_secs(2))
+        .send()
+        .await
+        .expect("Redirect server should answer");
+
+    assert_eq!(response.status(), 301, "Expected 301 Moved Permanently");
+    let location = response
+        .headers()
+        .get("location")
+        .expect("Location header missing")
+        .to_str()
+        .unwrap();
+    assert_eq!(
+        location,
+        format!("https://127.0.0.1:{https_port}/some/path?x=1&y=2"),
+        "Location should preserve host, path and query, swapping scheme and port"
+    );
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_bare_secured_uses_config_paths() {
+    let port = 8214;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) = write_self_signed_cert(temp_dir.path());
+
+    let server_code = format!(
+        r#"
+        listen on port {port} secured as secure_server
+        wait for request comes in on secure_server as req with timeout 5000
+        respond to req with "Config-driven TLS"
+        close server secure_server
+    "#
+    );
+
+    let config = WflConfig {
+        web_server_tls_cert_file: Some(cert_path),
+        web_server_tls_key_file: Some(key_path),
+        ..Default::default()
+    };
+    let server_handle = start_server_with_config(server_code, config);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let response = insecure_client()
+        .get(format!("https://127.0.0.1:{port}/"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .expect("HTTPS request using config-supplied cert should succeed");
+    assert_eq!(response.text().await.unwrap(), "Config-driven TLS");
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_missing_certificate_file_is_actionable_error() {
+    let code = r#"listen on port 8217 secured with certificate "/nonexistent/cert.pem" and key "/nonexistent/key.pem" as secure_server"#;
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser.parse().expect("Failed to parse");
+
+    let mut interpreter = Interpreter::with_config(Arc::new(WflConfig::default()));
+    let result = interpreter.interpret(&ast).await;
+
+    let errors = result.expect_err("Missing certificate file should be a runtime error");
+    let message = format!("{errors:?}");
+    assert!(
+        message.contains("/nonexistent/cert.pem"),
+        "Error should name the missing certificate file, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_bare_secured_without_config_is_actionable_error() {
+    let code = r#"listen on port 8218 secured as secure_server"#;
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser.parse().expect("Failed to parse");
+
+    // Default config has no TLS paths
+    let mut interpreter = Interpreter::with_config(Arc::new(WflConfig::default()));
+    let result = interpreter.interpret(&ast).await;
+
+    let errors = result.expect_err("Bare 'secured' without config paths should error");
+    let message = format!("{errors:?}");
+    assert!(
+        message.contains("web_server_tls_cert_file"),
+        "Error should point at the .wflcfg settings, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn test_dual_http_and_https_servers() {
+    let http_port = 8215;
+    let https_port = 8216;
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (cert_path, key_path) = write_self_signed_cert(temp_dir.path());
+
+    let server_code = format!(
+        r#"
+        listen on port {http_port} as http_server
+        listen on port {https_port} secured with certificate "{cert_path}" and key "{key_path}" as secure_server
+        wait for request comes in on http_server as req with timeout 5000
+        respond to req with "HTTP OK"
+        wait for request comes in on secure_server as req2 with timeout 5000
+        respond to req2 with "HTTPS OK"
+        close server http_server
+        close server secure_server
+    "#
+    );
+
+    let server_handle = start_server_with_config(server_code, WflConfig::default());
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let client = insecure_client();
+
+    // The program serves one request per server, HTTP first.
+    let http_response = client
+        .get(format!("http://127.0.0.1:{http_port}/"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .expect("HTTP server should answer");
+    assert_eq!(http_response.text().await.unwrap(), "HTTP OK");
+
+    let https_response = client
+        .get(format!("https://127.0.0.1:{https_port}/"))
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+        .expect("HTTPS server should answer");
+    assert_eq!(https_response.text().await.unwrap(), "HTTPS OK");
+
+    let _ = server_handle.join();
+}


### PR DESCRIPTION
## Summary

This PR adds full HTTPS/TLS support to WFL's built-in web server, enabling secure connections without requiring a reverse proxy. Three new optional clauses extend the `listen` statement:

1. **Explicit certificate paths**: `listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as server`
2. **Config-driven paths**: `listen on port 8443 secured as server` (reads from `.wflcfg`)
3. **HTTP→HTTPS redirect**: `listen on port 8080 redirecting to port 8443 as server`

## Key Changes

### Parser & AST
- Extended `ListenStatement` with optional `tls: Option<TlsListenConfig>` and `redirect_to_port: Option<Expression>` fields
- Added `TlsListenConfig` struct to hold certificate and key path expressions
- Implemented contextual identifier parsing for `secured`, `certificate`, `key`, and `redirecting` (not reserved keywords, preserving backward compatibility)
- Handled lexer's multi-word identifier merging (e.g., `port my_port secured` → `Identifier("my_port secured")`) by detecting and splitting these tokens before expression parsing

### Interpreter
- Added `strip_host_port()` helper to extract hostname from Host header while preserving IPv6 brackets
- Added `validate_tls_pem_files()` to validate certificate/key files at startup with actionable error messages
- Implemented TLS server initialization using `warp` with `tokio-rustls`
- Implemented redirect server that answers all requests with `301 Moved Permanently`, preserving path and query string while swapping scheme and port
- Redirect servers register like normal servers (enabling `close server`) but never feed their request channels

### Configuration
- Added `web_server_tls_cert_file` and `web_server_tls_key_file` to `WflConfig`
- Config values only apply to bare `secured` form; explicit paths in code always win
- Plain `listen` statements never become HTTPS via config (prevents silent conversion of HTTP servers)

### Type Checking & Analysis
- Added type validation for certificate/key path expressions (must be `Text`)
- Added type validation for redirect target port (must be `Number`)

### Documentation & Testing
- Added comprehensive HTTPS section to web server documentation with examples
- Added parser tests (`web_server_tls_parser_test.rs`) covering all syntax variants and merged identifier handling
- Added integration tests (`web_server_tls_test.rs`) with self-signed certificates via `rcgen`
- Added example program (`TestPrograms/web_server_tls.wfl`)
- Updated configuration reference and keyword documentation
- Added dev diary entry explaining design decisions

### Build & Scripts
- Updated `Cargo.toml` to enable `warp` TLS feature (adds `tokio-rustls` 0.24 → `rustls` 0.21, coexisting with existing `rustls` 0.23)
- Updated web test scripts (`run_web_tests.ps1` and `.sh`) to generate self-signed certificates and test HTTPS functionality

## Notable Implementation Details

**No new keywords**: `secured`, `certificate`, `key`, and `redirecting` are plain identifiers matched positionally by the parser. This preserves backward compatibility with existing programs that use these words as variable names (e.g., `store key as "secret"`).

**Merged identifier handling**: The lexer fuses adjacent identifiers into single tokens. The parser detects and splits these *before* parsing port expressions, since `with` is a concatenation operator and would otherwise be absorbed into the expression.

**Redirect server design**: Redirect servers answer requests natively without reaching the WFL request loop, so `wait for request` on a redirect server times out. This is intentional—the server exists solely to redirect traffic.

**Config precedence**: TLS intent always lives in the program; `.wflcfg` only supplies defaults for the bare `secured` form. This prevents silent HTTPS conversion when running dual HTTP/HTTPS setups.

https://claude.ai/code/session_01Vs7eRcLpvVztrNXLWo5GND

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPS/TLS for web server listeners via `listen ... secured`, with optional HTTP→HTTPS `301` redirects via `listen ... redirecting`.
  * Added configuration defaults for TLS certificate/key paths used by bare `secured` listeners.
  * Support for running HTTP and HTTPS listeners side by side.
* **Bug Fixes**
  * Improved TLS file validation at startup with clearer, actionable error reporting.
  * Redirects preserve the original path and query while switching to the HTTPS target.
* **Documentation**
  * Expanded web server and configuration references with HTTPS/TLS and redirect examples, plus clarification on TLS “marker words” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->