### PR TITLE
ci: raise nightly Windows build timeout to 60 min (fixes cap-boundary cancellation)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,7 +123,7 @@ jobs:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.should_build == 'true'
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:
@@ -546,3 +546,4 @@ jobs:
             $ASSET_FILES
 
           echo "Release created successfully: $TAG with $(echo $ASSET_FILES | wc -w) assets"
+


### PR DESCRIPTION
## Problem

Last nightly — **run [28731843110](https://github.com/WebFirstLanguage/wfl/actions/runs/28731843110)** (2026-07-05 06:21 UTC, sha `12860f1c`) — ended in **`cancelled`**, not success. The `Build WFL for Windows` job was cancelled at exactly its **45-minute `timeout-minutes` cap**, right as it reached the final `cargo wix` MSI-packaging step (fmt, clippy, build, test, LSP test, and VS Code extension had all already passed). This is a **timeout, not a code failure**.

## Root cause

Build+test wall-time on `windows-latest` has crept up to the cap:

| Nightly | Windows build duration | Result |
|---|---|---|
| 07-03 (`d190191b`) | 38.6 min | success |
| 07-04 (`576730bc`) | 43.5 min | success (1.5 min headroom) |
| 07-05 (`12860f1c`) | > 45 min | **cancelled at cap** |

The margin was already razor-thin on 07-04; 07-05 crossed it.

## Fix

Raise the `Build WFL for Windows` job `timeout-minutes` from **45 → 60** to restore headroom. One line; no code or behavior change. The release job (15 min, ubuntu) is untouched.

## Verification

Nightly only runs on `schedule`/`workflow_dispatch`, so this PR’s push/PR CI does not exercise it. I am dispatching the nightly on this branch to confirm the full Windows pipeline completes green within the new budget; result will be linked in a follow-up comment.

*Opened by the WFL repo warden (automated triage pass).*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the nightly Windows build timeout, helping long-running builds complete more reliably.
  * Applied a minor formatting cleanup at the end of the workflow file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->