### PR TITLE
fix(ci): make version-bump push resilient to concurrent main merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,26 @@ jobs:
       - name: Push changes
         if: success()
         run: |
-          git push origin HEAD:${{ github.ref_name }}
+          set -eu
+          BRANCH="${{ github.ref_name }}"
+          # The bump commit must fast-forward main. When another commit lands on
+          # main during this run (concurrent merges), the first push is rejected
+          # as non-fast-forward. Re-base the bump onto the new tip and retry.
+          # Because two concurrent runs can compute the same next version, we
+          # reset to the fresh tip and re-run the bump so the version is derived
+          # from the true current version instead of replaying a stale bump.
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:"$BRANCH"; then
+              echo "Pushed version bump on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt (main advanced); re-bumping from latest tip..."
+            git fetch origin "$BRANCH"
+            git reset --hard "origin/$BRANCH"
+            python scripts/bump_version.py --update-all
+          done
+          echo "::error::Failed to push version bump after 5 attempts (main kept advancing)."
+          exit 1
 
       - name: Tag the new version
         if: success()


### PR DESCRIPTION
## What was broken
The `Bump Version` job in `.github/workflows/ci.yml` failed on the push of
`22b038e7` ("feat: add the `route` construct"), run
[28747917076](https://github.com/WebFirstLanguage/wfl/actions/runs/28747917076).
Every other job in that run was green; only `Bump Version` went red.

## Root cause
The job bumps the version, commits it, then runs a bare:

```yaml
git push origin HEAD:${{ github.ref_name }}
```

with no rebase or retry. When a second commit lands on `main` while the run is
in flight — which is exactly what happened on 2026-07-05, when `0e5094e1` was
pushed at 16:56 and this run's `Bump Version` step reached its push at 16:57 —
the push is rejected as **non-fast-forward**:

```
 ! [rejected]        HEAD -> main (non-fast-forward)
error: failed to push some refs to '.../wfl'
hint: Updates were rejected because the tip of your current branch is behind
      its remote counterpart.
```

The bump itself was harmless (main is at `26.7.16`, pushed by the winning run),
but the losing run is left red. In the worst case, two concurrent runs can
both lose and `main` misses its bump entirely until the next push.

## The fix
Replace the single push with a bounded retry loop (5 attempts). The happy path
(first push) is unchanged. On a non-fast-forward rejection it fetches the new
tip, `reset --hard`s onto it, and **re-runs `bump_version.py`** so the version
is derived from the true current version rather than replaying a now-stale
bump (two concurrent runs would otherwise compute the same next version and
conflict on the version files). Workflow-only change; no Rust/source touched,
so no `TestPrograms/` backward-compat impact.

## Verification
- `python -c 'yaml.safe_load(...)'` — the workflow parses.
- `bash -n` on the new push script — shell syntax valid.
- The first-attempt behavior is byte-identical to the previous step, so normal
  (no-race) runs are unaffected.

⚠️ **Note for the reviewer:** the `Bump Version` job is gated
`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`, so it does
**not** run on PR branches — this PR's own CI cannot exercise the changed job.
It will only run once merged to `main`. Please eyeball the retry logic before
merging; it can't be proven green by PR CI.

_Automated triage PR opened by the WFL repo warden for a human to review and merge._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated version updates when multiple changes land at the same time.
  * Retry logic now helps prevent failed updates caused by the latest branch moving forward during a run.
  * If a retry still fails, the process now stops cleanly with an error instead of leaving things in an inconsistent state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->