### PR TITLE
feat: add the `route` construct for natural-language value dispatch

### DIFF
--- a/Docs/03-language-basics/control-flow.md
+++ b/Docs/03-language-basics/control-flow.md
@@ -822,6 +822,7 @@ Or explore related topics:
 - [Operators and Expressions →](operators-and-expressions.md) - Review comparison operators
 - [Actions (Functions) →](actions-functions.md) - Use conditionals in functions
 - [Error Handling →](error-handling.md) - Handle errors with conditions
+- [Routing →](../04-advanced-features/routing.md) - Dispatch on a value with `route` instead of a long `otherwise check if` chain
 
 ---
 

--- a/Docs/04-advanced-features/index.md
+++ b/Docs/04-advanced-features/index.md
@@ -13,6 +13,7 @@ This section covers WFL's advanced capabilities:
 5. **[Containers (OOP)](containers-oop.md)** - Object-oriented programming
 6. **[Subprocess Execution](subprocess-execution.md)** - Running external commands
 7. **[Interoperability](interoperability.md)** - Working with other technologies
+8. **[Routing](routing.md)** - Dispatch on a value with `route` (WFL's match/switch)
 
 ## Prerequisites
 

--- a/Docs/04-advanced-features/routing.md
+++ b/Docs/04-advanced-features/routing.md
@@ -1,0 +1,184 @@
+# Routing with `route`
+
+`route` is WFL's natural-language way to **dispatch on a value** — pick one branch
+out of many based on what a value is. It reads like the `check if` chains you
+already know, but it says the subject once instead of on every line.
+
+Its flagship use is web-server request routing (matching a URL path), but `route`
+is general: it is WFL's `match`/`switch`, and works on any value.
+
+## Why `route`?
+
+Dispatching on a value is one of the most common shapes in real programs. Without
+`route`, you repeat the subject on every arm:
+
+```wfl
+check if path is equal to "/":
+    display "home"
+otherwise check if path is equal to "/health":
+    display "ok"
+otherwise check if path is equal to "/pricing":
+    display "pricing"
+otherwise:
+    display "not found"
+end check
+```
+
+The value — the thing that actually varies — is buried in the middle of each line,
+and `path is equal to` is repeated over and over. `route` factors that out:
+
+```wfl
+route path:
+    when "/":
+        display "home"
+    when "/health":
+        display "ok"
+    when "/pricing":
+        display "pricing"
+    otherwise:
+        display "not found"
+end route
+```
+
+Same behavior, less noise. In fact, `route` **is** the `check if` chain above —
+the parser rewrites one into the other — so there is nothing new to learn about how
+it runs. Anything you can write in a `check if` body, you can write in a `when` arm.
+
+## Anatomy of a `route` block
+
+```wfl
+route <subject>:
+    when <pattern>:
+        <statements>
+    when <pattern>:
+        <statements>
+    otherwise:
+        <statements>
+end route
+```
+
+- **`route <subject>:`** — `<subject>` is any expression (a variable, a property, a
+  function result). It is the value every arm is compared against.
+- **`when <pattern>:`** — an arm. If `<pattern>` matches the subject, the arm's
+  statements run and the block finishes. Arms are tried top to bottom, and the
+  **first match wins** — exactly like `otherwise check if`.
+- **`otherwise:`** — the default arm, run when no `when` matched. It is optional and,
+  if present, must come last.
+- **`end route`** — closes the block, like `end check` and `end action`.
+
+If nothing matches and there is no `otherwise`, the `route` simply does nothing —
+it is a no-op, never an error.
+
+## Patterns
+
+A `when` head accepts these pattern forms:
+
+| Pattern                     | Matches when the subject …                    | Example |
+|-----------------------------|-----------------------------------------------|---------|
+| `when V`                    | is equal to `V`                               | `when "/pricing":` |
+| `when V1 or V2`             | is equal to any listed value                  | `when 404 or 410:` |
+| `when contains V`           | (text) contains the substring `V`             | `when contains "admin":` |
+| `when one of L`             | is a member of the list `L`                   | `when one of asset_files:` |
+| `when starts with V`        | (text) starts with the prefix `V`             | `when starts with "/api/":` |
+| `when ends with V`          | (text) ends with the suffix `V`               | `when ends with ".css":` |
+| `otherwise`                 | no earlier arm matched                        | `otherwise:` |
+
+These are ordinary WFL comparisons under the hood: `when V` is `subject is equal to
+V`, `when contains V` is `contains of subject and V`, `when starts with V` is
+`starts_with of subject and V`, and so on. You can always fall back to a full
+`check if` if you need a condition the pattern table doesn't cover.
+
+### Equality and or-lists
+
+```wfl
+route status_code:
+    when 200:
+        display "OK"
+    when 404 or 410:
+        display "Gone"
+    otherwise:
+        display "Unexpected status"
+end route
+```
+
+### Text tests — `contains`, `starts with`, `ends with`
+
+```wfl
+route request_path:
+    when starts with "/api/":
+        display "API request"
+    when ends with ".css":
+        display "stylesheet"
+    when contains "admin":
+        display "restricted area"
+    otherwise:
+        display "static page"
+end route
+```
+
+### List membership — `one of`
+
+```wfl
+store known_assets as ["/style.css", "/logo.svg", "/app.js"]
+route candidate:
+    when one of known_assets:
+        display "serve known asset"
+    otherwise:
+        display "404 unknown asset"
+end route
+```
+
+## First match wins
+
+Arms are checked in order, so put more specific arms first. Here a request to
+`/api/theme.css` matches both `starts with "/api/"` and `ends with ".css"`, and the
+API arm wins because it is listed first:
+
+```wfl
+route path:
+    when starts with "/api/":
+        display "API"      // this runs for /api/theme.css
+    when ends with ".css":
+        display "stylesheet"
+    otherwise:
+        display "page"
+end route
+```
+
+## `route` is a general match / switch
+
+The subject is any expression, so `route` is not limited to web routing:
+
+```wfl
+route count:
+    when 1:
+        display "first"
+    when 2 or 3:
+        display "second or third"
+    otherwise:
+        display "later"
+end route
+```
+
+## The No-Unlearning path
+
+`route` is designed as a gradient, not a new dialect:
+
+- `when "/pricing":` maps one-to-one onto `check if path is equal to "/pricing":`,
+  and `otherwise` is the same word you already use.
+- A `when` arm's body is ordinary WFL statements — nothing inside an arm is new.
+- A beginner who only knows `check if` can read a `route` block on first sight, and
+  can always rewrite it back into a `check if` chain with nothing to unlearn.
+
+## Reserved words
+
+`route` is a reserved keyword and cannot be used as a variable name. `when` is also
+reserved (it is shared with `try`/`catch` error handling). If you were using `route`
+as an identifier, rename it (for example, `route` → `current_route`).
+
+## See also
+
+- [Control Flow](../03-language-basics/control-flow.md) — the `check if` chain that
+  `route` builds on.
+- [Web Servers](web-servers.md) — `route`'s flagship use: request dispatch.
+- [Keyword Reference](../reference/keyword-reference.md) — the full keyword list.

--- a/Docs/04-advanced-features/routing.md
+++ b/Docs/04-advanced-features/routing.md
@@ -69,6 +69,21 @@ end route
 If nothing matches and there is no `otherwise`, the `route` simply does nothing —
 it is a no-op, never an error.
 
+> **Note — the subject is compared once per arm.** Because `route` lowers to a
+> `check if / otherwise check if` chain, the subject expression is compared against
+> each `when` arm in turn until one matches. For the usual case — a variable or a
+> plain value — this is exactly what you want. If your subject is an expression with
+> side effects or one that is expensive to compute, evaluate it into a variable
+> first and route on that variable:
+>
+> ```wfl
+> store roll as roll_dice
+> route roll:
+>     when 1: display "one"
+>     otherwise: display "something else"
+> end route
+> ```
+
 ## Patterns
 
 A `when` head accepts these pattern forms:

--- a/Docs/development/route-construct-design.md
+++ b/Docs/development/route-construct-design.md
@@ -1,8 +1,37 @@
 # Design: The `route` Construct
 
-**Status:** Proposed (design/spec — not yet implemented)
+**Status:** Implemented — Level 1 + patterns (phases 1–4, 6). Level 2 declarative
+arms (phase 5) and the dedicated-AST/LSP work (phase 7) remain follow-ups.
 **Author:** WFL design discussion
 **Applies to:** Language + parser; flagship use is web-server request routing.
+
+## Implementation status
+
+The `route` construct is implemented as parser-level desugaring, exactly as the
+"Parser desugaring (recommended for Level 1)" strategy below describes. Highlights:
+
+- **Lexer:** `route` is a dedicated structural keyword (`Token::KeywordRoute`);
+  `when` is reused as the arm head (`src/lexer/token.rs`).
+- **Parser:** `src/parser/stmt/route.rs` lowers a `route … end route` block into
+  the same `IfStatement` chain a hand-written `check if / otherwise check if /
+  otherwise` would produce. No analyzer, type-checker, or interpreter changes.
+- **Patterns (all reliable under the full pipeline):** equality (`when V`),
+  or-lists (`when V1 or V2`), `when contains V`, `when one of L`, and — resolving
+  the issue #566 concern below — `when starts with V` and `when ends with V`.
+  Because the route head consumes these operator words as tokens directly (instead
+  of relying on the fragile bareword path), they desugar cleanly to the
+  `starts_with` / `ends_with` builtins, which are now also registered in the
+  type checker (`src/stdlib/typechecker.rs`).
+- **Tests:** parser unit tests (`src/parser/tests.rs`), a lexer token test
+  (`src/lexer/tests.rs`), an end-to-end pipeline test suite (`tests/route_test.rs`),
+  and a runnable demonstration (`TestPrograms/route_comprehensive.wfl`).
+- **Docs:** user guide at `Docs/04-advanced-features/routing.md`, cross-linked from
+  control flow; keyword references updated (`route` added as the 53rd structural
+  keyword, total 179).
+
+**Not yet implemented:** the Level 2 declarative arm forms (`show page`,
+`serve asset`, `call … with …`, plus `with status` / `with content_type`
+modifiers) and the optional dedicated `Statement::Route` AST node for tooling.
 
 ## Motivation
 

--- a/Docs/development/route-construct-design.md
+++ b/Docs/development/route-construct-design.md
@@ -14,14 +14,19 @@ The `route` construct is implemented as parser-level desugaring, exactly as the
   `when` is reused as the arm head (`src/lexer/token.rs`).
 - **Parser:** `src/parser/stmt/route.rs` lowers a `route … end route` block into
   the same `IfStatement` chain a hand-written `check if / otherwise check if /
-  otherwise` would produce. No analyzer, type-checker, or interpreter changes.
+  otherwise` would produce. The lowering introduces no new AST node, so the
+  **route construct itself** needs no analyzer, type-checker, or interpreter
+  changes — the desugared chain flows through the existing pipeline unchanged.
 - **Patterns (all reliable under the full pipeline):** equality (`when V`),
   or-lists (`when V1 or V2`), `when contains V`, `when one of L`, and — resolving
   the issue #566 concern below — `when starts with V` and `when ends with V`.
   Because the route head consumes these operator words as tokens directly (instead
   of relying on the fragile bareword path), they desugar cleanly to the
-  `starts_with` / `ends_with` builtins, which are now also registered in the
-  type checker (`src/stdlib/typechecker.rs`).
+  `starts_with` / `ends_with` builtins. Those builtins already existed at runtime
+  but lacked type signatures; this change additionally registers them in the type
+  checker (`src/stdlib/typechecker.rs`). That stdlib registration is the one change
+  outside the parser — it is independent of the route lowering and benefits any
+  caller of `starts_with` / `ends_with`, not just `route`.
 - **Tests:** parser unit tests (`src/parser/tests.rs`), a lexer token test
   (`src/lexer/tests.rs`), an end-to-end pipeline test suite (`tests/route_test.rs`),
   and a runnable demonstration (`TestPrograms/route_comprehensive.wfl`).

--- a/Docs/reference/keyword-reference.md
+++ b/Docs/reference/keyword-reference.md
@@ -4,7 +4,7 @@ Quick lookup for all WFL reserved keywords.
 
 **→ For complete technical details:** [Reserved Keywords (Complete) →](reserved-keywords.md)
 
-**Total:** 178 keywords and literals
+**Total:** 179 keywords and literals
 
 ---
 
@@ -17,7 +17,7 @@ Quick lookup for all WFL reserved keywords.
 
 ---
 
-## Control Flow Keywords (23)
+## Control Flow Keywords (24)
 
 | Keyword | Description | As Var? |
 |---------|-------------|---------|
@@ -36,9 +36,10 @@ Quick lookup for all WFL reserved keywords.
 | `if` | Conditional | ✗ |
 | `in` | For each collection | ✗ |
 | `loop` | Loop reference | ✗ |
-| `otherwise` | Else clause | ✗ |
+| `otherwise` | Else / default clause | ✗ |
 | `repeat` | Loop construct | ✗ |
 | `reversed` | Reverse iteration | ✓ |
+| `route` | Dispatch on a value (match/switch) | ✗ |
 | `skip` | Continue (alias) | ✗ |
 | `then` | Conditional separator | ✗ |
 | `to` | Count loop end | ✗ |
@@ -244,7 +245,7 @@ Quick lookup for all WFL reserved keywords.
 | `catch` | Error handler | ✗ |
 | `error` | Error reference | ✗ |
 | `try` | Error handling block | ✗ |
-| `when` | Specific error type | ✗ |
+| `when` | Specific error type; also a `route` arm head | ✗ |
 
 ---
 

--- a/Docs/reference/reserved-keywords.md
+++ b/Docs/reference/reserved-keywords.md
@@ -5,7 +5,7 @@ Complete technical documentation for all WFL reserved keywords.
 **→ For quick lookup:** [Keyword Reference (Quick) →](keyword-reference.md)
 
 **Source:** WFL Compiler v26.1.x (extracted from `src/lexer/token.rs`)
-**Total:** 178 keywords and literals
+**Total:** 179 keywords and literals
 **Last Updated:** 2026-01-16
 
 ---
@@ -16,7 +16,7 @@ Complete technical documentation for all WFL reserved keywords.
    - [What Makes a Keyword "Structural"?](#what-makes-a-keyword-structural)
    - [What Makes a Keyword "Contextual"?](#what-makes-a-keyword-contextual)
    - [Why Some Keywords Appear in Multiple Lists](#why-some-keywords-appear-in-multiple-lists)
-2. [Structural Keywords (52)](#structural-keywords-52)
+2. [Structural Keywords (53)](#structural-keywords-53)
 3. [Contextual Keywords (29)](#contextual-keywords-29)
 4. [Other Reserved Keywords (95)](#other-reserved-keywords-95)
 5. [Boolean & Null Literals (7)](#boolean--null-literals-7)
@@ -29,7 +29,7 @@ Complete technical documentation for all WFL reserved keywords.
 
 ## Understanding Keyword Classifications
 
-WFL's 178 reserved keywords are organized into four distinct types. Understanding these classifications helps you know which keywords you can never use as variable names, and which ones might be available in certain contexts.
+WFL's 179 reserved keywords are organized into four distinct types. Understanding these classifications helps you know which keywords you can never use as variable names, and which ones might be available in certain contexts.
 
 ### What Makes a Keyword "Structural"?
 
@@ -38,7 +38,7 @@ WFL's 178 reserved keywords are organized into four distinct types. Understandin
 **Key characteristics:**
 - **Always reserved** - Cannot be used as variable names in any context
 - **Parser priority** - Checked first by the parser
-- **Total count:** 52 keywords
+- **Total count:** 53 keywords
 
 **Examples:**
 ```wfl
@@ -93,7 +93,7 @@ create list called items     // ✅ 'list' is a type keyword here
 
 ### Marker Words That Are Not Keywords at All
 
-A few words have special meaning in exactly one statement position but are **not reserved in any way** — they are ordinary identifiers that the parser recognizes purely by position. They do not count toward the 178 keywords, and you can freely use them as variable names everywhere:
+A few words have special meaning in exactly one statement position but are **not reserved in any way** — they are ordinary identifiers that the parser recognizes purely by position. They do not count toward the 179 keywords, and you can freely use them as variable names everywhere:
 
 - `secured` - HTTPS marker in `listen on port 8443 secured ... as server`
 - `certificate` - certificate path marker in `secured with certificate "cert.pem"`
@@ -125,7 +125,7 @@ store push as "save"         // ❌ ERROR: 'push' is reserved (structural)
 
 ---
 
-## Structural Keywords (52)
+## Structural Keywords (53)
 
 These keywords **MUST** always be reserved and **CANNOT** be used as variable names. They define program structure and control flow.
 
@@ -169,6 +169,7 @@ These keywords **MUST** always be reserved and **CANNOT** be used as variable na
 | `repeat` | Loop construct | `repeat 10 times:` |
 | `requires` | Interface requirement | `requires method run` |
 | `return` | Return value | `return result` |
+| `route` | Dispatch on a value (match/switch) | `route path:` |
 | `skip` | Continue (alias) | `skip` |
 | `static` | Static member | `static property counter` |
 | `store` | Create variable | `store x as 10` |
@@ -179,12 +180,12 @@ These keywords **MUST** always be reserved and **CANNOT** be used as variable na
 | `try` | Error handling | `try:` |
 | `until` | Loop condition | `repeat until x is 10:` |
 | `wait` | Async wait | `wait for result` |
-| `when` | Specific error type | `catch when FileError:` |
+| `when` | Error type / `route` arm head | `catch when FileError:` · `when "/health":` |
 | `while` | Loop condition | `repeat while x is less than 10:` |
 | `with` | Parameter separator | `call action with x and y` |
 | `zero` | Pattern quantifier | `define pattern zero or more digits` |
 
-**Total:** 52 structural keywords
+**Total:** 53 structural keywords
 
 **Important Note:** The keywords `any`, `push`, `skip`, `than`, and `zero` also appear in the contextual keyword list in the source code, but since structural keywords are checked first in the parser, they **CANNOT** be used as variable names.
 
@@ -274,7 +275,7 @@ All other reserved keywords that don't fall into structural or contextual-only c
 
 **Count:** 95 other reserved keywords
 
-**Note:** This count (95) represents keywords that are not in the structural (52) or contextual-only (24) categories, and are not boolean/null literals (7). Total: 52 + 24 + 95 + 7 = 178.
+**Note:** This count (95) represents keywords that are not in the structural (53) or contextual-only (24) categories, and are not boolean/null literals (7). Total: 53 + 24 + 95 + 7 = 179.
 
 ---
 
@@ -360,7 +361,7 @@ Keywords organized by functional area for easier reference.
 
 ### Rule 1: Structural Keywords Are Always Reserved
 
-Never use the 52 structural keywords as variable names, function names, or any other identifier.
+Never use the 53 structural keywords as variable names, function names, or any other identifier.
 
 **Wrong:**
 ```wfl
@@ -533,7 +534,7 @@ store zero as 0             // ❌ ERROR: 'zero' is also structural
 
 ## Complete Alphabetical Reference
 
-Complete reference table of all 178 keywords.
+Complete reference table of all 179 keywords.
 
 | Keyword | Type | Category | As Var? | Example |
 |---------|------|----------|---------|---------|
@@ -677,6 +678,7 @@ Complete reference table of all 178 keywords.
 | `response` | Other | Web/Network | ❌ | `HTTP response` |
 | `return` | Structural | Operations | ❌ | `return value` |
 | `reversed` | Contextual | Control Flow | ✅ | `count reversed` |
+| `route` | Structural | Control Flow | ❌ | `route path:` |
 | `running` | Other | Process | ❌ | `process running` |
 | `same` | Other | Comparison | ❌ | `is same as` |
 | `script` | Other | Pattern | ❌ | `unicode script` |
@@ -717,7 +719,7 @@ Complete reference table of all 178 keywords.
 | `yes` | Literal | Values | ❌ | Boolean true |
 | `zero` | Structural | Pattern | ❌ | `zero or more` |
 
-**Total: 178 keywords and literals**
+**Total: 179 keywords and literals**
 
 ---
 

--- a/TestPrograms/route_comprehensive.wfl
+++ b/TestPrograms/route_comprehensive.wfl
@@ -1,0 +1,146 @@
+// route_comprehensive.wfl
+// End-to-end demonstration of the `route` construct: WFL's natural-language
+// "dispatch on a value" form. `route` lowers in the parser to the same
+// `check if / otherwise check if / otherwise` chain you would write by hand,
+// so everything here is ordinary WFL behavior with a cleaner surface.
+//
+// Run:  wfl TestPrograms/route_comprehensive.wfl
+// This program exits 0 and prints a deterministic transcript.
+
+display "=== route construct comprehensive test ==="
+display ""
+
+// ---------------------------------------------------------------------------
+// 1. Equality arms — the everyday case (subject is equal to the value).
+// ---------------------------------------------------------------------------
+display "-- equality --"
+store path as "/health"
+route path:
+    when "/":
+        display "home page"
+    when "/health":
+        display "health check ok"
+    otherwise:
+        display "not found"
+end route
+
+// ---------------------------------------------------------------------------
+// 2. Or-lists — one arm matches any of several values.
+// ---------------------------------------------------------------------------
+display ""
+display "-- or-list --"
+store status_code as 410
+route status_code:
+    when 200:
+        display "OK"
+    when 404 or 410:
+        display "Gone"
+    otherwise:
+        display "Unexpected status"
+end route
+
+// ---------------------------------------------------------------------------
+// 3. Text tests — contains / starts with / ends with.
+//    (These all run under the full pipeline, not just --analyze.)
+// ---------------------------------------------------------------------------
+display ""
+display "-- text tests --"
+store request_path as "/api/users"
+route request_path:
+    when starts with "/api/":
+        display "api route"
+    when ends with ".css":
+        display "stylesheet"
+    when contains "admin":
+        display "restricted area"
+    otherwise:
+        display "static page"
+end route
+
+store asset as "/theme/site.css"
+route asset:
+    when starts with "/api/":
+        display "api route"
+    when ends with ".css":
+        display "stylesheet"
+    otherwise:
+        display "static page"
+end route
+
+// ---------------------------------------------------------------------------
+// 4. Membership — subject is one of a list.
+// ---------------------------------------------------------------------------
+display ""
+display "-- membership --"
+store known_assets as ["/style.css", "/logo.svg", "/app.js"]
+store candidate as "/logo.svg"
+route candidate:
+    when one of known_assets:
+        display "serve known asset"
+    otherwise:
+        display "404 unknown asset"
+end route
+
+// ---------------------------------------------------------------------------
+// 5. First match wins — arm order is significant, exactly like check if.
+// ---------------------------------------------------------------------------
+display ""
+display "-- precedence --"
+store overlap as "/api/theme.css"
+route overlap:
+    when starts with "/api/":
+        display "matched api first"
+    when ends with ".css":
+        display "matched css"
+    otherwise:
+        display "no match"
+end route
+
+// ---------------------------------------------------------------------------
+// 6. Multi-statement arm bodies — an arm is ordinary WFL statements.
+// ---------------------------------------------------------------------------
+display ""
+display "-- multi-statement body --"
+store cmd as "deploy"
+route cmd:
+    when "deploy":
+        display "step 1: build"
+        display "step 2: upload"
+        display "step 3: restart"
+    otherwise:
+        display "unknown command"
+end route
+
+// ---------------------------------------------------------------------------
+// 7. No match, no otherwise — the route is a no-op (never errors).
+// ---------------------------------------------------------------------------
+display ""
+display "-- no-op (no match, no otherwise) --"
+store unmatched as 99
+display "before route"
+route unmatched:
+    when 1:
+        display "one"
+    when 2:
+        display "two"
+end route
+display "after route (route did nothing)"
+
+// ---------------------------------------------------------------------------
+// 8. Non-string subjects — route is a general match/switch, not web-only.
+// ---------------------------------------------------------------------------
+display ""
+display "-- general switch on a number --"
+count from 1 to 4:
+    route count:
+        when 1:
+            display "count is one"
+        when 2 or 3:
+            display "count is two or three"
+        otherwise:
+            display "count is something else"
+    end route
+end count
+
+display ""
+display "=== route construct comprehensive test complete ==="

--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -616,3 +616,19 @@ fn test_boolean_literal_values() {
         }
     }
 }
+
+#[test]
+fn test_route_keyword_lexing() {
+    use logos::Logos;
+
+    // `route` is a dedicated structural keyword.
+    let mut lexer = Token::lexer("route");
+    assert_eq!(lexer.next(), Some(Ok(Token::KeywordRoute)));
+
+    // `when` remains its own keyword, reused as the route arm head.
+    let mut lexer = Token::lexer("when");
+    assert_eq!(lexer.next(), Some(Ok(Token::KeywordWhen)));
+
+    // `route` is structural (must always be reserved).
+    assert!(Token::KeywordRoute.is_structural_keyword());
+}

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -199,6 +199,8 @@ pub enum Token {
     KeywordTry,
     #[token("when")]
     KeywordWhen,
+    #[token("route")]
+    KeywordRoute,
     #[token("catch")]
     KeywordCatch,
     #[token("data")]
@@ -584,6 +586,7 @@ impl Token {
                 | Token::KeywordExport
                 | Token::KeywordTry
                 | Token::KeywordWhen
+                | Token::KeywordRoute
                 | Token::KeywordCatch
                 | Token::KeywordSkip
                 | Token::KeywordThan

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -200,6 +200,8 @@ impl<'a> Parser<'a> {
             Token::KeywordBinary => "binary".to_string(),
             Token::KeywordBytes => "bytes".to_string(),
             Token::KeywordThat => "that".to_string(),
+            Token::KeywordRoute => "route".to_string(),
+            Token::KeywordWhen => "when".to_string(),
             _ => format!("{:?}", token),
         }
     }
@@ -215,6 +217,7 @@ impl<'a> Parser<'a> {
                 | Token::KeywordIf
                 | Token::KeywordCount
                 | Token::KeywordFor
+                | Token::KeywordRoute
                 | Token::KeywordDefine
                 | Token::KeywordChange
                 | Token::KeywordTry

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -13,8 +13,8 @@ pub use cursor::Cursor; // Re-export Cursor publicly for doctests
 use expr::{ExprParser, PrimaryExprParser};
 use stmt::{
     ActionParser, CollectionParser, ContainerParser, ControlFlowParser, DatabaseParser,
-    ErrorHandlingParser, IoParser, ModuleParser, PatternParser, ProcessParser, StmtParser,
-    TestingParser, VariableParser, WebParser,
+    ErrorHandlingParser, IoParser, ModuleParser, PatternParser, ProcessParser, RouteParser,
+    StmtParser, TestingParser, VariableParser, WebParser,
 };
 
 pub struct Parser<'a> {
@@ -436,6 +436,7 @@ impl<'a> StmtParser<'a> for Parser<'a> {
                 Token::KeywordIf => self.parse_single_line_if(),
                 Token::KeywordCount => self.parse_count_loop(),
                 Token::KeywordFor => self.parse_for_each_loop(),
+                Token::KeywordRoute => self.parse_route(),
                 Token::KeywordDefine => self.parse_action_definition(),
                 Token::KeywordChange => self.parse_assignment(),
                 Token::KeywordAdd => {

--- a/src/parser/stmt/mod.rs
+++ b/src/parser/stmt/mod.rs
@@ -15,6 +15,7 @@ mod io;
 mod module;
 mod patterns;
 mod processes;
+mod route;
 mod testing;
 mod variables;
 mod web;
@@ -29,6 +30,7 @@ pub(crate) use io::IoParser;
 pub(crate) use module::ModuleParser;
 pub(crate) use patterns::PatternParser;
 pub(crate) use processes::ProcessParser;
+pub(crate) use route::RouteParser;
 pub(crate) use testing::TestingParser;
 pub(crate) use variables::VariableParser;
 pub(crate) use web::WebParser;
@@ -56,6 +58,7 @@ pub(crate) trait StmtParser<'a>:
     + PatternParser<'a>
     + ContainerParser<'a>
     + ModuleParser<'a>
+    + RouteParser<'a>
     + TestingParser<'a>
 {
     /// Parses a statement by dispatching to the appropriate parser based on the current token.

--- a/src/parser/stmt/route.rs
+++ b/src/parser/stmt/route.rs
@@ -1,0 +1,353 @@
+//! `route` statement parsing — a natural-language "dispatch on a value" form.
+//!
+//! `route` is **pure syntactic sugar**. It lowers, entirely in the parser, to the
+//! same `check if / otherwise check if / otherwise` chain (`Statement::IfStatement`)
+//! that a hand-written dispatch would produce. Because no new AST node reaches the
+//! analyzer, type checker, or interpreter, every existing WFL program is unaffected
+//! and the feature needs no runtime support.
+//!
+//! ```text
+//! route <subject>:
+//!     when P1: B1
+//!     when P2: B2
+//!     otherwise: Bd
+//! end route
+//! ```
+//!
+//! lowers to
+//!
+//! ```text
+//! check if <subject matches P1>:
+//!     B1
+//! otherwise check if <subject matches P2>:
+//!     B2
+//! otherwise:
+//!     Bd
+//! end check
+//! ```
+//!
+//! The `<subject matches Pn>` condition is built from the pattern head:
+//!
+//! | Pattern head            | Condition                                   |
+//! |-------------------------|---------------------------------------------|
+//! | `when V`                | `subject is equal to V`                     |
+//! | `when V1 or V2`         | `subject == V1 or subject == V2`            |
+//! | `when contains V`       | `contains of subject and V`                 |
+//! | `when one of L`         | `contains of L and subject` (membership)    |
+//! | `when starts with V`    | `starts_with of subject and V`              |
+//! | `when ends with V`      | `ends_with of subject and V`                |
+
+use super::super::{ParseError, Parser, Statement};
+use super::StmtParser;
+use crate::lexer::token::Token;
+use crate::parser::ast::{Argument, Expression, Literal, Operator};
+use crate::parser::expr::{ExprParser, PrimaryExprParser};
+
+pub(crate) trait RouteParser<'a>: ExprParser<'a> {
+    /// Parse a `route … end route` block and return its desugared
+    /// `IfStatement` chain.
+    fn parse_route(&mut self) -> Result<Statement, ParseError>
+    where
+        Self: StmtParser<'a>;
+}
+
+/// Build a two-argument builtin call expression, e.g. `contains of a and b`.
+fn builtin_call(
+    name: &str,
+    a: Expression,
+    b: Expression,
+    line: usize,
+    column: usize,
+) -> Expression {
+    Expression::FunctionCall {
+        function: Box::new(Expression::Variable(name.to_string(), line, column)),
+        arguments: vec![
+            Argument {
+                name: None,
+                value: a,
+            },
+            Argument {
+                name: None,
+                value: b,
+            },
+        ],
+        line,
+        column,
+    }
+}
+
+impl<'a> RouteParser<'a> for Parser<'a> {
+    fn parse_route(&mut self) -> Result<Statement, ParseError>
+    where
+        Self: StmtParser<'a>,
+    {
+        let route_token = self.bump_sync().unwrap(); // Consume "route"
+        let line = route_token.line;
+        let column = route_token.column;
+
+        // The subject is any expression, up to the ':' that opens the body.
+        let subject = self.parse_expression()?;
+
+        if let Some(token) = self.cursor.peek()
+            && matches!(&token.token, Token::Colon)
+        {
+            self.bump_sync(); // Consume the colon if present
+        }
+        self.skip_eol();
+
+        let mut arms: Vec<(Expression, Vec<Statement>)> = Vec::new();
+        let mut default_body: Option<Vec<Statement>> = None;
+
+        loop {
+            self.skip_eol();
+
+            let Some(token) = self.cursor.peek() else {
+                return Err(self.cursor.error(
+                    "Expected 'when', 'otherwise', or 'end route' in route block".to_string(),
+                ));
+            };
+
+            match &token.token {
+                Token::KeywordWhen => {
+                    if default_body.is_some() {
+                        return Err(ParseError::from_token(
+                            "'otherwise' must be the last arm in a route block".to_string(),
+                            token,
+                        ));
+                    }
+
+                    let when_token = self.bump_sync().unwrap(); // Consume "when"
+                    let condition =
+                        self.parse_route_pattern(&subject, when_token.line, when_token.column)?;
+
+                    if let Some(t) = self.cursor.peek()
+                        && matches!(&t.token, Token::Colon)
+                    {
+                        self.bump_sync(); // Consume the colon if present
+                    }
+                    self.skip_eol();
+
+                    let body = self.parse_route_arm_body()?;
+                    arms.push((condition, body));
+                }
+                Token::KeywordOtherwise => {
+                    if default_body.is_some() {
+                        return Err(ParseError::from_token(
+                            "A route block may only have one 'otherwise' arm".to_string(),
+                            token,
+                        ));
+                    }
+
+                    self.bump_sync(); // Consume "otherwise"
+
+                    if let Some(t) = self.cursor.peek()
+                        && matches!(&t.token, Token::Colon)
+                    {
+                        self.bump_sync(); // Consume the colon if present
+                    }
+                    self.skip_eol();
+
+                    default_body = Some(self.parse_route_arm_body()?);
+                }
+                Token::KeywordEnd => break,
+                other => {
+                    return Err(ParseError::from_token(
+                        format!(
+                            "Expected 'when', 'otherwise', or 'end route', found {:?}",
+                            other
+                        ),
+                        token,
+                    ));
+                }
+            }
+        }
+
+        self.expect_token(Token::KeywordEnd, "Expected 'end' to close route block")?;
+        self.expect_token(Token::KeywordRoute, "Expected 'route' after 'end'")?;
+
+        // Fold the arms into a right-nested if/else-if chain, with the optional
+        // `otherwise` block as the innermost `else`.
+        let had_arms = !arms.is_empty();
+        let mut else_block: Option<Vec<Statement>> = default_body;
+
+        for (condition, body) in arms.into_iter().rev() {
+            let if_stmt = Statement::IfStatement {
+                condition,
+                then_block: body,
+                else_block: else_block.take(),
+                line,
+                column,
+            };
+            else_block = Some(vec![if_stmt]);
+        }
+
+        if had_arms {
+            // After folding, `else_block` holds exactly the outermost if.
+            Ok(else_block
+                .expect("chain with at least one arm is non-empty")
+                .pop()
+                .expect("folded chain contains the outermost if"))
+        } else if let Some(body) = else_block {
+            // A route with only an `otherwise`: run it unconditionally.
+            Ok(Statement::IfStatement {
+                condition: Expression::Literal(Literal::Boolean(true), line, column),
+                then_block: body,
+                else_block: None,
+                line,
+                column,
+            })
+        } else {
+            // An empty route (no arms, no otherwise) is a no-op, matching the
+            // semantics of a `check if` with no matching branch.
+            Ok(Statement::IfStatement {
+                condition: Expression::Literal(Literal::Boolean(false), line, column),
+                then_block: Vec::new(),
+                else_block: None,
+                line,
+                column,
+            })
+        }
+    }
+}
+
+impl<'a> Parser<'a> {
+    /// Parse the pattern that follows a `when` head and return the boolean
+    /// condition it desugars to, comparing against `subject`.
+    fn parse_route_pattern(
+        &mut self,
+        subject: &Expression,
+        line: usize,
+        column: usize,
+    ) -> Result<Expression, ParseError> {
+        let Some(token) = self.cursor.peek() else {
+            return Err(self
+                .cursor
+                .error("Expected a pattern after 'when'".to_string()));
+        };
+
+        match &token.token {
+            // `when contains V` → contains of subject and V (text substring / list membership)
+            Token::KeywordContains => {
+                self.bump_sync(); // Consume "contains"
+                let value = self.parse_primary_expression()?;
+                Ok(builtin_call(
+                    "contains",
+                    subject.clone(),
+                    value,
+                    line,
+                    column,
+                ))
+            }
+            // `when one of L` → contains of L and subject (membership test)
+            Token::KeywordOne
+                if self
+                    .cursor
+                    .peek_next()
+                    .is_some_and(|t| t.token == Token::KeywordOf) =>
+            {
+                self.bump_sync(); // Consume "one"
+                self.bump_sync(); // Consume "of"
+                let list = self.parse_primary_expression()?;
+                Ok(builtin_call(
+                    "contains",
+                    list,
+                    subject.clone(),
+                    line,
+                    column,
+                ))
+            }
+            // `when starts with V` → starts_with of subject and V
+            Token::Identifier(id)
+                if id == "starts"
+                    && self
+                        .cursor
+                        .peek_next()
+                        .is_some_and(|t| t.token == Token::KeywordWith) =>
+            {
+                self.bump_sync(); // Consume "starts"
+                self.bump_sync(); // Consume "with"
+                let value = self.parse_primary_expression()?;
+                Ok(builtin_call(
+                    "starts_with",
+                    subject.clone(),
+                    value,
+                    line,
+                    column,
+                ))
+            }
+            // `when ends with V` → ends_with of subject and V
+            Token::Identifier(id)
+                if id == "ends"
+                    && self
+                        .cursor
+                        .peek_next()
+                        .is_some_and(|t| t.token == Token::KeywordWith) =>
+            {
+                self.bump_sync(); // Consume "ends"
+                self.bump_sync(); // Consume "with"
+                let value = self.parse_primary_expression()?;
+                Ok(builtin_call(
+                    "ends_with",
+                    subject.clone(),
+                    value,
+                    line,
+                    column,
+                ))
+            }
+            // `when V` or `when V1 or V2 or …` → equality, or-chained
+            _ => {
+                let first = self.parse_primary_expression()?;
+                let mut condition = Expression::BinaryOperation {
+                    left: Box::new(subject.clone()),
+                    operator: Operator::Equals,
+                    right: Box::new(first),
+                    line,
+                    column,
+                };
+
+                while self
+                    .cursor
+                    .peek()
+                    .is_some_and(|t| t.token == Token::KeywordOr)
+                {
+                    self.bump_sync(); // Consume "or"
+                    let next = self.parse_primary_expression()?;
+                    let equality = Expression::BinaryOperation {
+                        left: Box::new(subject.clone()),
+                        operator: Operator::Equals,
+                        right: Box::new(next),
+                        line,
+                        column,
+                    };
+                    condition = Expression::BinaryOperation {
+                        left: Box::new(condition),
+                        operator: Operator::Or,
+                        right: Box::new(equality),
+                        line,
+                        column,
+                    };
+                }
+
+                Ok(condition)
+            }
+        }
+    }
+
+    /// Collect the statements that make up a `when`/`otherwise` arm body,
+    /// stopping at the next arm, the `otherwise` arm, or `end route`.
+    fn parse_route_arm_body(&mut self) -> Result<Vec<Statement>, ParseError> {
+        let mut body = Vec::with_capacity(4);
+
+        while let Some(token) = self.cursor.peek() {
+            match &token.token {
+                Token::KeywordWhen | Token::KeywordOtherwise | Token::KeywordEnd => break,
+                Token::Eol => {
+                    self.bump_sync(); // Skip Eol between statements
+                }
+                _ => body.push(self.parse_statement()?),
+            }
+        }
+
+        Ok(body)
+    }
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1815,3 +1815,245 @@ end pattern"#;
         panic!("Expected PatternDefinition, got {result:?}");
     }
 }
+
+// ---------------------------------------------------------------------------
+// `route` construct — desugaring to the `check if` / `IfStatement` chain.
+// ---------------------------------------------------------------------------
+
+/// Parse a source string that contains exactly one statement and return it.
+fn parse_single(input: &str) -> Statement {
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+    parser
+        .parse_statement()
+        .unwrap_or_else(|e| panic!("parse failed for {input:?}: {e:?}"))
+}
+
+#[test]
+fn route_equality_arm_desugars_to_equals_if() {
+    let stmt = parse_single("route path:\n    when \"/\":\n        display \"home\"\nend route");
+    if let Statement::IfStatement {
+        condition,
+        then_block,
+        else_block,
+        ..
+    } = stmt
+    {
+        match condition {
+            Expression::BinaryOperation {
+                left,
+                operator: Operator::Equals,
+                right,
+                ..
+            } => {
+                assert!(matches!(*left, Expression::Variable(ref n, ..) if n == "path"));
+                assert!(
+                    matches!(*right, Expression::Literal(Literal::String(ref s), ..) if s.as_ref() == "/")
+                );
+            }
+            other => panic!("expected Equals condition, got {other:?}"),
+        }
+        assert_eq!(then_block.len(), 1, "arm body should have one statement");
+        assert!(else_block.is_none(), "no otherwise -> no else block");
+    } else {
+        panic!("route should desugar to an IfStatement, got {stmt:?}");
+    }
+}
+
+#[test]
+fn route_or_list_arm_desugars_to_or_of_equalities() {
+    let stmt =
+        parse_single("route code:\n    when 404 or 410:\n        display \"gone\"\nend route");
+    if let Statement::IfStatement { condition, .. } = stmt {
+        match condition {
+            Expression::BinaryOperation {
+                operator: Operator::Or,
+                left,
+                right,
+                ..
+            } => {
+                assert!(matches!(
+                    *left,
+                    Expression::BinaryOperation {
+                        operator: Operator::Equals,
+                        ..
+                    }
+                ));
+                assert!(matches!(
+                    *right,
+                    Expression::BinaryOperation {
+                        operator: Operator::Equals,
+                        ..
+                    }
+                ));
+            }
+            other => panic!("expected Or condition, got {other:?}"),
+        }
+    } else {
+        panic!("expected IfStatement, got {stmt:?}");
+    }
+}
+
+#[test]
+fn route_contains_arm_desugars_to_contains_call() {
+    let stmt =
+        parse_single("route path:\n    when contains \"admin\":\n        display \"a\"\nend route");
+    if let Statement::IfStatement { condition, .. } = stmt {
+        match condition {
+            Expression::FunctionCall {
+                function,
+                arguments,
+                ..
+            } => {
+                assert!(matches!(*function, Expression::Variable(ref n, ..) if n == "contains"));
+                assert_eq!(arguments.len(), 2);
+                // contains of subject and needle
+                assert!(
+                    matches!(arguments[0].value, Expression::Variable(ref n, ..) if n == "path")
+                );
+                assert!(
+                    matches!(arguments[1].value, Expression::Literal(Literal::String(ref s), ..) if s.as_ref() == "admin")
+                );
+            }
+            other => panic!("expected contains FunctionCall, got {other:?}"),
+        }
+    } else {
+        panic!("expected IfStatement, got {stmt:?}");
+    }
+}
+
+#[test]
+fn route_one_of_arm_is_membership_contains() {
+    let stmt =
+        parse_single("route path:\n    when one of assets:\n        display \"a\"\nend route");
+    if let Statement::IfStatement { condition, .. } = stmt {
+        match condition {
+            Expression::FunctionCall {
+                function,
+                arguments,
+                ..
+            } => {
+                assert!(matches!(*function, Expression::Variable(ref n, ..) if n == "contains"));
+                // membership: contains of list and subject
+                assert!(
+                    matches!(arguments[0].value, Expression::Variable(ref n, ..) if n == "assets")
+                );
+                assert!(
+                    matches!(arguments[1].value, Expression::Variable(ref n, ..) if n == "path")
+                );
+            }
+            other => panic!("expected contains FunctionCall, got {other:?}"),
+        }
+    } else {
+        panic!("expected IfStatement, got {stmt:?}");
+    }
+}
+
+#[test]
+fn route_starts_and_ends_with_desugar_to_builtins() {
+    let starts = parse_single(
+        "route path:\n    when starts with \"/api/\":\n        display \"api\"\nend route",
+    );
+    if let Statement::IfStatement { condition, .. } = starts {
+        assert!(
+            matches!(condition, Expression::FunctionCall { ref function, .. }
+            if matches!(**function, Expression::Variable(ref n, ..) if n == "starts_with"))
+        );
+    } else {
+        panic!("expected IfStatement");
+    }
+
+    let ends = parse_single(
+        "route path:\n    when ends with \".css\":\n        display \"css\"\nend route",
+    );
+    if let Statement::IfStatement { condition, .. } = ends {
+        assert!(
+            matches!(condition, Expression::FunctionCall { ref function, .. }
+            if matches!(**function, Expression::Variable(ref n, ..) if n == "ends_with"))
+        );
+    } else {
+        panic!("expected IfStatement");
+    }
+}
+
+#[test]
+fn route_otherwise_becomes_final_else_chain() {
+    let stmt = parse_single(
+        "route x:\n    when 1:\n        display \"one\"\n    when 2:\n        display \"two\"\n    otherwise:\n        display \"other\"\nend route",
+    );
+    // Outer if is arm 1; its else is [inner if for arm 2]; inner if's else is the otherwise body.
+    if let Statement::IfStatement { else_block, .. } = stmt {
+        let inner = else_block.expect("arm 1 should have an else");
+        assert_eq!(inner.len(), 1);
+        if let Statement::IfStatement {
+            else_block: inner_else,
+            ..
+        } = &inner[0]
+        {
+            let default_body = inner_else
+                .as_ref()
+                .expect("arm 2 should have otherwise else");
+            assert_eq!(default_body.len(), 1, "otherwise body has one statement");
+            assert!(matches!(
+                default_body[0],
+                Statement::DisplayStatement { .. }
+            ));
+        } else {
+            panic!("expected nested IfStatement for arm 2");
+        }
+    } else {
+        panic!("expected IfStatement");
+    }
+}
+
+#[test]
+fn route_with_only_otherwise_runs_unconditionally() {
+    let stmt = parse_single("route x:\n    otherwise:\n        display \"always\"\nend route");
+    if let Statement::IfStatement {
+        condition,
+        then_block,
+        else_block,
+        ..
+    } = stmt
+    {
+        assert!(matches!(
+            condition,
+            Expression::Literal(Literal::Boolean(true), ..)
+        ));
+        assert_eq!(then_block.len(), 1);
+        assert!(else_block.is_none());
+    } else {
+        panic!("expected IfStatement");
+    }
+}
+
+#[test]
+fn empty_route_is_a_noop() {
+    let stmt = parse_single("route x:\nend route");
+    if let Statement::IfStatement {
+        condition,
+        then_block,
+        ..
+    } = stmt
+    {
+        assert!(matches!(
+            condition,
+            Expression::Literal(Literal::Boolean(false), ..)
+        ));
+        assert!(then_block.is_empty());
+    } else {
+        panic!("expected IfStatement");
+    }
+}
+
+#[test]
+fn route_otherwise_before_when_is_an_error() {
+    let input = "route x:\n    otherwise:\n        display \"d\"\n    when 5:\n        display \"five\"\nend route";
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+    let result = parser.parse_statement();
+    assert!(
+        result.is_err(),
+        "otherwise before a when arm must be rejected"
+    );
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1955,9 +1955,13 @@ fn route_starts_and_ends_with_desugar_to_builtins() {
         "route path:\n    when starts with \"/api/\":\n        display \"api\"\nend route",
     );
     if let Statement::IfStatement { condition, .. } = starts {
+        // Assert the callee name AND that the arguments are (subject, literal)
+        // in that order, so a swapped or hardcoded argument fails the test.
         assert!(
-            matches!(condition, Expression::FunctionCall { ref function, .. }
-            if matches!(**function, Expression::Variable(ref n, ..) if n == "starts_with"))
+            matches!(condition, Expression::FunctionCall { ref function, ref arguments, .. }
+            if matches!(**function, Expression::Variable(ref n, ..) if n == "starts_with")
+                && matches!(arguments[0].value, Expression::Variable(ref n, ..) if n == "path")
+                && matches!(arguments[1].value, Expression::Literal(Literal::String(ref s), ..) if s.as_ref() == "/api/"))
         );
     } else {
         panic!("expected IfStatement");
@@ -1968,8 +1972,10 @@ fn route_starts_and_ends_with_desugar_to_builtins() {
     );
     if let Statement::IfStatement { condition, .. } = ends {
         assert!(
-            matches!(condition, Expression::FunctionCall { ref function, .. }
-            if matches!(**function, Expression::Variable(ref n, ..) if n == "ends_with"))
+            matches!(condition, Expression::FunctionCall { ref function, ref arguments, .. }
+            if matches!(**function, Expression::Variable(ref n, ..) if n == "ends_with")
+                && matches!(arguments[0].value, Expression::Variable(ref n, ..) if n == "path")
+                && matches!(arguments[1].value, Expression::Literal(Literal::String(ref s), ..) if s.as_ref() == ".css"))
         );
     } else {
         panic!("expected IfStatement");

--- a/src/stdlib/typechecker.rs
+++ b/src/stdlib/typechecker.rs
@@ -17,6 +17,8 @@ pub fn register_stdlib_types(analyzer: &mut Analyzer) {
     register_touppercase(analyzer);
     register_tolowercase(analyzer);
     register_substring(analyzer);
+    register_starts_with(analyzer);
+    register_ends_with(analyzer);
 
     register_list_length(analyzer);
     register_push(analyzer);
@@ -156,6 +158,22 @@ fn register_substring(analyzer: &mut Analyzer) {
     let param_types = vec![Type::Text, Type::Number, Type::Number];
 
     analyzer.register_builtin_function("substring", param_types, return_type);
+}
+
+fn register_starts_with(analyzer: &mut Analyzer) {
+    let return_type = Type::Boolean;
+    let param_types = vec![Type::Text, Type::Text];
+
+    analyzer.register_builtin_function("starts_with", param_types.clone(), return_type.clone());
+    analyzer.register_builtin_function("startswith", param_types, return_type);
+}
+
+fn register_ends_with(analyzer: &mut Analyzer) {
+    let return_type = Type::Boolean;
+    let param_types = vec![Type::Text, Type::Text];
+
+    analyzer.register_builtin_function("ends_with", param_types.clone(), return_type.clone());
+    analyzer.register_builtin_function("endswith", param_types, return_type);
 }
 
 fn register_list_length(analyzer: &mut Analyzer) {

--- a/tests/route_test.rs
+++ b/tests/route_test.rs
@@ -4,69 +4,11 @@
 //! tests drive the *full* pipeline (lex → parse → analyze → typecheck →
 //! interpret) through the compiled binary and assert on observable output.
 
-use std::env;
-use std::fs;
-use std::path::PathBuf;
-use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-fn get_wfl_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().unwrap();
-    let release_path = current_dir.join(if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    });
-    if release_path.exists() {
-        return release_path;
-    }
-    let debug_path = current_dir.join(if cfg!(target_os = "windows") {
-        "target/debug/wfl.exe"
-    } else {
-        "target/debug/wfl"
-    });
-    if debug_path.exists() {
-        return debug_path;
-    }
-    panic!("WFL binary not found. Build with `cargo build` first.");
-}
-
-static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-fn get_unique_test_file_path(prefix: &str) -> PathBuf {
-    let counter = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let timestamp = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    env::temp_dir().join(format!(
-        "{}_{}_{:?}_{}_{}.wfl",
-        prefix,
-        std::process::id(),
-        thread::current().id(),
-        timestamp,
-        counter
-    ))
-}
-
-fn run_wfl_program(program_content: &str, test_name: &str) -> std::process::Output {
-    let binary_path = get_wfl_binary_path();
-    let test_file = get_unique_test_file_path(test_name);
-    fs::write(&test_file, program_content).expect("Failed to write test file");
-
-    let output = Command::new(&binary_path)
-        .arg(&test_file)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .stdin(Stdio::null())
-        .output()
-        .expect("Failed to execute WFL binary");
-
-    let _ = fs::remove_file(&test_file);
-    output
-}
+// Shared harness: `get_wfl_binary_path`, `get_unique_test_file_path`, and
+// `run_wfl_program` (which already runs the binary under a 30s timeout, so a
+// bug that hangs the interpreter fails fast instead of stalling CI).
+mod test_helpers;
+use test_helpers::run_wfl_program;
 
 /// Run a program, assert it exited cleanly, and return trimmed stdout lines.
 fn run_ok(program: &str, test_name: &str) -> Vec<String> {

--- a/tests/route_test.rs
+++ b/tests/route_test.rs
@@ -1,0 +1,255 @@
+//! End-to-end tests for the `route` construct.
+//!
+//! `route` is parser-level sugar that lowers to a `check if` chain, so these
+//! tests drive the *full* pipeline (lex → parse → analyze → typecheck →
+//! interpret) through the compiled binary and assert on observable output.
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn get_wfl_binary_path() -> PathBuf {
+    let current_dir = env::current_dir().unwrap();
+    let release_path = current_dir.join(if cfg!(target_os = "windows") {
+        "target/release/wfl.exe"
+    } else {
+        "target/release/wfl"
+    });
+    if release_path.exists() {
+        return release_path;
+    }
+    let debug_path = current_dir.join(if cfg!(target_os = "windows") {
+        "target/debug/wfl.exe"
+    } else {
+        "target/debug/wfl"
+    });
+    if debug_path.exists() {
+        return debug_path;
+    }
+    panic!("WFL binary not found. Build with `cargo build` first.");
+}
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn get_unique_test_file_path(prefix: &str) -> PathBuf {
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    env::temp_dir().join(format!(
+        "{}_{}_{:?}_{}_{}.wfl",
+        prefix,
+        std::process::id(),
+        thread::current().id(),
+        timestamp,
+        counter
+    ))
+}
+
+fn run_wfl_program(program_content: &str, test_name: &str) -> std::process::Output {
+    let binary_path = get_wfl_binary_path();
+    let test_file = get_unique_test_file_path(test_name);
+    fs::write(&test_file, program_content).expect("Failed to write test file");
+
+    let output = Command::new(&binary_path)
+        .arg(&test_file)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .output()
+        .expect("Failed to execute WFL binary");
+
+    let _ = fs::remove_file(&test_file);
+    output
+}
+
+/// Run a program, assert it exited cleanly, and return trimmed stdout lines.
+fn run_ok(program: &str, test_name: &str) -> Vec<String> {
+    let output = run_wfl_program(program, test_name);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "program should exit 0.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}"
+    );
+    stdout
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect()
+}
+
+#[test]
+fn route_equality_selects_matching_arm() {
+    let program = r#"
+store path as "/health"
+route path:
+    when "/":
+        display "home"
+    when "/health":
+        display "ok"
+    otherwise:
+        display "not found"
+end route
+"#;
+    let lines = run_ok(program, "route_equality");
+    assert_eq!(lines, vec!["ok"]);
+}
+
+#[test]
+fn route_or_list_matches_any_listed_value() {
+    let program = r#"
+store code as 410
+route code:
+    when 200:
+        display "OK"
+    when 404 or 410:
+        display "Gone"
+    otherwise:
+        display "Other"
+end route
+"#;
+    let lines = run_ok(program, "route_or_list");
+    assert_eq!(lines, vec!["Gone"]);
+}
+
+#[test]
+fn route_falls_through_to_otherwise() {
+    let program = r#"
+store path as "/nope"
+route path:
+    when "/":
+        display "home"
+    otherwise:
+        display "not found"
+end route
+"#;
+    let lines = run_ok(program, "route_otherwise");
+    assert_eq!(lines, vec!["not found"]);
+}
+
+#[test]
+fn route_starts_with_ends_with_and_contains() {
+    // starts with / ends with / contains all run under the full pipeline,
+    // not just `--analyze` (the motivating issue #566 for these operators).
+    let program = r#"
+store results as []
+store api as "/api/users"
+route api:
+    when starts with "/api/":
+        display "api-route"
+    otherwise:
+        display "static"
+end route
+
+store css as "/assets/site.css"
+route css:
+    when ends with ".css":
+        display "stylesheet"
+    otherwise:
+        display "other"
+end route
+
+store admin as "/admin/panel"
+route admin:
+    when contains "admin":
+        display "restricted"
+    otherwise:
+        display "public"
+end route
+"#;
+    let lines = run_ok(program, "route_text_ops");
+    assert_eq!(lines, vec!["api-route", "stylesheet", "restricted"]);
+}
+
+#[test]
+fn route_one_of_tests_list_membership() {
+    let program = r#"
+store assets as ["/a.js", "/b.js", "/c.css"]
+store name as "/b.js"
+route name:
+    when one of assets:
+        display "known"
+    otherwise:
+        display "unknown"
+end route
+"#;
+    let lines = run_ok(program, "route_one_of");
+    assert_eq!(lines, vec!["known"]);
+}
+
+#[test]
+fn route_arm_precedence_first_match_wins() {
+    // Both arms would match "/api/style.css"; the first listed arm must win,
+    // exactly like an `otherwise check if` chain.
+    let program = r#"
+store p as "/api/style.css"
+route p:
+    when starts with "/api/":
+        display "api"
+    when ends with ".css":
+        display "css"
+    otherwise:
+        display "other"
+end route
+"#;
+    let lines = run_ok(program, "route_precedence");
+    assert_eq!(lines, vec!["api"]);
+}
+
+#[test]
+fn route_with_no_match_and_no_otherwise_is_noop() {
+    let program = r#"
+store x as 99
+display "before"
+route x:
+    when 1:
+        display "one"
+    when 2:
+        display "two"
+end route
+display "after"
+"#;
+    let lines = run_ok(program, "route_noop");
+    assert_eq!(lines, vec!["before", "after"]);
+}
+
+#[test]
+fn route_multi_statement_arm_body_runs_in_order() {
+    let program = r#"
+store x as 1
+route x:
+    when 1:
+        display "a"
+        display "b"
+        display "c"
+    otherwise:
+        display "z"
+end route
+"#;
+    let lines = run_ok(program, "route_multi_stmt");
+    assert_eq!(lines, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn route_otherwise_before_when_is_rejected() {
+    let program = r#"
+store x as 1
+route x:
+    otherwise:
+        display "d"
+    when 1:
+        display "one"
+end route
+"#;
+    let output = run_wfl_program(program, "route_bad_order");
+    assert!(
+        !output.status.success(),
+        "a route with `otherwise` before a `when` arm must fail to parse"
+    );
+}


### PR DESCRIPTION
`route` is WFL's natural-language "dispatch on a value" form — the
match/switch it previously lacked. Its flagship use is web-server request
routing, but the subject is any expression so it is general.

Implemented as pure parser-level desugaring: a `route … end route` block
lowers to the same `check if / otherwise check if / otherwise`
(`Statement::IfStatement`) chain a hand-written dispatch produces, so the
analyzer, type checker, and interpreter are unchanged and every existing
program is unaffected (No-Unlearning Invariant: a `when` arm is ordinary
WFL statements, and the block can always be rewritten back to `check if`).

Pattern heads (all validated under the full pipeline, not just --analyze):
- `when V`                equality
- `when V1 or V2`         or-chained equalities
- `when contains V`       substring / list membership
- `when one of L`         list membership
- `when starts with V`    starts_with builtin
- `when ends with V`      ends_with builtin
- `otherwise`             default arm (optional, must be last)

`starts with` / `ends with` sidestep the fragile bareword-operator path
(issue #566) by consuming the operator words as tokens directly in the
route head; `starts_with` / `ends_with` are now also registered in the
type checker.

Tests: parser unit tests, a lexer token test, an end-to-end pipeline suite
(tests/route_test.rs), and a runnable demo
(TestPrograms/route_comprehensive.wfl). Docs: new
Docs/04-advanced-features/routing.md cross-linked from control flow;
keyword references updated (`route` is the 53rd structural keyword;
total 179).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MgYFmuEgJnk1dAXBiQhZwv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `route` control-flow construct for value-based dispatch with `when` arms, `otherwise` fallback, and “first match wins” semantics.
  * Supports equality, `or` lists, text matching (`starts with`/`ends with`/`contains`), and membership (`one of`).
  * Added corresponding standard library built-ins for text matching.
* **Documentation**
  * Added a dedicated `route` page and updated advanced-feature learning paths and keyword references to include `route`/`when`.
* **Tests**
  * Added lexer, parser, and end-to-end integration coverage, including a comprehensive `route` program and validation of invalid `otherwise` placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->