### PR TITLE
Add custom response headers support to respond statement

### DIFF
--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -217,11 +217,81 @@ respond to <request> with <content> and content_type <type>
 - `text/css` - CSS stylesheets
 - `application/javascript` - JavaScript files
 
+### With Custom Headers
+
+Set extra response headers by passing a map to `and headers`. This mirrors the
+outbound client's `with headers` clause — the same "headers are a map" idea,
+nothing new to learn.
+
+```wfl
+create map extra_headers:
+    "Cache-Control" is "no-store"
+    "X-Request-Id" is "abc-123"
+end map
+
+respond to req with json_data and content_type "application/json" and headers extra_headers
+```
+
+**Syntax:**
+```wfl
+respond to <request> with <content> and headers <map>
+```
+
+**Notes:**
+- The map keys are header names and the values are header values (text).
+- The `content_type` clause remains authoritative for `Content-Type`; a
+  `Content-Type` key in the map is ignored so the response never carries two.
+
 ### Combined
 
 ```wfl
-respond to req with "Created!" and status 201 and content_type "application/json"
+respond to req with "Created!" and status 201 and content_type "application/json" and headers extra_headers
 ```
+
+All optional clauses (`status`, `content_type`, `headers`) can appear in any
+order after the content.
+
+## The QUERY Method (RFC 10008)
+
+WFL supports [RFC 10008](https://www.rfc-editor.org/info/rfc10008/), the HTTP
+`QUERY` method. `QUERY` is a *safe* and *idempotent* request that carries a
+body — it fills the gap between `GET` (safe/idempotent but no body) and `POST`
+(has a body but is neither), which is ideal for complex read-only lookups whose
+parameters are too large or sensitive for the URL.
+
+Because WFL treats HTTP methods as plain text, no special syntax is required.
+
+**Sending a QUERY (client):**
+
+```wfl
+open url at "https://api.example.com/search" with method "QUERY" and headers request_headers and body "$.items[*]" and read response as result
+```
+
+Per RFC 10008 a `QUERY` request must include a `Content-Type` describing the
+query body, so set it in the request headers map (for example
+`"Content-Type" is "application/jsonpath"`).
+
+**Handling a QUERY (server):**
+
+A `QUERY` request arrives like any other; dispatch on the method and use the
+`headers` clause to advertise `Accept-Query` (which query formats the endpoint
+accepts) and, optionally, `Content-Location` to point at a resource holding the
+results.
+
+```wfl
+create map query_headers:
+    "Accept-Query" is "application/jsonpath, application/sql"
+    "Content-Location" is "/data/results/latest"
+end map
+
+check if req["method"] is "QUERY":
+    respond to req with results_json and content_type "application/json" and headers query_headers
+otherwise:
+    respond to req with "Method Not Allowed" and status 405
+end check
+```
+
+See `TestPrograms/rfc10008_query_server.wfl` for a complete example.
 
 ## Routing
 

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -238,9 +238,12 @@ respond to <request> with <content> and headers <map>
 ```
 
 **Notes:**
-- The map keys are header names and the values are header values (text).
-- The `content_type` clause remains authoritative for `Content-Type`; a
-  `Content-Type` key in the map is ignored so the response never carries two.
+- The map keys are header names; values are text (numbers and booleans are
+  accepted and converted to text).
+- The `content_type` clause remains authoritative for `Content-Type`. Keys the
+  response pipeline computes itself — `Content-Type`, `Content-Length`, and
+  `Transfer-Encoding` — are ignored if present in the map, so the response never
+  carries duplicate or conflicting copies of them.
 
 ### Combined
 
@@ -263,13 +266,16 @@ Because WFL treats HTTP methods as plain text, no special syntax is required.
 
 **Sending a QUERY (client):**
 
+Per RFC 10008 a `QUERY` request must include a `Content-Type` describing the
+query body, so set it in the request headers map:
+
 ```wfl
+create map request_headers:
+    "Content-Type" is "application/jsonpath"
+end map
+
 open url at "https://api.example.com/search" with method "QUERY" and headers request_headers and body "$.items[*]" and read response as result
 ```
-
-Per RFC 10008 a `QUERY` request must include a `Content-Type` describing the
-query body, so set it in the request headers map (for example
-`"Content-Type" is "application/jsonpath"`).
 
 **Handling a QUERY (server):**
 

--- a/TestPrograms/rfc10008_query_server.wfl
+++ b/TestPrograms/rfc10008_query_server.wfl
@@ -1,0 +1,40 @@
+// CI-SKIP: RFC 10008 QUERY server demo — requires an HTTP client to drive it (covered end-to-end by tests/respond_headers_test.rs)
+//
+// Demonstrates RFC 10008 (The HTTP QUERY Method) support in WFL.
+//
+// QUERY is a safe, idempotent HTTP method that carries a request body, closing
+// the gap between GET (no body) and POST (not safe/idempotent). WFL already
+// sends and receives QUERY because HTTP methods are plain strings end-to-end:
+//   - a client sends it with:  open url at "..." with method "QUERY" and body b ...
+//   - a server reads it from:  the request's "method" property
+//
+// The piece this file exercises is the `respond ... and headers <map>` clause,
+// which lets a WFL server set the RFC 10008 response headers `Accept-Query`
+// (advertising which query formats it accepts) and `Content-Location`
+// (pointing at a retrievable resource holding the results).
+
+display "=== RFC 10008 QUERY server demo ==="
+
+// The response headers RFC 10008 calls for. `Accept-Query` advertises the
+// query content types this endpoint understands; `Content-Location` identifies
+// a resource from which the same results can later be fetched with GET.
+create map query_response_headers:
+    "Accept-Query" is "application/jsonpath, application/sql"
+    "Content-Location" is "/data/results/latest"
+end map
+
+listen on port 8130 as query_server
+display "Listening for a QUERY on port 8130..."
+
+wait for request comes in on query_server as incoming with timeout 30000
+
+// A real handler would parse the query body and run it. Here we return a fixed
+// JSON result and advertise the RFC 10008 headers alongside it.
+store results as "{\"items\": [1, 2, 3]}"
+
+respond to incoming with results and content_type "application/json" and headers query_response_headers
+
+display "Responded to QUERY with Accept-Query and Content-Location headers"
+
+close server query_server
+display "=== Demo complete ==="

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1599,6 +1599,7 @@ impl Analyzer {
                 content,
                 status,
                 content_type,
+                headers,
                 ..
             } => {
                 // Analyze all expressions
@@ -1611,6 +1612,10 @@ impl Analyzer {
 
                 if let Some(ct_expr) = content_type {
                     self.analyze_expression(ct_expr);
+                }
+
+                if let Some(headers_expr) = headers {
+                    self.analyze_expression(headers_expr);
                 }
             }
 

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -850,6 +850,7 @@ impl Analyzer {
                 content,
                 status,
                 content_type,
+                headers,
                 ..
             } => {
                 self.mark_used_in_expression(request, usages);
@@ -859,6 +860,9 @@ impl Analyzer {
                 }
                 if let Some(content_type) = content_type {
                     self.mark_used_in_expression(content_type, usages);
+                }
+                if let Some(headers) = headers {
+                    self.mark_used_in_expression(headers, usages);
                 }
             }
             Statement::ListenStatement { port, .. } => {
@@ -1701,6 +1705,44 @@ mod tests {
         assert_eq!(diagnostics.len(), 1);
         assert!(diagnostics[0].message.contains("unused"));
         assert_eq!(diagnostics[0].code, "ANALYZE-UNUSED");
+    }
+
+    #[test]
+    fn test_respond_headers_expression_marks_variable_used() {
+        // Regression: a variable referenced only in the
+        // `respond ... and headers <map>` clause must be marked used, not
+        // falsely reported as unused. RFC 10008 servers build a header map
+        // (Accept-Query, Content-Location) and pass it straight to respond.
+        let program = Program {
+            statements: vec![
+                Statement::VariableDeclaration {
+                    name: "response_headers".to_string(),
+                    value: Expression::Literal(Literal::Integer(1), 1, 1),
+                    is_constant: false,
+                    line: 1,
+                    column: 1,
+                },
+                Statement::RespondStatement {
+                    request: Expression::Variable("req".to_string(), 2, 1),
+                    content: Expression::Literal(Literal::String(Arc::from("ok")), 2, 1),
+                    status: None,
+                    content_type: None,
+                    headers: Some(Expression::Variable("response_headers".to_string(), 2, 30)),
+                    line: 2,
+                    column: 1,
+                },
+            ],
+        };
+
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_unused_variables(&program, 0);
+
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| !d.message.contains("response_headers")),
+            "response_headers used only in `respond ... and headers` must not be flagged unused: {diagnostics:?}"
+        );
     }
 
     #[test]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5686,6 +5686,7 @@ impl Interpreter {
                 content,
                 status,
                 content_type,
+                headers,
                 line,
                 column,
             } => {
@@ -5759,12 +5760,61 @@ impl Interpreter {
                     "text/plain".to_string() // Default content type
                 };
 
+                // Evaluate custom response headers (optional). Mirrors the
+                // outbound client's headers map: a WFL Object of name -> value.
+                // Enables RFC 10008 (HTTP QUERY) servers to advertise
+                // `Accept-Query` and point at results with `Content-Location`
+                // or `Location`.
+                let mut custom_headers: HashMap<String, String> = HashMap::new();
+                if let Some(headers_expr) = headers {
+                    let headers_val = self
+                        .evaluate_expression(headers_expr, Rc::clone(&env))
+                        .await?;
+                    match &headers_val {
+                        Value::Object(obj) => {
+                            for (name, value) in obj.borrow().iter() {
+                                let value_str = match value {
+                                    Value::Text(s) => s.to_string(),
+                                    Value::Number(_) | Value::Bool(_) => value.to_string(),
+                                    _ => {
+                                        return Err(RuntimeError::new(
+                                            format!(
+                                                "Response header '{name}' must be text, got {}",
+                                                value.type_name()
+                                            ),
+                                            *line,
+                                            *column,
+                                        ));
+                                    }
+                                };
+                                // The content_type clause is authoritative for
+                                // Content-Type; drop any duplicate from the map
+                                // so the response never carries two of them.
+                                if name.eq_ignore_ascii_case("content-type") {
+                                    continue;
+                                }
+                                custom_headers.insert(name.clone(), value_str);
+                            }
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Expected a map for response headers, got {}",
+                                    headers_val.type_name()
+                                ),
+                                *line,
+                                *column,
+                            ));
+                        }
+                    }
+                }
+
                 // Create response
                 let response = WflHttpResponse {
                     content: content_str,
                     status: status_code,
                     content_type: content_type_str,
-                    headers: HashMap::new(), // TODO: Add support for custom headers
+                    headers: custom_headers,
                 };
 
                 // Send response

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5779,7 +5779,7 @@ impl Interpreter {
                                     _ => {
                                         return Err(RuntimeError::new(
                                             format!(
-                                                "Response header '{name}' must be text, got {}",
+                                                "Response header '{name}' must be text, a number, or a boolean, got {}",
                                                 value.type_name()
                                             ),
                                             *line,
@@ -5787,10 +5787,18 @@ impl Interpreter {
                                         ));
                                     }
                                 };
-                                // The content_type clause is authoritative for
-                                // Content-Type; drop any duplicate from the map
-                                // so the response never carries two of them.
-                                if name.eq_ignore_ascii_case("content-type") {
+                                // Content-Type, Content-Length, and
+                                // Transfer-Encoding are computed by the response
+                                // pipeline (the `content_type` clause and warp's
+                                // builder set them explicitly). Warp *appends*
+                                // custom headers, so letting the map override
+                                // these would emit duplicate/conflicting headers
+                                // (RFC 7230 §3.3.2) and risk response splitting.
+                                // Drop them so the pipeline stays authoritative.
+                                if name.eq_ignore_ascii_case("content-type")
+                                    || name.eq_ignore_ascii_case("content-length")
+                                    || name.eq_ignore_ascii_case("transfer-encoding")
+                                {
                                     continue;
                                 }
                                 custom_headers.insert(name.clone(), value_str);

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -516,6 +516,9 @@ pub enum Statement {
         content: Expression,
         status: Option<Expression>,
         content_type: Option<Expression>,
+        /// Optional map of extra response headers, e.g. `Accept-Query` /
+        /// `Content-Location` / `Location` for RFC 10008 (HTTP QUERY).
+        headers: Option<Expression>,
         line: usize,
         column: usize,
     },

--- a/src/parser/stmt/web.rs
+++ b/src/parser/stmt/web.rs
@@ -200,11 +200,12 @@ impl<'a> WebParser<'a> for Parser<'a> {
         // Parse content expression (use primary to avoid consuming "and")
         let content = self.parse_primary_expression()?;
 
-        // Optional status and content_type
+        // Optional status, content_type, and headers
         let mut status = None;
         let mut content_type = None;
+        let mut headers = None;
 
-        // Check for optional "and" clauses (status and/or content_type)
+        // Check for optional "and" clauses (status, content_type, and/or headers)
         loop {
             if let Some(token) = self.cursor.peek()
                 && token.token == Token::KeywordAnd
@@ -262,6 +263,30 @@ impl<'a> WebParser<'a> for Parser<'a> {
                                 Some(Expression::Variable(rest.to_string(), id_line, id_column));
                         }
                         continue;
+                    } else if let Token::Identifier(id) = &next_token.token
+                        && (id == "headers" || id.starts_with("headers "))
+                    {
+                        // Mirrors the outbound client's `with headers <map>` form.
+                        // The lexer merges adjacent identifiers, so a variable
+                        // value can arrive glued to the marker
+                        // (`and headers h` lexes as Identifier("headers h")).
+                        let id = id.clone();
+                        let (id_line, id_column) = (next_token.line, next_token.column);
+                        self.bump_sync(); // Consume "and"
+                        self.bump_sync(); // Consume the (possibly merged) "headers" marker
+                        let rest = id
+                            .strip_prefix("headers")
+                            .map(str::trim_start)
+                            .unwrap_or("");
+                        if rest.is_empty() {
+                            // Primary expression only, so a following "and
+                            // status ..." clause stays available.
+                            headers = Some(self.parse_primary_expression()?);
+                        } else {
+                            headers =
+                                Some(Expression::Variable(rest.to_string(), id_line, id_column));
+                        }
+                        continue;
                     }
                 }
             }
@@ -273,6 +298,7 @@ impl<'a> WebParser<'a> for Parser<'a> {
             content,
             status,
             content_type,
+            headers,
             line: respond_token.line,
             column: respond_token.column,
         })

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1896,7 +1896,7 @@ impl TypeChecker {
                 content,
                 status,
                 content_type,
-                headers: _headers,
+                headers,
                 line: _line,
                 column: _column,
             } => {
@@ -1940,6 +1940,24 @@ impl TypeChecker {
                             "Content type must be text".to_string(),
                             Some(Type::Text),
                             Some(ct_type),
+                            *_line,
+                            *_column,
+                        );
+                    }
+                }
+
+                // Check headers if provided (should be a map). Mirrors the
+                // outbound HttpRequestStatement headers check.
+                if let Some(headers_expr) = headers {
+                    let headers_type = self.infer_expression_type(headers_expr);
+                    if !matches!(
+                        headers_type,
+                        Type::Map(_, _) | Type::Unknown | Type::Any | Type::Error
+                    ) {
+                        self.type_error(
+                            "Response headers must be a map of header names to values".to_string(),
+                            Some(Type::Map(Box::new(Type::Text), Box::new(Type::Text))),
+                            Some(headers_type),
                             *_line,
                             *_column,
                         );
@@ -3795,6 +3813,46 @@ mod tests {
             errors
                 .iter()
                 .any(|e| e.message.contains("incompatible type"))
+        );
+    }
+
+    #[test]
+    fn test_respond_headers_must_be_a_map() {
+        // A non-map value in the `headers` clause must be a type error, the same
+        // way non-map request headers are rejected on `open url`.
+        let program = Program {
+            statements: vec![
+                Statement::VariableDeclaration {
+                    name: "req".to_string(),
+                    value: Expression::Literal(Literal::String(Arc::from("stub")), 1, 1),
+                    is_constant: false,
+                    line: 1,
+                    column: 1,
+                },
+                Statement::RespondStatement {
+                    request: Expression::Variable("req".to_string(), 2, 1),
+                    content: Expression::Literal(Literal::String(Arc::from("ok")), 2, 1),
+                    status: None,
+                    content_type: None,
+                    headers: Some(Expression::Literal(Literal::Integer(42), 2, 1)),
+                    line: 2,
+                    column: 1,
+                },
+            ],
+        };
+
+        let mut type_checker = TypeChecker::new();
+        let result = type_checker.check_types(&program);
+        assert!(
+            result.is_err(),
+            "Expected a type error for non-map response headers"
+        );
+        let errors = result.err().unwrap();
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.message.contains("Response headers must be a map")),
+            "Expected the response-headers type error, got: {errors:?}"
         );
     }
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1896,6 +1896,7 @@ impl TypeChecker {
                 content,
                 status,
                 content_type,
+                headers: _headers,
                 line: _line,
                 column: _column,
             } => {

--- a/tests/respond_headers_test.rs
+++ b/tests/respond_headers_test.rs
@@ -1,0 +1,189 @@
+// TDD tests for custom response headers on the `respond` statement.
+//
+// Motivation: RFC 10008 (The HTTP QUERY Method) requires servers to be able to
+// advertise `Accept-Query` and to point at query results with `Content-Location`
+// / `Location`. Until now `respond to` could only set the status and content
+// type, so a WFL server had no way to emit those headers. This adds an optional
+// `and headers <map>` clause that mirrors the outbound client's `with headers`
+// form (same concept, same syntax — nothing to unlearn).
+//
+// New syntax:
+//   respond to req with "body" and content_type "application/json" and headers h
+//
+// where `h` is a map of header name -> value.
+
+use std::time::Duration;
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::parser::ast::Statement;
+
+fn parse_single_statement(code: &str) -> Statement {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error for {code:?}: {e:?}"));
+    assert_eq!(
+        program.statements.len(),
+        1,
+        "Expected exactly one statement for {code:?}"
+    );
+    program.statements.into_iter().next().unwrap()
+}
+
+#[test]
+fn test_respond_without_headers_leaves_headers_none() {
+    // Backward compatibility: the existing form must keep parsing with no headers.
+    let stmt =
+        parse_single_statement(r#"respond to req with "hello" and content_type "text/plain""#);
+    match stmt {
+        Statement::RespondStatement {
+            headers,
+            content_type,
+            ..
+        } => {
+            assert!(headers.is_none(), "Expected no headers clause");
+            assert!(content_type.is_some(), "content_type should still parse");
+        }
+        other => panic!("Expected RespondStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_respond_with_headers_clause_captures_headers() {
+    let stmt = parse_single_statement(
+        r#"respond to req with "hello" and content_type "text/plain" and headers response_headers"#,
+    );
+    match stmt {
+        Statement::RespondStatement { headers, .. } => {
+            assert!(
+                headers.is_some(),
+                "Expected the `and headers <map>` clause to be captured"
+            );
+        }
+        other => panic!("Expected RespondStatement, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_respond_with_headers_clause_order_independent() {
+    // `headers` may appear before `status`/`content_type`.
+    let stmt = parse_single_statement(
+        r#"respond to req with "hello" and headers response_headers and status 200 and content_type "text/plain""#,
+    );
+    match stmt {
+        Statement::RespondStatement {
+            headers,
+            status,
+            content_type,
+            ..
+        } => {
+            assert!(headers.is_some(), "headers should parse");
+            assert!(status.is_some(), "status should parse");
+            assert!(content_type.is_some(), "content_type should parse");
+        }
+        other => panic!("Expected RespondStatement, got {other:?}"),
+    }
+}
+
+/// Helper to start a WFL server in a separate thread with its own runtime.
+/// Mirrors the harness in `web_server_content_length_test.rs`.
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("Failed to parse WFL server code");
+            let mut interpreter = Interpreter::new();
+            let _ = interpreter.interpret(&ast).await;
+        });
+    })
+}
+
+// End-to-end RFC 10008 flow: a WFL server receives a QUERY request, echoes the
+// method it saw as the body, and advertises `Accept-Query` via a custom header
+// map. A reqwest client sends the QUERY and verifies both.
+#[tokio::test]
+async fn test_query_response_sets_custom_headers() {
+    let port = 8123;
+    let server_code = format!(
+        r#"
+        create map query_headers:
+            "Accept-Query" is "application/jsonpath"
+            "Content-Location" is "/data/results/1"
+        end map
+        listen on port {port} as query_server
+        wait for request comes in on query_server as req with timeout 10000
+        store seen_method as req["method"]
+        respond to req with seen_method and content_type "application/json" and headers query_headers
+        close server query_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+
+    // Give the server time to bind.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .request(
+            reqwest::Method::from_bytes(b"QUERY").unwrap(),
+            format!("http://127.0.0.1:{port}/data"),
+        )
+        .header("Content-Type", "application/jsonpath")
+        .body("$.items[*]")
+        .send()
+        .await
+        .expect("Failed to send QUERY request");
+
+    let status = response.status();
+
+    let accept_query = response
+        .headers()
+        .get("accept-query")
+        .expect("Accept-Query header missing")
+        .to_str()
+        .expect("Invalid Accept-Query value")
+        .to_string();
+
+    let content_location = response
+        .headers()
+        .get("content-location")
+        .expect("Content-Location header missing")
+        .to_str()
+        .expect("Invalid Content-Location value")
+        .to_string();
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .expect("Content-Type header missing")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let body = response.text().await.expect("Failed to read body");
+
+    assert!(status.is_success(), "QUERY should succeed, got {status}");
+    assert_eq!(
+        accept_query, "application/jsonpath",
+        "Accept-Query header should be set from the response headers map"
+    );
+    assert_eq!(
+        content_location, "/data/results/1",
+        "Content-Location header should be set from the response headers map"
+    );
+    assert_eq!(
+        content_type, "application/json",
+        "content_type clause should still set Content-Type"
+    );
+    assert_eq!(
+        body, "QUERY",
+        "Server should have observed the QUERY method"
+    );
+
+    let _ = server_handle.join();
+}

--- a/tests/respond_headers_test.rs
+++ b/tests/respond_headers_test.rs
@@ -97,9 +97,25 @@ fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
             let mut parser = Parser::new(&tokens);
             let ast = parser.parse().expect("Failed to parse WFL server code");
             let mut interpreter = Interpreter::new();
-            let _ = interpreter.interpret(&ast).await;
+            // Surface interpreter failures so a server that fails to start shows
+            // its real cause instead of only a downstream "connection refused".
+            if let Err(errors) = interpreter.interpret(&ast).await {
+                eprintln!("WFL server thread failed: {errors:?}");
+            }
         });
     })
+}
+
+/// Poll the port until the server is accepting connections, so tests do not
+/// depend on a fixed sleep that can be too short under CI load.
+async fn wait_for_port(port: u16) {
+    for _ in 0..100 {
+        if std::net::TcpStream::connect(("127.0.0.1", port)).is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("Server on port {port} did not start accepting connections in time");
 }
 
 // End-to-end RFC 10008 flow: a WFL server receives a QUERY request, echoes the
@@ -124,8 +140,7 @@ async fn test_query_response_sets_custom_headers() {
 
     let server_handle = start_server_thread(server_code);
 
-    // Give the server time to bind.
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    wait_for_port(port).await;
 
     let client = reqwest::Client::new();
     let response = client
@@ -183,6 +198,73 @@ async fn test_query_response_sets_custom_headers() {
     assert_eq!(
         body, "QUERY",
         "Server should have observed the QUERY method"
+    );
+
+    let _ = server_handle.join();
+}
+
+// A `Content-Type` (or other pipeline-computed header) in the custom headers map
+// must not override or duplicate the value set by the `content_type` clause /
+// response pipeline — the response must carry exactly one Content-Type.
+#[tokio::test]
+async fn test_content_type_in_headers_map_is_dropped() {
+    let port = 8124;
+    let server_code = format!(
+        r#"
+        create map sneaky_headers:
+            "Content-Type" is "text/evil"
+            "Content-Length" is "999"
+            "X-Ok" is "yes"
+        end map
+        listen on port {port} as ct_server
+        wait for request comes in on ct_server as req with timeout 10000
+        respond to req with "hello" and content_type "text/plain" and headers sneaky_headers
+        close server ct_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    wait_for_port(port).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/"))
+        .header("Content-Length", "0")
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    // Exactly one Content-Type, and it is the clause value — not "text/evil".
+    let content_types: Vec<String> = response
+        .headers()
+        .get_all("content-type")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        content_types,
+        vec!["text/plain".to_string()],
+        "content_type clause must be the sole Content-Type"
+    );
+
+    // Content-Length stays the pipeline-computed value (5 bytes = "hello"),
+    // not the "999" the map tried to inject.
+    let content_lengths: Vec<String> = response
+        .headers()
+        .get_all("content-length")
+        .iter()
+        .map(|v| v.to_str().unwrap().to_string())
+        .collect();
+    assert_eq!(
+        content_lengths,
+        vec!["5".to_string()],
+        "Content-Length must stay pipeline-computed, not overridden by the map"
+    );
+
+    // A non-reserved custom header still passes through.
+    assert_eq!(
+        response.headers().get("x-ok").unwrap().to_str().unwrap(),
+        "yes"
     );
 
     let _ = server_handle.join();


### PR DESCRIPTION
## Summary
Adds support for custom HTTP response headers in the `respond` statement via an optional `and headers <map>` clause. This enables WFL servers to implement RFC 10008 (HTTP QUERY method) by allowing them to set headers like `Accept-Query` and `Content-Location`.

## Key Changes

- **Parser** (`src/parser/stmt/web.rs`): Extended `respond` statement parsing to accept an optional `and headers <map>` clause that can appear in any order alongside `status` and `content_type` clauses.

- **AST** (`src/parser/ast.rs`): Added `headers: Option<Expression>` field to `RespondStatement` to capture the optional headers map expression.

- **Interpreter** (`src/interpreter/mod.rs`): Implemented header evaluation logic that:
  - Evaluates the headers expression to a WFL Object (map)
  - Converts header values to strings (supporting text, numbers, and booleans)
  - Filters out duplicate `Content-Type` entries to prevent conflicts with the `content_type` clause
  - Populates the response's custom headers HashMap

- **Type Checker** (`src/typechecker/mod.rs`): Updated to handle the new `headers` field in pattern matching.

- **Documentation** (`Docs/04-advanced-features/web-servers.md`): 
  - Added "With Custom Headers" section explaining the new syntax and behavior
  - Added comprehensive "The QUERY Method (RFC 10008)" section with examples for both client and server usage
  - Clarified that all optional clauses can appear in any order

- **Tests** (`tests/respond_headers_test.rs`): Added comprehensive test suite including:
  - Backward compatibility test (existing syntax still works)
  - Parser tests for header clause capture and order independence
  - End-to-end integration test demonstrating RFC 10008 QUERY flow with custom headers

- **Example Program** (`TestPrograms/rfc10008_query_server.wfl`): Added complete RFC 10008 QUERY server demo showing practical usage.

## Implementation Details

The design follows WFL's "no-unlearning" principle by mirroring the outbound client's `with headers <map>` syntax — same concept, same syntax, nothing new to learn. The `Content-Type` header is intentionally filtered from the custom headers map to maintain the authoritative role of the `content_type` clause, preventing response header conflicts.

Header values are coerced to strings, supporting text, numbers, and booleans, with clear error messages for unsupported types.

https://claude.ai/code/session_015YKDtPA3oVRA55g3yUbCQs
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom HTTP response headers in `respond to` statements.
  * Added support for the HTTP `QUERY` method, including client and server examples.

* **Documentation**
  * Expanded web server docs with custom header usage, header precedence rules, and updated combined examples.
  * Added guidance for handling `QUERY` requests.

* **Tests**
  * Added coverage for parsing response headers and verifying `QUERY` responses include the expected headers and content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->