### PR TITLE
Port rust_loc_counter.py to WFL with format_number stdlib function

### DIFF
--- a/Docs/03-language-basics/variables-and-types.md
+++ b/Docs/03-language-basics/variables-and-types.md
@@ -239,6 +239,8 @@ Every script starts with a few variables defined by the runtime:
 - `script_path` - the absolute path of the running script file
 - `script_directory` - the absolute directory containing the running script
 
+When no script file is running (for example in the REPL or an embedded interpreter), `script_path` and `script_directory` are empty text (`""`) instead of absolute paths - check for empty text before relying on them in code that may run outside a script file.
+
 `script_path` and `script_directory` are handy for locating files relative to the script itself, no matter which directory it is launched from:
 
 ```wfl

--- a/Docs/03-language-basics/variables-and-types.md
+++ b/Docs/03-language-basics/variables-and-types.md
@@ -227,6 +227,25 @@ end action
 call use global                    // Output: 100
 ```
 
+### Runtime-Provided Globals
+
+Every script starts with a few variables defined by the runtime:
+
+- `args` - list of command-line arguments passed after the script name
+- `arg_count` - how many arguments were passed
+- `positional_args` - arguments that are not `--flag` style options
+- `program_name` - the file name of the running script
+- `current_directory` - the directory the script was launched from
+- `script_path` - the absolute path of the running script file
+- `script_directory` - the absolute directory containing the running script
+
+`script_path` and `script_directory` are handy for locating files relative to the script itself, no matter which directory it is launched from:
+
+```wfl
+store data_dir as path_join of script_directory and "data"
+display "Data lives in: " with data_dir
+```
+
 ### Local Scope (Actions)
 
 Variables inside actions are local to that action:

--- a/Docs/05-standard-library/text-module.md
+++ b/Docs/05-standard-library/text-module.md
@@ -393,6 +393,45 @@ store directories as split of path by "/"
 
 ---
 
+### format_number
+
+**Purpose:** Format a number as text with a fixed number of decimal places.
+
+**Signature:**
+```wfl
+format_number of <number> and <precision>
+```
+
+**Parameters:**
+- `number` (Number): The value to format (must be finite)
+- `precision` (Number): How many decimal places to keep (a whole number from 0 to 17)
+
+**Returns:** Text - The value rounded to `precision` decimal places, always showing exactly that many digits
+
+**Example:**
+```wfl
+store ratio as 2 divided by 3
+display "Two thirds: " with format_number of ratio and 2
+display "Whole percent: " with format_number of 45 and 1
+```
+
+**Output:**
+```
+Two thirds: 0.67
+Whole percent: 45.0
+```
+
+**Notes:**
+- Unlike plain `display` (which prints `45` for the number `45.0`), the result always keeps the requested number of decimals - useful for aligned reports and percentages.
+- Rounding is round-half-to-even on the underlying binary value, matching Python's `f"{x:.Nf}"` formatting.
+
+**Use Cases:**
+- Percentages in reports
+- Currency-style output
+- Aligned numeric columns
+
+---
+
 ## Complete Example
 
 Using all text functions together:

--- a/Tools/rust_loc_counter.wfl
+++ b/Tools/rust_loc_counter.wfl
@@ -1,329 +1,477 @@
 // Rust Line Counter - WFL Implementation
-// Analyzes Rust source files and generates line count statistics
-// 
-// This is a WebFirst Language implementation of the rust_loc_counter.py tool
-// It recursively scans .rs files and provides accurate counts of:
-// - Total lines
-// - Code lines  
-// - Comment lines
-// - Blank lines
 //
-// Usage: wfl rust_loc_counter.wfl [directory]
-// Default directory: ./src
+// A 1:1 port of Tools/rust_loc_counter.py: given the same source tree it
+// produces byte-identical output, both the report printed to stdout and the
+// markdown report written to ../Docs/rust_loc_report.md (only the embedded
+// wall-clock timestamps differ between runs).
+//
+// Like the Python script, it scans <script dir>/../src for .rs files and
+// categorizes each line as code, comment, or blank.
+//
+// Usage: wfl Tools/rust_loc_counter.wfl
 
-// Function to check if a line is blank (empty or only whitespace)
-define action called is_blank_line with line:
-    store trimmed as line
-    // WFL doesn't have trim, so check if empty
-    check if length of line is 0:
-        return true
+// Emulates Python's s.split(needle, 1)[1]: everything after the first
+// occurrence of needle. Callers only use it when needle is present.
+define action called after_first with fx_text and fx_needle:
+    store fx_found_at as index_of of fx_text and fx_needle
+    check if fx_found_at is less than 0:
+        return ""
     end check
-    return false
+    store fx_start as fx_found_at plus length of fx_needle
+    store fx_total_len as length of fx_text
+    return substring of fx_text and fx_start and fx_total_len
 end action
 
-// Function to check if a line starts with a single-line comment
-define action called is_single_line_comment with line:
-    // Check if line starts with //
-    check if length of line is greater than 1:
-        store first_two as line[0] with line[1]
-        check if first_two is "//":
-            return true
+// Counts lines in one Rust file, mirroring count_lines_in_file() in the
+// Python script branch for branch (including its quirks, e.g. a line that
+// starts with "/*" counts as a comment even when code follows "*/").
+// Returns [total, code, comments, blank]; [0, 0, 0, 0] on read errors.
+define action called analyze_rust_file with af_path:
+    store af_stats as []
+    try:
+        open file at af_path for reading as af_handle
+        wait for store af_content as read content from af_handle
+        close file af_handle
+
+        store af_total as 0
+        store af_code as 0
+        store af_comments as 0
+        store af_blank as 0
+        store af_in_block as false
+
+        check if af_content is not "":
+            store af_raw_lines as split af_content by "\n"
+            store af_line_count as length of af_raw_lines
+            // Python's file iteration yields no trailing empty line when the
+            // file ends with a newline, but split does - drop it.
+            store af_ends_nl as ends_with of af_content and "\n"
+            check if af_ends_nl is true:
+                change af_line_count to af_line_count minus 1
+            end check
+
+            store af_index as 0
+            repeat while af_index is less than af_line_count:
+                store af_raw_line as af_raw_lines[af_index]
+                store af_line as trim of af_raw_line
+                change af_total to af_total plus 1
+
+                store af_starts_block as starts_with of af_line and "/*"
+                store af_starts_line as starts_with of af_line and "//"
+
+                check if af_line is "":
+                    change af_blank to af_blank plus 1
+                otherwise check if af_in_block is true:
+                    change af_comments to af_comments plus 1
+                    store af_has_close as contains of af_line and "*/"
+                    check if af_has_close is true:
+                        change af_in_block to false
+                        store af_after_raw as call after_first with af_line and "*/"
+                        store af_after as trim of af_after_raw
+                        check if af_after is not "":
+                            store af_after_comment as starts_with of af_after and "//"
+                            check if af_after_comment is false:
+                                change af_code to af_code plus 1
+                            end check
+                        end check
+                    end check
+                otherwise check if af_starts_block is true:
+                    change af_comments to af_comments plus 1
+                    store af_same_close as contains of af_line and "*/"
+                    check if af_same_close is false:
+                        change af_in_block to true
+                    end check
+                otherwise check if af_starts_line is true:
+                    change af_comments to af_comments plus 1
+                otherwise:
+                    change af_code to af_code plus 1
+                    store af_open_at as index_of of af_line and "/*"
+                    check if af_open_at is greater than or equal to 0:
+                        store af_line_len as length of af_line
+                        store af_tail as substring of af_line and af_open_at and af_line_len
+                        store af_tail_close as contains of af_tail and "*/"
+                        check if af_tail_close is false:
+                            change af_in_block to true
+                        end check
+                    end check
+                end check
+
+                change af_index to af_index plus 1
+            end repeat
         end check
-    end check
-    return false
+
+        push with af_stats and af_total
+        push with af_stats and af_code
+        push with af_stats and af_comments
+        push with af_stats and af_blank
+    when error:
+        display "Error processing " with af_path
+        push with af_stats and 0
+        push with af_stats and 0
+        push with af_stats and 0
+        push with af_stats and 0
+    end try
+    return af_stats
 end action
 
-// Function to analyze a single Rust file
-define action called analyze_rust_file with file_path:
-    store stats as []
-    
-    try:
-        // Get total line count
-        store total_lines as count_lines of file_path
-        
-        // Read file content to analyze each line
-        open file at file_path for reading as rust_file
-        wait for store file_content as read content from rust_file
-        close file rust_file
-        
-        // Split content into lines
-        store lines as split file_content by "\n"
-        
-        // Initialize counters
-        store code_lines as 0
-        store comment_lines as 0
-        store blank_lines as 0
-        store in_block_comment as false
-        
-        // Process each line
-        for each line in lines:
-            store is_blank as true
-            store is_comment as false
-            store is_code as false
-            
-            // Check if line has any non-whitespace content
-            check if length of line is greater than 0:
-                store is_blank as false
-                
-                // Handle block comments
-                check if in_block_comment is true:
-                    add 1 to comment_lines
-                    store is_comment as true
-                    
-                    // Check for end of block comment
-                    store has_end as contains of line and "*/"
-                    check if has_end is true:
-                        change in_block_comment to false
-                        
-                        // Check if there's code after the block comment
-                        store parts as split line by "*/"
-                        check if length of parts is greater than 1:
-                            store after_comment as parts[1]
-                            check if length of after_comment is greater than 0:
-                                // Check if it's not another comment
-                                store is_comment_after as is_single_line_comment with after_comment
-                                check if is_comment_after is false:
-                                    add 1 to code_lines
-                                    store is_code as true
-                                end check
-                            end check
-                        end check
-                    end check
-                else:
-                    // Check for start of block comment
-                    store has_start as contains of line and "/*"
-                    check if has_start is true:
-                        add 1 to comment_lines
-                        store is_comment as true
-                        
-                        // Check if block comment ends on same line
-                        store has_end_same as contains of line and "*/"
-                        check if has_end_same is false:
-                            change in_block_comment to true
-                        end check
-                    else:
-                        // Check for single-line comment
-                        store is_single_comment as is_single_line_comment with line
-                        check if is_single_comment is true:
-                            add 1 to comment_lines
-                            store is_comment as true
-                        else:
-                            // Skip truly empty lines
-                            store trimmed_line as line
-                            store i as 0
-                            store has_content as false
-                            
-                            count from 0 to length of line:
-                                store char as line[i]
-                                check if char is not " ":
-                                    check if char is not "\t":
-                                        change has_content to true
-                                    end check
-                                end check
-                                add 1 to i
-                            end count
-                            
-                            check if has_content is true:
-                                add 1 to code_lines
-                                store is_code as true
-                            else:
-                                add 1 to blank_lines
-                                store is_blank as true
-                            end check
-                        end check
-                    end check
-                end check
-            else:
-                add 1 to blank_lines
+// Recursive replica of os.walk(topdown): the current directory's .rs files
+// first (in raw readdir order, same as os.scandir), then each subdirectory
+// in that same order. ws_rel tracks the path key relative to the repo root
+// ("src/...") exactly as the Python script's os.path.relpath produces it.
+define action called walk_src with ws_abs and ws_rel and ws_sink:
+    store ws_entries as list_dir of ws_abs
+    for each ws_entry in ws_entries:
+        store ws_full as path_join of ws_abs and ws_entry
+        store ws_entry_is_dir as is_dir of ws_full
+        check if ws_entry_is_dir is false:
+            store ws_is_rust as ends_with of ws_entry and ".rs"
+            check if ws_is_rust is true:
+                store ws_key as ws_rel with "/" with ws_entry
+                store ws_stats as call analyze_rust_file with ws_full
+                store ws_row as []
+                push with ws_row and ws_key
+                push with ws_row and ws_stats[0]
+                push with ws_row and ws_stats[1]
+                push with ws_row and ws_stats[2]
+                push with ws_row and ws_stats[3]
+                push with ws_sink and ws_row
             end check
-        end for
-        
-        // Return statistics as a list
-        add total_lines to stats
-        add code_lines to stats
-        add comment_lines to stats
-        add blank_lines to stats
-        
-    when error:
-        display "Error analyzing file: " with file_path
-        add 0 to stats
-        add 0 to stats
-        add 0 to stats
-        add 0 to stats
-    end try
-    
-    return stats
-end action
-
-// Main action to run the line counter
-define action called run_rust_loc_counter with target_dir:
-    display "=========================================="
-    display "RUST CODE LINE COUNT REPORT"
-    display "Target directory: " with target_dir
-    display "=========================================="
-    display ""
-    
-    // Initialize totals
-    store total_files as 0
-    store total_lines as 0
-    store total_code as 0
-    store total_comments as 0  
-    store total_blank as 0
-    
-    // Store file statistics
-    store file_stats as []
-    
-    // Get all files in the directory
-    try:
-        wait for store all_files as list files recursively in target_dir
-        
-        // Process each .rs file
-        for each file_path in all_files:
-            store has_rs as contains of file_path and ".rs"
-            check if has_rs is true:
-                // Make sure it ends with .rs
-                store path_length as length of file_path
-                check if path_length is greater than 3:
-                    store last_three as file_path[path_length - 3] with file_path[path_length - 2] with file_path[path_length - 1]
-                    check if last_three is ".rs":
-                        add 1 to total_files
-                        
-                        // Analyze the file
-                        store file_result as analyze_rust_file with file_path
-                        
-                        // Extract statistics
-                        store file_total as file_result[0]
-                        store file_code as file_result[1]
-                        store file_comments as file_result[2]
-                        store file_blank as file_result[3]
-                        
-                        // Update totals
-                        add file_total to total_lines
-                        add file_code to total_code
-                        add file_comments to total_comments
-                        add file_blank to total_blank
-                        
-                        // Store for detailed report
-                        store file_info as []
-                        add file_path to file_info
-                        add file_total to file_info
-                        add file_code to file_info
-                        add file_comments to file_info
-                        add file_blank to file_info
-                        add file_info to file_stats
-                        
-                        display "Processed: " with file_path with " (" with file_total with " lines)"
-                    end check
-                end check
-            end check
-        end for
-        
-    when error:
-        display "Error listing files in: " with target_dir
-    end try
-    
-    // Calculate percentages
-    store code_percent as 0
-    store comment_percent as 0
-    store blank_percent as 0
-    
-    check if total_lines is greater than 0:
-        store code_percent as total_code
-        multiply code_percent by 100
-        divide code_percent by total_lines
-        
-        store comment_percent as total_comments
-        multiply comment_percent by 100
-        divide comment_percent by total_lines
-        
-        store blank_percent as total_blank
-        multiply blank_percent by 100
-        divide blank_percent by total_lines
-    end check
-    
-    // Display overall statistics
-    display ""
-    display "OVERALL STATISTICS:"
-    display "Total files processed: " with total_files
-    display "Total lines: " with total_lines
-    display "Code lines: " with total_code with " (" with code_percent with "%)"
-    display "Comment lines: " with total_comments with " (" with comment_percent with "%)"
-    display "Blank lines: " with total_blank with " (" with blank_percent with "%)"
-    
-    // Display detailed file statistics
-    display ""
-    display "LINES BY FILE:"
-    display "File                                              Total      Code       Comments   Blank"
-    display "-------------------------------------------------------------------------"
-    
-    for each file_info in file_stats:
-        store file_name as file_info[0]
-        store file_total as file_info[1]
-        store file_code as file_info[2]
-        store file_comments as file_info[3]
-        store file_blank as file_info[4]
-        
-        // Format output (simplified due to WFL limitations)
-        display file_name with "  " with file_total with "  " with file_code with "  " with file_comments with "  " with file_blank
+        end check
     end for
-    
-    // Generate markdown report
-    display ""
-    display "Generating markdown report..."
-    
-    try:
-        store markdown_report as "# Rust Code Line Count Report
-
-*Generated by WFL Rust Line Counter*
-
-## Overall Statistics
-
-- **Total files processed:** "
-        change markdown_report to markdown_report with total_files with "
-- **Total lines:** " with total_lines with "
-- **Code lines:** " with total_code with " (" with code_percent with "%)
-- **Comment lines:** " with total_comments with " (" with comment_percent with "%)
-- **Blank lines:** " with total_blank with " (" with blank_percent with "%)
-
-## Lines by File
-
-| File | Total | Code | Comments | Blank |
-| ---- | ----- | ---- | -------- | ----- |
-"
-        
-        // Add file entries to markdown
-        for each file_info in file_stats:
-            store file_name as file_info[0]
-            store file_total as file_info[1]
-            store file_code as file_info[2]
-            store file_comments as file_info[3]
-            store file_blank as file_info[4]
-            
-            change markdown_report to markdown_report with "| " with file_name with " | " with file_total with " | " with file_code with " | " with file_comments with " | " with file_blank with " |
-"
-        end for
-        
-        change markdown_report to markdown_report with "
-
----
-_Generated by WFL Rust Line Counter_
-"
-        
-        // Write markdown report
-        open file at "./Docs/rust_loc_report.md" for writing as md_file
-        wait for write content markdown_report into md_file
-        close file md_file
-        
-        display "✓ Markdown report written to ./Docs/rust_loc_report.md"
-        
-    when error:
-        display "✗ Could not write markdown report"
-    end try
-    
-    return "Analysis complete: " with total_files with " files, " with total_lines with " total lines"
+    for each ws_entry2 in ws_entries:
+        store ws_full2 as path_join of ws_abs and ws_entry2
+        store ws_dir_check as is_dir of ws_full2
+        check if ws_dir_check is true:
+            store ws_child_rel as ws_rel with "/" with ws_entry2
+            call walk_src with ws_full2 and ws_child_rel and ws_sink
+        end check
+    end for
 end action
 
-// Run the line counter on the src directory by default
-store result as run_rust_loc_counter with "./src"
+// Stable descending sort by the numeric second element of each row,
+// equivalent to Python's sorted(items, key=lambda x: x[1][0], reverse=True):
+// rows with equal totals keep their insertion order.
+define action called stable_sort_desc with sb_entries:
+    store sb_sorted as []
+    for each sb_candidate in sb_entries:
+        store sb_rebuilt as []
+        store sb_inserted as false
+        for each sb_existing in sb_sorted:
+            check if sb_inserted is false:
+                check if sb_existing[1] is less than sb_candidate[1]:
+                    push with sb_rebuilt and sb_candidate
+                    change sb_inserted to true
+                end check
+            end check
+            push with sb_rebuilt and sb_existing
+        end for
+        check if sb_inserted is false:
+            push with sb_rebuilt and sb_candidate
+        end check
+        change sb_sorted to sb_rebuilt
+    end for
+    return sb_sorted
+end action
+
+// Emulates Python's str.split() with no arguments for the space-separated
+// header lines: split on spaces and drop the empty pieces.
+define action called split_ws with sw_text:
+    store sw_pieces as split sw_text by " "
+    store sw_words as []
+    for each sw_piece in sw_pieces:
+        check if sw_piece is not "":
+            push with sw_words and sw_piece
+        end check
+    end for
+    return sw_words
+end action
+
+// Builds the plain-text report, mirroring generate_report() in the Python
+// script line by line.
+define action called build_report with br_files and br_dirs and br_totals:
+    store br_lines as []
+    store br_eq as "================================================================================"
+    store br_dash as "--------------------------------------------------------------------------------"
+
+    push with br_lines and br_eq
+    push with br_lines and "RUST CODE LINE COUNT REPORT"
+    store br_stamp as format_datetime of datetime_now and "%Y-%m-%d %H:%M:%S"
+    store br_gen as "Generated on: " with br_stamp
+    push with br_lines and br_gen
+    push with br_lines and br_eq
+
+    store br_file_count as br_totals[0]
+    store br_sum_total as br_totals[1]
+    store br_sum_code as br_totals[2]
+    store br_sum_comments as br_totals[3]
+    store br_sum_blank as br_totals[4]
+
+    // Percentages use the same operation order as the Python f-strings:
+    // (part / total) * 100, then one-decimal formatting.
+    store br_code_ratio as br_sum_code divided by br_sum_total
+    store br_code_pct as br_code_ratio times 100
+    store br_code_pct_text as format_number of br_code_pct and 1
+    store br_comment_ratio as br_sum_comments divided by br_sum_total
+    store br_comment_pct as br_comment_ratio times 100
+    store br_comment_pct_text as format_number of br_comment_pct and 1
+    store br_blank_ratio as br_sum_blank divided by br_sum_total
+    store br_blank_pct as br_blank_ratio times 100
+    store br_blank_pct_text as format_number of br_blank_pct and 1
+
+    push with br_lines and ""
+    push with br_lines and "OVERALL STATISTICS:"
+    store br_files_line as "Total files processed: " with br_file_count
+    push with br_lines and br_files_line
+    store br_total_line as "Total lines: " with br_sum_total
+    push with br_lines and br_total_line
+    store br_code_line as "Code lines: " with br_sum_code with " (" with br_code_pct_text with "%)"
+    push with br_lines and br_code_line
+    store br_comment_line as "Comment lines: " with br_sum_comments with " (" with br_comment_pct_text with "%)"
+    push with br_lines and br_comment_line
+    store br_blank_line as "Blank lines: " with br_sum_blank with " (" with br_blank_pct_text with "%)"
+    push with br_lines and br_blank_line
+
+    push with br_lines and ""
+    push with br_lines and "LINES BY DIRECTORY:"
+    store br_h0 as padright of "Directory" and 40
+    store br_h1 as padright of "Total" and 10
+    store br_h2 as padright of "Code" and 10
+    store br_h3 as padright of "Comments" and 10
+    store br_h4 as padright of "Blank" and 10
+    store br_header as br_h0 with " " with br_h1 with " " with br_h2 with " " with br_h3 with " " with br_h4
+    push with br_lines and br_header
+    push with br_lines and br_dash
+
+    for each br_dir_row in br_dirs:
+        store br_d_name as padright of br_dir_row[0] and 40
+        store br_d_total_text as "" with br_dir_row[1]
+        store br_d_total as padright of br_d_total_text and 10
+        store br_d_code_text as "" with br_dir_row[2]
+        store br_d_code as padright of br_d_code_text and 10
+        store br_d_comments_text as "" with br_dir_row[3]
+        store br_d_comments as padright of br_d_comments_text and 10
+        store br_d_blank_text as "" with br_dir_row[4]
+        store br_d_blank as padright of br_d_blank_text and 10
+        store br_d_line as br_d_name with " " with br_d_total with " " with br_d_code with " " with br_d_comments with " " with br_d_blank
+        push with br_lines and br_d_line
+    end for
+
+    push with br_lines and ""
+    push with br_lines and "LINES BY FILE:"
+    change br_h0 to padright of "File" and 50
+    store br_file_header as br_h0 with " " with br_h1 with " " with br_h2 with " " with br_h3 with " " with br_h4
+    push with br_lines and br_file_header
+    push with br_lines and br_dash
+
+    for each br_file_row in br_files:
+        store br_f_name as padright of br_file_row[0] and 50
+        store br_f_total_text as "" with br_file_row[1]
+        store br_f_total as padright of br_f_total_text and 10
+        store br_f_code_text as "" with br_file_row[2]
+        store br_f_code as padright of br_f_code_text and 10
+        store br_f_comments_text as "" with br_file_row[3]
+        store br_f_comments as padright of br_f_comments_text and 10
+        store br_f_blank_text as "" with br_file_row[4]
+        store br_f_blank as padright of br_f_blank_text and 10
+        store br_f_line as br_f_name with " " with br_f_total with " " with br_f_code with " " with br_f_comments with " " with br_f_blank
+        push with br_lines and br_f_line
+    end for
+
+    return join of br_lines and "\n"
+end action
+
+// Converts the plain-text report to markdown, replicating the Python
+// save_report_to_markdown() branch ladder exactly - including its quirks
+// (prev_line only updates in the final else branch, in_table never resets,
+// and the file table is sliced with the directory table's column widths).
+// Do not "fix" these: they are required for byte parity.
+define action called report_to_markdown with md_report:
+    store md_lines as []
+    push with md_lines and "# Rust Code Line Count Report"
+    store md_stamp as format_datetime of datetime_now and "%Y-%m-%d %H:%M:%S"
+    store md_gen as "*Generated on: " with md_stamp with "*"
+    push with md_lines and md_gen
+    push with md_lines and ""
+
+    store md_in_section as false
+    store md_in_table as false
+    store md_prev as ""
+    store md_widths as [40, 10, 10, 10, 10]
+
+    store md_rows as split md_report by "\n"
+    for each md_row in md_rows:
+        store md_is_eq as starts_with of md_row and "="
+        check if md_is_eq is true:
+            continue
+        end check
+        store md_is_title as starts_with of md_row and "RUST CODE LINE COUNT REPORT"
+        check if md_is_title is true:
+            continue
+        end check
+        store md_is_gen as starts_with of md_row and "Generated on:"
+        check if md_is_gen is true:
+            continue
+        end check
+        store md_trimmed as trim of md_row
+        check if md_trimmed is "":
+            push with md_lines and ""
+            continue
+        end check
+        store md_is_overall as starts_with of md_row and "OVERALL STATISTICS:"
+        check if md_is_overall is true:
+            push with md_lines and "## Overall Statistics"
+            continue
+        end check
+        store md_is_dir_section as starts_with of md_row and "LINES BY DIRECTORY:"
+        check if md_is_dir_section is true:
+            push with md_lines and "## Lines by Directory"
+            change md_in_section to true
+            continue
+        end check
+        store md_is_file_section as starts_with of md_row and "LINES BY FILE:"
+        check if md_is_file_section is true:
+            push with md_lines and "## Lines by File"
+            change md_in_section to true
+            continue
+        end check
+        store md_is_dash as starts_with of md_row and "-"
+        store md_table_dash as false
+        check if md_in_section is true:
+            check if md_is_dash is true:
+                change md_table_dash to true
+            end check
+        end check
+        check if md_table_dash is true:
+            store md_words as call split_ws with md_prev
+            store md_words_joined as join of md_words and " | "
+            store md_header_row as "| " with md_words_joined with " |"
+            push with md_lines and md_header_row
+            store md_dash_cells as []
+            for each md_word in md_words:
+                push with md_dash_cells and "---"
+            end for
+            store md_dashes_joined as join of md_dash_cells and " | "
+            store md_dash_row as "| " with md_dashes_joined with " |"
+            push with md_lines and md_dash_row
+            change md_in_table to true
+            continue
+        end check
+        check if md_in_table is true:
+            store md_cells as []
+            store md_remaining as md_row
+            for each md_width in md_widths:
+                store md_raw_cell as substring of md_remaining and 0 and md_width
+                store md_cell as trim of md_raw_cell
+                push with md_cells and md_cell
+                store md_rem_len as length of md_remaining
+                check if md_width is less than md_rem_len:
+                    store md_rest_len as md_rem_len minus md_width
+                    change md_remaining to substring of md_remaining and md_width and md_rest_len
+                otherwise:
+                    change md_remaining to ""
+                end check
+            end for
+            store md_cells_joined as join of md_cells and " | "
+            store md_cell_row as "| " with md_cells_joined with " |"
+            push with md_lines and md_cell_row
+            continue
+        end check
+        change md_prev to md_row
+        push with md_lines and md_row
+    end for
+
+    return join of md_lines and "\n"
+end action
+
+// --- Main flow, mirroring main() in the Python script ---
+
+// Python: src_directory = join(dirname(abspath(__file__)), "..", "src").
+// abspath(__file__) is normalized but the ".." from the join stays literal,
+// so the printed path is e.g. /repo/Tools/../src.
+store parent_ref as path_join of script_directory and ".."
+store src_dir as path_join of parent_ref and "src"
+
+display "Counting lines of Rust code in " with src_dir with "..."
+
+store all_file_rows as []
+call walk_src with src_dir and "src" and all_file_rows
+
+// Overall totals, accumulated in walk order like the Python script.
+store grand_total as 0
+store grand_code as 0
+store grand_comments as 0
+store grand_blank as 0
+for each tally_row in all_file_rows:
+    store tally_total as tally_row[1]
+    add tally_total to grand_total
+    store tally_code as tally_row[2]
+    add tally_code to grand_code
+    store tally_comments as tally_row[3]
+    add tally_comments to grand_comments
+    store tally_blank as tally_row[4]
+    add tally_blank to grand_blank
+end for
+
+// Per-directory totals. Directory keys are collected in first-seen walk
+// order, matching the insertion order of the Python defaultdict.
+store dir_keys as []
+for each seen_row in all_file_rows:
+    store seen_key as seen_row[0]
+    store seen_dir as path_dirname of seen_key
+    store seen_at as index_of of dir_keys and seen_dir
+    check if seen_at is less than 0:
+        push with dir_keys and seen_dir
+    end check
+end for
+
+store all_dir_rows as []
+for each agg_dir in dir_keys:
+    store agg_total as 0
+    store agg_code as 0
+    store agg_comments as 0
+    store agg_blank as 0
+    for each agg_row in all_file_rows:
+        store agg_row_key as agg_row[0]
+        store agg_row_dir as path_dirname of agg_row_key
+        check if agg_row_dir is agg_dir:
+            store agg_row_total as agg_row[1]
+            add agg_row_total to agg_total
+            store agg_row_code as agg_row[2]
+            add agg_row_code to agg_code
+            store agg_row_comments as agg_row[3]
+            add agg_row_comments to agg_comments
+            store agg_row_blank as agg_row[4]
+            add agg_row_blank to agg_blank
+        end check
+    end for
+    store agg_out as []
+    push with agg_out and agg_dir
+    push with agg_out and agg_total
+    push with agg_out and agg_code
+    push with agg_out and agg_comments
+    push with agg_out and agg_blank
+    push with all_dir_rows and agg_out
+end for
+
+store sorted_dirs as call stable_sort_desc with all_dir_rows
+store sorted_files as call stable_sort_desc with all_file_rows
+
+store report_totals as []
+store file_row_count as length of all_file_rows
+push with report_totals and file_row_count
+push with report_totals and grand_total
+push with report_totals and grand_code
+push with report_totals and grand_comments
+push with report_totals and grand_blank
+
+store report_text as call build_report with sorted_files and sorted_dirs and report_totals
+display report_text
+
+store markdown_text as call report_to_markdown with report_text
+store docs_dir as path_join of parent_ref and "Docs"
+store out_path as path_join of docs_dir and "rust_loc_report.md"
+open file at out_path for writing as md_handle
+wait for write content markdown_text into md_handle
+close file md_handle
+
 display ""
-display result
+display "Report saved to " with out_path

--- a/Tools/rust_loc_counter.wfl
+++ b/Tools/rust_loc_counter.wfl
@@ -125,7 +125,7 @@ define action called walk_src with ws_abs and ws_rel and ws_sink:
         check if ws_entry_is_dir is false:
             store ws_is_rust as ends_with of ws_entry and ".rs"
             check if ws_is_rust is true:
-                store ws_key as ws_rel with "/" with ws_entry
+                store ws_key as path_join of ws_rel and ws_entry
                 store ws_stats as call analyze_rust_file with ws_full
                 store ws_row as []
                 push with ws_row and ws_key
@@ -141,7 +141,7 @@ define action called walk_src with ws_abs and ws_rel and ws_sink:
         store ws_full2 as path_join of ws_abs and ws_entry2
         store ws_dir_check as is_dir of ws_full2
         check if ws_dir_check is true:
-            store ws_child_rel as ws_rel with "/" with ws_entry2
+            store ws_child_rel as path_join of ws_rel and ws_entry2
             call walk_src with ws_full2 and ws_child_rel and ws_sink
         end check
     end for

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -364,6 +364,24 @@ impl Analyzer {
         };
         let _ = global_scope.define(positional_args_symbol);
 
+        let script_path_symbol = Symbol {
+            name: "script_path".to_string(),
+            kind: SymbolKind::Variable { mutable: false },
+            symbol_type: Some(Type::Text),
+            line: 0,
+            column: 0,
+        };
+        let _ = global_scope.define(script_path_symbol);
+
+        let script_directory_symbol = Symbol {
+            name: "script_directory".to_string(),
+            kind: SymbolKind::Variable { mutable: false },
+            symbol_type: Some(Type::Text),
+            line: 0,
+            column: 0,
+        };
+        let _ = global_scope.define(script_directory_symbol);
+
         Analyzer {
             current_scope: global_scope,
             errors: Vec::new(),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -74,6 +74,7 @@ const BUILTIN_FUNCTIONS: &[&str] = &[
     "trim",
     "padleft",
     "padright",
+    "format_number",
     "capitalize",
     "reverse",
     "reverse_text",
@@ -291,8 +292,8 @@ pub fn get_function_arity(name: &str) -> usize {
         | "capitalize" | "reverse" | "reverse_text" => 1,
         // Two argument functions
         "contains" | "indexof" | "index_of" | "lastindexof" | "last_index_of" | "padleft"
-        | "padright" | "startswith" | "starts_with" | "endswith" | "ends_with" | "split"
-        | "string_split" | "join" => 2,
+        | "padright" | "format_number" | "startswith" | "starts_with" | "endswith"
+        | "ends_with" | "split" | "string_split" | "join" => 2,
         // Three argument functions
         "substring" | "replace" => 3,
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1380,6 +1380,40 @@ impl Default for Interpreter {
     }
 }
 
+/// Resolve `path` against `cwd` and normalize it lexically, mirroring Python's
+/// `os.path.abspath` (`normpath(join(cwd, path))`): `.` components are dropped
+/// and `..` collapses without touching the filesystem (no symlink resolution).
+fn lexical_abspath(path: &std::path::Path, cwd: &std::path::Path) -> String {
+    use std::path::Component;
+
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        cwd.join(path)
+    };
+
+    let mut root = PathBuf::new();
+    let mut parts: Vec<std::ffi::OsString> = Vec::new();
+    for component in joined.components() {
+        match component {
+            Component::Prefix(prefix) => root.push(prefix.as_os_str()),
+            Component::RootDir => root.push(std::path::MAIN_SEPARATOR_STR),
+            Component::CurDir => {}
+            // Like os.path.normpath, ".." at the root is dropped
+            Component::ParentDir => {
+                parts.pop();
+            }
+            Component::Normal(part) => parts.push(part.to_os_string()),
+        }
+    }
+
+    let mut result = root;
+    for part in parts {
+        result.push(part);
+    }
+    result.to_string_lossy().into_owned()
+}
+
 impl Interpreter {
     pub fn new() -> Self {
         Self::with_config(Arc::new(WflConfig::default()))
@@ -1915,6 +1949,23 @@ impl Interpreter {
                 .to_string_lossy()
                 .into_owned();
             let _ = env.define("current_directory", Value::Text(Arc::from(current_dir)));
+
+            // Store the running script's absolute path and directory,
+            // the equivalent of Python's __file__ / dirname(abspath(__file__))
+            let (script_path, script_directory) = match self.current_source_file.borrow().as_ref() {
+                Some(source_file) => {
+                    let cwd = std::env::current_dir().unwrap_or_default();
+                    let abs = lexical_abspath(source_file, &cwd);
+                    let dir = std::path::Path::new(&abs)
+                        .parent()
+                        .map(|p| p.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    (abs, dir)
+                }
+                None => (String::new(), String::new()),
+            };
+            let _ = env.define("script_path", Value::Text(Arc::from(script_path)));
+            let _ = env.define("script_directory", Value::Text(Arc::from(script_directory)));
 
             // Store flags as individual variables with flag_ prefix
             for (key, value) in flags_map {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1951,16 +1951,29 @@ impl Interpreter {
             let _ = env.define("current_directory", Value::Text(Arc::from(current_dir)));
 
             // Store the running script's absolute path and directory,
-            // the equivalent of Python's __file__ / dirname(abspath(__file__))
+            // the equivalent of Python's __file__ / dirname(abspath(__file__)).
+            // Always absolute or empty: empty when no script file is running,
+            // or when a relative script path can't be resolved because the
+            // current directory is unavailable.
             let (script_path, script_directory) = match self.current_source_file.borrow().as_ref() {
                 Some(source_file) => {
-                    let cwd = std::env::current_dir().unwrap_or_default();
-                    let abs = lexical_abspath(source_file, &cwd);
-                    let dir = std::path::Path::new(&abs)
-                        .parent()
-                        .map(|p| p.to_string_lossy().into_owned())
-                        .unwrap_or_default();
-                    (abs, dir)
+                    let cwd = if source_file.is_absolute() {
+                        // lexical_abspath ignores cwd for absolute paths
+                        Some(PathBuf::new())
+                    } else {
+                        std::env::current_dir().ok()
+                    };
+                    match cwd {
+                        Some(cwd) => {
+                            let abs = lexical_abspath(source_file, &cwd);
+                            let dir = std::path::Path::new(&abs)
+                                .parent()
+                                .map(|p| p.to_string_lossy().into_owned())
+                                .unwrap_or_default();
+                            (abs, dir)
+                        }
+                        None => (String::new(), String::new()),
+                    }
                 }
                 None => (String::new(), String::new()),
             };

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -312,3 +312,86 @@ end action
         panic!("Expected Value::List, got {:?}", result);
     }
 }
+
+#[test]
+fn test_lexical_abspath() {
+    use super::lexical_abspath;
+    use std::path::Path;
+
+    // Absolute paths pass through unchanged
+    assert_eq!(
+        lexical_abspath(Path::new("/a/b/c.wfl"), Path::new("/cwd")),
+        "/a/b/c.wfl"
+    );
+    // Relative paths join to the cwd
+    assert_eq!(
+        lexical_abspath(Path::new("Tools/foo.wfl"), Path::new("/home/user/wfl")),
+        "/home/user/wfl/Tools/foo.wfl"
+    );
+    // "." components are dropped, ".." collapses lexically (like Python os.path.abspath)
+    assert_eq!(
+        lexical_abspath(Path::new("./Tools/../src/x.rs"), Path::new("/base")),
+        "/base/src/x.rs"
+    );
+    // ".." at the root is dropped, matching os.path.normpath("/../x") == "/x"
+    assert_eq!(lexical_abspath(Path::new("/../x"), Path::new("/")), "/x");
+    assert_eq!(
+        lexical_abspath(Path::new("a/b.wfl"), Path::new("/w/./z/..")),
+        "/w/a/b.wfl"
+    );
+}
+
+#[tokio::test]
+async fn test_script_path_and_directory_globals() {
+    let mut interpreter = Interpreter::new();
+    interpreter.set_source_file(std::path::PathBuf::from("Tools/rust_loc_counter.wfl"));
+
+    let tokens = lex_wfl_with_positions("store placeholder as 1");
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().unwrap();
+    interpreter.interpret(&program).await.unwrap();
+
+    let env = interpreter.global_env.borrow();
+    let script_path = env.get("script_path").expect("script_path defined");
+    let script_directory = env
+        .get("script_directory")
+        .expect("script_directory defined");
+    match (&script_path, &script_directory) {
+        (Value::Text(path_text), Value::Text(dir_text)) => {
+            assert!(
+                std::path::Path::new(path_text.as_ref()).is_absolute(),
+                "script_path should be absolute, got {path_text}"
+            );
+            assert!(
+                path_text.ends_with("Tools/rust_loc_counter.wfl")
+                    || path_text.ends_with("Tools\\rust_loc_counter.wfl"),
+                "unexpected script_path {path_text}"
+            );
+            assert!(
+                dir_text.ends_with("Tools"),
+                "unexpected script_directory {dir_text}"
+            );
+        }
+        other => panic!("Expected Text globals, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_script_path_globals_empty_without_source_file() {
+    let mut interpreter = Interpreter::new();
+
+    let tokens = lex_wfl_with_positions("store placeholder as 1");
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().unwrap();
+    interpreter.interpret(&program).await.unwrap();
+
+    let env = interpreter.global_env.borrow();
+    assert_eq!(
+        env.get("script_path"),
+        Some(Value::Text(std::sync::Arc::from("")))
+    );
+    assert_eq!(
+        env.get("script_directory"),
+        Some(Value::Text(std::sync::Arc::from("")))
+    );
+}

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -313,6 +313,7 @@ end action
     }
 }
 
+#[cfg(unix)]
 #[test]
 fn test_lexical_abspath() {
     use super::lexical_abspath;
@@ -338,6 +339,35 @@ fn test_lexical_abspath() {
     assert_eq!(
         lexical_abspath(Path::new("a/b.wfl"), Path::new("/w/./z/..")),
         "/w/a/b.wfl"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn test_lexical_abspath_windows() {
+    use super::lexical_abspath;
+    use std::path::Path;
+
+    // Absolute paths pass through unchanged
+    assert_eq!(
+        lexical_abspath(Path::new(r"C:\a\b\c.wfl"), Path::new(r"C:\cwd")),
+        r"C:\a\b\c.wfl"
+    );
+    // Relative paths join to the cwd
+    assert_eq!(
+        lexical_abspath(Path::new(r"Tools\foo.wfl"), Path::new(r"C:\repo")),
+        r"C:\repo\Tools\foo.wfl"
+    );
+    // "." components are dropped, ".." collapses lexically; forward slashes
+    // are accepted as separators and normalized
+    assert_eq!(
+        lexical_abspath(Path::new("./Tools/../src/x.rs"), Path::new(r"C:\base")),
+        r"C:\base\src\x.rs"
+    );
+    // ".." at the root is dropped
+    assert_eq!(
+        lexical_abspath(Path::new(r"C:\..\x"), Path::new(r"C:\")),
+        r"C:\x"
     );
 }
 

--- a/src/stdlib/text.rs
+++ b/src/stdlib/text.rs
@@ -348,6 +348,35 @@ pub fn native_padright(args: Vec<Value>) -> Result<Value, RuntimeError> {
     perform_pad(args, false)
 }
 
+const MAX_FORMAT_PRECISION: f64 = 17.0;
+
+pub fn native_format_number(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("format_number", &args, 2)?;
+
+    let value = expect_number(&args[0])?;
+    if !value.is_finite() {
+        return Err(RuntimeError::new(
+            "format_number expects a finite number".to_string(),
+            0,
+            0,
+        ));
+    }
+
+    let precision = expect_number(&args[1])?;
+    if !(0.0..=MAX_FORMAT_PRECISION).contains(&precision) || precision.fract() != 0.0 {
+        return Err(RuntimeError::new(
+            format!(
+                "format_number expects a whole-number precision between 0 and {MAX_FORMAT_PRECISION}, got {precision}"
+            ),
+            0,
+            0,
+        ));
+    }
+
+    let precision = precision as usize;
+    Ok(Value::Text(Arc::from(format!("{value:.precision$}"))))
+}
+
 pub fn native_capitalize(args: Vec<Value>) -> Result<Value, RuntimeError> {
     unary_text_op("capitalize", args, |text| {
         let mut chars = text.chars();
@@ -408,6 +437,7 @@ pub fn register_text(env: &mut Environment) {
     env.define_native("lastindexof", native_last_index_of);
     env.define_native("padleft", native_padleft);
     env.define_native("padright", native_padright);
+    env.define_native("format_number", native_format_number);
     env.define_native("capitalize", native_capitalize);
     env.define_native("reverse", native_reverse_text);
     env.define_native("reverse_text", native_reverse_text);
@@ -687,5 +717,73 @@ mod tests {
         ])
         .unwrap();
         assert_eq!(result, Value::Text(Arc::from(" worl")));
+    }
+
+    #[test]
+    fn test_format_number_one_decimal() {
+        let result = native_format_number(vec![Value::Number(45.678), Value::Number(1.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("45.7")));
+    }
+
+    #[test]
+    fn test_format_number_whole_keeps_decimal() {
+        let result = native_format_number(vec![Value::Number(100.0), Value::Number(1.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("100.0")));
+    }
+
+    #[test]
+    fn test_format_number_round_half_even() {
+        // 0.25 is exact in binary; Python's f"{0.25:.1f}" gives "0.2"
+        let result = native_format_number(vec![Value::Number(0.25), Value::Number(1.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("0.2")));
+        // 0.75 is exact in binary; Python gives "0.8"
+        let result = native_format_number(vec![Value::Number(0.75), Value::Number(1.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("0.8")));
+    }
+
+    #[test]
+    fn test_format_number_zero_precision() {
+        let result = native_format_number(vec![Value::Number(12.0), Value::Number(0.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("12")));
+    }
+
+    #[test]
+    fn test_format_number_more_decimals() {
+        let result =
+            native_format_number(vec![Value::Number(1.0 / 3.0), Value::Number(3.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("0.333")));
+    }
+
+    #[test]
+    fn test_format_number_negative_value() {
+        let result = native_format_number(vec![Value::Number(-2.345), Value::Number(2.0)]).unwrap();
+        assert_eq!(result, Value::Text(Arc::from("-2.35")));
+    }
+
+    #[test]
+    fn test_format_number_wrong_arg_count() {
+        assert!(native_format_number(vec![Value::Number(1.0)]).is_err());
+    }
+
+    #[test]
+    fn test_format_number_non_number_value() {
+        assert!(
+            native_format_number(vec![Value::Text(Arc::from("x")), Value::Number(1.0)]).is_err()
+        );
+    }
+
+    #[test]
+    fn test_format_number_bad_precision() {
+        assert!(native_format_number(vec![Value::Number(1.0), Value::Number(-1.0)]).is_err());
+        assert!(native_format_number(vec![Value::Number(1.0), Value::Number(1.5)]).is_err());
+        assert!(native_format_number(vec![Value::Number(1.0), Value::Number(100.0)]).is_err());
+    }
+
+    #[test]
+    fn test_format_number_non_finite_value() {
+        assert!(native_format_number(vec![Value::Number(f64::NAN), Value::Number(1.0)]).is_err());
+        assert!(
+            native_format_number(vec![Value::Number(f64::INFINITY), Value::Number(1.0)]).is_err()
+        );
     }
 }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -157,8 +157,8 @@ impl TypeChecker {
             // Text functions
             "length" | "indexof" | "index_of" | "lastindexof" | "last_index_of" => Type::Number,
             "touppercase" | "to_uppercase" | "tolowercase" | "to_lowercase" | "substring"
-            | "replace" | "trim" | "padleft" | "padright" | "capitalize" | "reverse"
-            | "reverse_text" => Type::Text,
+            | "replace" | "trim" | "padleft" | "padright" | "format_number" | "capitalize"
+            | "reverse" | "reverse_text" => Type::Text,
             "contains" | "startswith" | "starts_with" | "endswith" | "ends_with" => Type::Boolean,
             "split" => Type::List(Box::new(Type::Text)),
             "join" => Type::Text,


### PR DESCRIPTION
## Summary
This PR completes a 1:1 port of `Tools/rust_loc_counter.py` to WFL (`Tools/rust_loc_counter.wfl`), producing byte-identical output to the Python version. It also introduces the `format_number` stdlib function to support formatted numeric output with fixed decimal places.

## Key Changes

### WFL Script Port
- **Complete rewrite of `Tools/rust_loc_counter.wfl`**: Replaced the incomplete WFL implementation with a faithful port of the Python script that:
  - Recursively scans `src/` for `.rs` files using `walk_src()` (mirroring `os.walk`)
  - Categorizes each line as code, comment, or blank with identical logic to the Python version (including quirks like treating lines starting with `/*` as comments even when code follows `*/`)
  - Aggregates statistics by file and directory
  - Generates a plain-text report with aligned columns
  - Converts the report to markdown and writes it to `Docs/rust_loc_report.md`
  - Uses new runtime globals `script_path` and `script_directory` to locate the source tree relative to the script

### New `format_number` Stdlib Function
- **Added `native_format_number()` in `src/stdlib/text.rs`**: Formats a number as text with a fixed number of decimal places (0–17)
  - Validates that the number is finite and precision is a whole number in range
  - Uses Rust's `format!` with precision specifier to match Python's `f"{x:.Nf}"` rounding behavior (round-half-to-even)
  - Always displays exactly the requested number of decimal places (e.g., `45.0` for `45` with precision 1)
- **Registered in `register_text()`** and added to `BUILTIN_FUNCTIONS` in `src/builtins.rs`
- **Type checker support** in `src/typechecker/mod.rs` (returns `Type::Text`)
- **Comprehensive tests** covering one/multiple decimals, zero precision, rounding, negative values, and error cases

### Runtime Globals
- **Added `script_path` and `script_directory` globals** in `src/interpreter/mod.rs`:
  - `script_path`: Absolute path of the running script (empty string if not set)
  - `script_directory`: Directory containing the script (empty string if not set)
  - Computed using new `lexical_abspath()` function that mirrors Python's `os.path.abspath` (normalizes `.` and `..` without filesystem access)
- **Registered in analyzer** (`src/analyzer/mod.rs`) as immutable Text variables
- **Added tests** verifying correct path resolution and behavior when source file is not set

### Documentation
- **Added `format_number` to text module docs** (`Docs/05-standard-library/text-module.md`) with signature, parameters, examples, and use cases
- **Documented runtime globals** in `Docs/03-language-basics/variables-and-types.md` with explanation of `script_path` and `script_directory`

## Implementation Details
- The WFL port uses helper functions (`after_first`, `walk_src`, `stable_sort_desc`, `split_ws`, `build_report`, `report_to_markdown`) to organize the logic and maintain readability
- The markdown conversion preserves the Python script's exact behavior, including its quirks (e.g., `prev_line` only updates in the final else branch, `in_table` never resets)
- `lexical_abspath()` handles edge cases like `..` at the root (dropped, matching `os.path.normpath`) and normalizes paths without touching the filesystem
- All tests pass; the WFL script produces identical output to the Python version when run on the same source tree

https://claude.ai/code/session_01Beew1K4fYM8vVh1HVoidAU