### PR TITLE
Add auth/session crypto primitives and RNG seeding lint

### DIFF
--- a/Dev diary/2026-07-09-auth-session-crypto-primitives.md
+++ b/Dev diary/2026-07-09-auth-session-crypto-primitives.md
@@ -1,0 +1,87 @@
+# Auth & Session Crypto Primitives (section 13.1, launch-blocking)
+
+**Date:** 2026-07-09
+
+## What Changed
+
+The password-hashing builtins gave WFL a safe way to *store* a password, but
+auth and session code still had gaps that pushed developers toward dangerous
+hand-rolled code. This change closes the three launch-blocking gaps in section
+13.1 and adds a static-analysis rule to keep a fourth foot-gun out of security
+code.
+
+Three new native builtins in `src/stdlib/crypto.rs`:
+
+```wfl
+// Raw PBKDF2-HMAC-SHA256 key derivation (caller controls salt/iterations/length)
+store key as pbkdf2_hmac_sha256 of "password" and salt and 600000 and 32
+
+// Timing-safe comparison — for MACs, tokens, session IDs, reset codes
+store ok as constant_time_equals of expected and received
+
+// CSPRNG bytes as hex — for salts, session IDs, CSRF/reset tokens
+store salt as secure_random_bytes of 16
+```
+
+And one analyzer rule (`ANALYZE-SECURITY`): `random_seed` is now an error in any
+file that also performs cryptographic, authentication, or session work.
+
+## Why
+
+Each of these was a concrete way for correct-looking WFL to be insecure:
+
+- **`pbkdf2_hmac_sha256`** — under the serialized-response server model, running a
+  600k-iteration KDF in interpreted WFL on `/login` is a whole-site DoS. Moving
+  the iteration loop into Rust bounds the per-hash cost. Unlike `pbkdf2_hash`
+  (which self-selects salt/iterations and returns a PHC string), this is the raw
+  KDF: it takes an explicit salt, iteration count, and output length, so it can
+  derive keys and interoperate with PBKDF2 hashes produced elsewhere. Validated
+  against the standard PBKDF2-HMAC-SHA256 test vectors.
+
+- **`constant_time_equals`** — WFL previously exposed only short-circuiting
+  comparison (`is`), which leaks, through timing, how much of a secret a caller
+  guessed correctly. That left no correct way to verify a MAC or token — a
+  No-Unlearning violation. The `subtle` crate was already a dependency. The docs'
+  webhook-verification example (which compared signatures with `is`) is updated
+  to use `constant_time_equals`.
+
+- **`secure_random_bytes`** — composing tokens from numeric `random_int` risks
+  modulo bias and under-entropy. This exposes the OS CSPRNG directly for salts,
+  session IDs, and CSRF/reset tokens.
+
+- **`random_seed` lint** — seeding the general-purpose RNG makes its output
+  predictable. Seeding it inside auth/session/crypto code is almost always a
+  mistake, so the analyzer now flags it. The heuristic: if a file calls any
+  crypto builtin *and* calls `random_seed`, every `random_seed` call site is
+  reported as an error. `wfl --analyze` exits non-zero, so CI can block it.
+  Seeding remains allowed in ordinary code (simulations, reproducible demos).
+
+## Implementation Notes
+
+- Output encoding is lowercase hex for all three builtins, matching the rest of
+  the crypto module (`sha256`, `hmac_sha256`, `generate_csrf_token`).
+- Bounds guard against runaway cost/allocation: iterations ≤ 100,000,000,
+  derived-key length ≤ 1024 bytes, `secure_random_bytes` n ≤ 4096. Zero is
+  rejected for iterations, length, and n.
+- Derived-key and random buffers are zeroized after encoding.
+- `constant_time_equals` short-circuits on unequal length (length is not secret)
+  and otherwise compares via `subtle`'s `ct_eq`.
+- The analyzer walks statement bodies (actions, loops, if/try, test blocks,
+  websocket/event handlers, container methods) so seeding is caught inside
+  nested scopes, not just at the top level.
+
+## Tests
+
+- `tests/crypto_kdf_test.rs` — RFC/NIST-style PBKDF2 vectors (c=1/2/4096,
+  dkLen=32/40), constant-time equality (equal/unequal/length-mismatch, HMAC
+  verification), and `secure_random_bytes` (length, uniqueness, bounds).
+- `src/analyzer/static_analyzer.rs` unit tests — the lint fires with crypto
+  present (top-level and inside an action body) and stays silent without it.
+- `TestPrograms/crypto_auth_primitives_test.wfl` — end-to-end coverage including
+  a password-storage round-trip using the raw KDF + constant-time compare.
+
+## Docs
+
+- `Docs/05-standard-library/crypto-module.md` — new "Auth & session primitives"
+  group and full function entries; webhook example fixed to constant-time compare.
+- `Docs/reference/builtin-functions-reference.md` — new reference rows.

--- a/Docs/05-standard-library/crypto-module.md
+++ b/Docs/05-standard-library/crypto-module.md
@@ -1,8 +1,9 @@
 # Crypto Module
 
-The Crypto module provides cryptographic functions in three groups:
+The Crypto module provides cryptographic functions in four groups:
 
 - **Password hashing** — `hash_password`/`verify_password` and the algorithm-specific Argon2id, bcrypt, scrypt and PBKDF2 functions. Use these to store user passwords safely.
+- **Auth & session primitives** — `pbkdf2_hmac_sha256` (raw key derivation), `constant_time_equals` (timing-safe comparison), and `secure_random_bytes` (CSPRNG bytes for salts, tokens, and session IDs).
 - **Standard hashing/MAC** — `sha256` and `hmac_sha256` for interoperating with external services (webhook verification, API signing).
 - **WFLHASH** — a custom hash algorithm for data integrity, checksums, and non-critical security applications.
 
@@ -314,7 +315,8 @@ store expected_signature as hmac_sha256 of signed_payload and webhook_secret
 // In a real webhook handler this comes from the Stripe-Signature header
 store received_signature as hmac_sha256 of signed_payload and webhook_secret
 
-check if expected_signature is received_signature:
+// Compare signatures with constant_time_equals, never `is` — see the note below.
+check if constant_time_equals of expected_signature and received_signature is yes:
     display "Webhook is authentic"
 otherwise:
     display "Webhook signature mismatch - reject it!"
@@ -327,6 +329,117 @@ end check
 - Any integration that specifies HMAC-SHA256
 
 **Note:** For WFL-internal message authentication where interoperability is not required, `wflmac256` also works; `hmac_sha256` is the standard everyone else speaks.
+
+> **Always compare signatures and tokens with [`constant_time_equals`](#constant_time_equals), not `is`.** A normal `is` comparison stops at the first differing byte, and the time it takes leaks how much of a secret an attacker guessed correctly. `constant_time_equals` takes the same time regardless, closing that side channel.
+
+---
+
+### pbkdf2_hmac_sha256
+
+**Purpose:** Derive a key from a password using PBKDF2-HMAC-SHA256 with a caller-supplied salt, iteration count, and output length. Runs the iteration loop in native code, so the per-call cost is bounded and predictable.
+
+**Signature:**
+```wfl
+pbkdf2_hmac_sha256 of <password> and <salt> and <iterations> and <length>
+```
+
+**Parameters:**
+- `password` (Text): The password or passphrase.
+- `salt` (Text): A unique salt. Use [`secure_random_bytes`](#secure_random_bytes) to generate one and store it alongside the derived key.
+- `iterations` (Number): Iteration count. Follow current guidance (OWASP recommends **600,000** for PBKDF2-HMAC-SHA256). Must be at least 1.
+- `length` (Number): Derived-key length in bytes (1–1024). The result is `2 × length` hex characters.
+
+**Returns:** Text — the derived key as a lowercase hexadecimal string.
+
+**When to use which PBKDF2 function:**
+- **Storing a user's password?** Prefer [`hash_password`](#password-hashing) (or `pbkdf2_hash`). Those generate a random salt, pin a safe iteration count, and return a self-describing string you store as-is.
+- **Deriving a key, or matching a PBKDF2 hash created by another system?** Use `pbkdf2_hmac_sha256`, which gives you full control over salt, iterations, and length.
+
+**Example:**
+```wfl
+// Generate and store a salt once, then derive the key.
+store salt as secure_random_bytes of 16
+store derived_key as pbkdf2_hmac_sha256 of "correct horse battery staple" and salt and 600000 and 32
+display "Store the salt and this key: " with derived_key
+
+// To verify a login, re-derive with the SAME salt and compare in constant time.
+store attempt_key as pbkdf2_hmac_sha256 of "correct horse battery staple" and salt and 600000 and 32
+store login_ok as constant_time_equals of derived_key and attempt_key
+// login_ok is yes
+```
+
+**Notes:**
+- Deterministic — the same password, salt, iterations, and length always produce the same key.
+- Store the salt with the derived key; you need it to re-derive on the next login.
+- More iterations means more work for both you and an attacker. Do not lower the count to speed up logins.
+
+---
+
+### constant_time_equals
+
+**Purpose:** Compare two strings in constant time. Use this whenever you compare a secret against attacker-supplied input — MACs, CSRF tokens, session IDs, password-reset codes.
+
+**Signature:**
+```wfl
+constant_time_equals of <a> and <b>
+```
+
+**Parameters:**
+- `a` (Text): First value.
+- `b` (Text): Second value.
+
+**Returns:** Boolean — `yes` if the two strings are byte-for-byte equal, otherwise `no`.
+
+**Why not just use `is`?** A normal comparison returns as soon as it finds a difference, so it finishes faster the earlier the mismatch is. An attacker who can measure that timing can recover a secret one byte at a time. `constant_time_equals` always examines the full input, so the time it takes reveals nothing about *where* the values differ. (String length is not secret, so inputs of different lengths return `no` immediately.)
+
+**Example:**
+```wfl
+store expected as hmac_sha256 of signed_payload and webhook_secret
+store received as hmac_sha256 of signed_payload and webhook_secret
+
+check if constant_time_equals of expected and received is yes:
+    display "Signature valid"
+otherwise:
+    display "Signature invalid - reject"
+end check
+```
+
+**Use Cases:**
+- Verifying HMAC / webhook signatures
+- Checking CSRF tokens and session identifiers
+- Comparing password-reset or email-verification codes
+
+---
+
+### secure_random_bytes
+
+**Purpose:** Generate cryptographically secure random bytes from the operating system's CSPRNG, returned as a hex string. Use this for salts, session identifiers, CSRF tokens, and password-reset tokens.
+
+**Signature:**
+```wfl
+secure_random_bytes of <n>
+```
+
+**Parameters:**
+- `n` (Number): Number of random bytes to generate (1–4096). The result is `2 × n` hexadecimal characters.
+
+**Returns:** Text — `n` random bytes encoded as a lowercase hexadecimal string.
+
+**Example:**
+```wfl
+store salt as secure_random_bytes of 16      // 32 hex chars, for a password salt
+store session_id as secure_random_bytes of 32 // 64 hex chars, for a session cookie
+display "New session id: " with session_id
+```
+
+**Why not build tokens from `random_int`?** Composing a token out of numeric random values risks *modulo bias* (some values become more likely than others) and *under-entropy* (fewer truly random bits than the length suggests). `secure_random_bytes` draws uniform bytes straight from the OS CSPRNG, avoiding both.
+
+> **Never call `random_seed` in authentication, session, or cryptographic code.** Seeding the general-purpose random generator makes its output predictable, which would compromise anything built on it. WFL's static analyzer (`wfl --analyze`) reports this as an error, so CI can block it. `secure_random_bytes` is unaffected by `random_seed`, but seeding signals a dangerous pattern in security code.
+
+**Use Cases:**
+- Password salts (pair with [`pbkdf2_hmac_sha256`](#pbkdf2_hmac_sha256))
+- Session identifiers and cookies
+- CSRF tokens, password-reset tokens, API keys
 
 ---
 

--- a/Docs/05-standard-library/overview.md
+++ b/Docs/05-standard-library/overview.md
@@ -22,8 +22,8 @@ Standard Library (181+ functions)
 │   └── Date and time handling
 ├── Random Module (6 functions)
 │   └── Random number generation
-├── Crypto Module (4 functions)
-│   └── Cryptographic hashing
+├── Crypto Module (20 functions)
+│   └── Password hashing, auth/session primitives, hashing & MAC
 ├── Pattern Module (3 functions)
 │   └── Pattern matching utilities
 └── Typechecker Module

--- a/Docs/reference/builtin-functions-reference.md
+++ b/Docs/reference/builtin-functions-reference.md
@@ -130,6 +130,14 @@ Store user passwords with these — never with fast hashes like `sha256` or `wfl
 | `pbkdf2_hash` | `pbkdf2_hash of <password>` | Text | PBKDF2-HMAC-SHA256 hash |
 | `pbkdf2_verify` | `pbkdf2_verify of <password> and <hash>` | Boolean | Verify PBKDF2 hash |
 
+### Auth & session primitives (3 functions)
+
+| Function | Signature | Returns | Description |
+|----------|-----------|---------|-------------|
+| `pbkdf2_hmac_sha256` | `pbkdf2_hmac_sha256 of <password> and <salt> and <iterations> and <length>` | Text | Raw PBKDF2-HMAC-SHA256 key derivation (hex) |
+| `constant_time_equals` | `constant_time_equals of <a> and <b>` | Boolean | Timing-safe string comparison |
+| `secure_random_bytes` | `secure_random_bytes of <n>` | Text | `n` CSPRNG bytes as hex (for salts, tokens, session IDs) |
+
 ### Hashing & MAC (7 functions)
 
 | Function | Signature | Returns | Description |

--- a/TestPrograms/crypto_auth_primitives_test.wfl
+++ b/TestPrograms/crypto_auth_primitives_test.wfl
@@ -1,0 +1,133 @@
+// Launch-blocking auth/session crypto primitives (section 13.1)
+// Verifies pbkdf2_hmac_sha256, constant_time_equals, and secure_random_bytes.
+// These give auth/session code a correct, native primitive instead of
+// hand-rolling a KDF, a timing-safe compare, or token generation in WFL.
+
+display "=== Auth Primitives Test ==="
+display ""
+
+store pass_count as 0
+store fail_count as 0
+
+// === PBKDF2-HMAC-SHA256 (standard vectors alongside RFC 6070) ===
+display "1. pbkdf2_hmac_sha256 Tests"
+
+store dk1 as pbkdf2_hmac_sha256 of "password" and "salt" and 1 and 32
+check if dk1 is "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b":
+    display "PASS: pbkdf2 c=1 dkLen=32"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: pbkdf2 c=1 gave " with dk1
+    change fail_count to fail_count plus 1
+end check
+
+store dk2 as pbkdf2_hmac_sha256 of "password" and "salt" and 4096 and 32
+check if dk2 is "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a":
+    display "PASS: pbkdf2 c=4096 dkLen=32"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: pbkdf2 c=4096 gave " with dk2
+    change fail_count to fail_count plus 1
+end check
+
+// A different salt must produce a different derived key.
+store dk3 as pbkdf2_hmac_sha256 of "password" and "pepper" and 4096 and 32
+check if dk2 is dk3:
+    display "FAIL: different salt should change the key"
+    change fail_count to fail_count plus 1
+otherwise:
+    display "PASS: different salt changes the key"
+    change pass_count to pass_count plus 1
+end check
+display ""
+
+// === constant_time_equals ===
+display "2. constant_time_equals Tests"
+
+store eq as constant_time_equals of "s3cr3t-token" and "s3cr3t-token"
+check if eq is yes:
+    display "PASS: equal strings compare equal"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: equal strings should compare equal"
+    change fail_count to fail_count plus 1
+end check
+
+store neq as constant_time_equals of "s3cr3t-token" and "s3cr3t-toKen"
+check if neq is no:
+    display "PASS: different strings compare unequal"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: different strings should compare unequal"
+    change fail_count to fail_count plus 1
+end check
+
+// Timing-safe MAC verification: the correct way to check a signature.
+store expected as hmac_sha256 of "payload" and "secret"
+store received as hmac_sha256 of "payload" and "secret"
+store mac_ok as constant_time_equals of expected and received
+check if mac_ok is yes:
+    display "PASS: HMAC verified with constant_time_equals"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: HMAC should verify"
+    change fail_count to fail_count plus 1
+end check
+display ""
+
+// === secure_random_bytes ===
+display "3. secure_random_bytes Tests"
+
+store token1 as secure_random_bytes of 16
+check if length of token1 is 32:
+    display "PASS: 16 bytes -> 32 hex chars"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: expected 32 hex chars, got " with length of token1
+    change fail_count to fail_count plus 1
+end check
+
+store token2 as secure_random_bytes of 16
+check if constant_time_equals of token1 and token2 is no:
+    display "PASS: two tokens differ"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: two random tokens should differ"
+    change fail_count to fail_count plus 1
+end check
+display ""
+
+// === End-to-end: password storage with a caller-supplied salt ===
+display "4. Password storage round-trip (raw KDF)"
+
+store user_salt as secure_random_bytes of 16
+store stored_key as pbkdf2_hmac_sha256 of "correct horse battery staple" and user_salt and 600000 and 32
+
+// Login: re-derive with the same salt and compare in constant time.
+store login_key as pbkdf2_hmac_sha256 of "correct horse battery staple" and user_salt and 600000 and 32
+store login_ok as constant_time_equals of stored_key and login_key
+check if login_ok is yes:
+    display "PASS: correct password verifies"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: correct password should verify"
+    change fail_count to fail_count plus 1
+end check
+
+store wrong_key as pbkdf2_hmac_sha256 of "wrong password" and user_salt and 600000 and 32
+store wrong_ok as constant_time_equals of stored_key and wrong_key
+check if wrong_ok is no:
+    display "PASS: wrong password rejected"
+    change pass_count to pass_count plus 1
+otherwise:
+    display "FAIL: wrong password should be rejected"
+    change fail_count to fail_count plus 1
+end check
+display ""
+
+display "=== Results: " with pass_count with " passed, " with fail_count with " failed ==="
+check if fail_count is 0:
+    display "All auth primitive tests passed!"
+otherwise:
+    display "SOME TESTS FAILED"
+end check

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -100,6 +100,267 @@ pub trait StaticAnalyzer {
     fn check_shadowing(&self, program: &Program, file_id: usize) -> Vec<WflDiagnostic>;
 
     fn check_inconsistent_returns(&self, program: &Program, file_id: usize) -> Vec<WflDiagnostic>;
+
+    fn check_insecure_rng_seeding(&self, program: &Program, file_id: usize) -> Vec<WflDiagnostic>;
+}
+
+/// Builtins whose presence marks a file as an auth/session/crypto module. If any
+/// of these is called, seeding the RNG with `random_seed` makes the CSPRNG
+/// predictable and is flagged as an error.
+const SECURITY_SENSITIVE_BUILTINS: &[&str] = &[
+    "hash_password",
+    "verify_password",
+    "argon2_hash",
+    "argon2_verify",
+    "bcrypt_hash",
+    "bcrypt_verify",
+    "scrypt_hash",
+    "scrypt_verify",
+    "pbkdf2_hash",
+    "pbkdf2_verify",
+    "pbkdf2_hmac_sha256",
+    "constant_time_equals",
+    "secure_random_bytes",
+    "generate_csrf_token",
+    "sha256",
+    "hmac_sha256",
+    "wflhash256",
+    "wflhash512",
+    "wflhash256_with_salt",
+    "wflmac256",
+];
+
+/// Record of a builtin call site discovered while walking the AST.
+struct CallSite {
+    name: String,
+    line: usize,
+    column: usize,
+}
+
+/// Collect every builtin/function call name (with position) in a list of statements.
+fn collect_calls_in_statements(statements: &[Statement], out: &mut Vec<CallSite>) {
+    for stmt in statements {
+        collect_calls_in_statement(stmt, out);
+    }
+}
+
+fn collect_calls_in_statement(stmt: &Statement, out: &mut Vec<CallSite>) {
+    match stmt {
+        Statement::VariableDeclaration { value, .. }
+        | Statement::Assignment { value, .. }
+        | Statement::DisplayStatement { value, .. } => {
+            collect_calls_in_expression(value, out);
+        }
+        Statement::ExpressionStatement { expression, .. } => {
+            collect_calls_in_expression(expression, out);
+        }
+        Statement::ReturnStatement {
+            value: Some(value), ..
+        } => {
+            collect_calls_in_expression(value, out);
+        }
+        Statement::PushStatement { list, value, .. } => {
+            collect_calls_in_expression(list, out);
+            collect_calls_in_expression(value, out);
+        }
+        Statement::IfStatement {
+            condition,
+            then_block,
+            else_block,
+            ..
+        } => {
+            collect_calls_in_expression(condition, out);
+            collect_calls_in_statements(then_block, out);
+            if let Some(else_block) = else_block {
+                collect_calls_in_statements(else_block, out);
+            }
+        }
+        Statement::SingleLineIf {
+            condition,
+            then_stmt,
+            else_stmt,
+            ..
+        } => {
+            collect_calls_in_expression(condition, out);
+            collect_calls_in_statement(then_stmt, out);
+            if let Some(else_stmt) = else_stmt {
+                collect_calls_in_statement(else_stmt, out);
+            }
+        }
+        Statement::ForEachLoop {
+            collection, body, ..
+        } => {
+            collect_calls_in_expression(collection, out);
+            collect_calls_in_statements(body, out);
+        }
+        Statement::CountLoop {
+            start,
+            end,
+            step,
+            body,
+            ..
+        } => {
+            collect_calls_in_expression(start, out);
+            collect_calls_in_expression(end, out);
+            if let Some(step) = step {
+                collect_calls_in_expression(step, out);
+            }
+            collect_calls_in_statements(body, out);
+        }
+        Statement::WhileLoop {
+            condition, body, ..
+        }
+        | Statement::RepeatWhileLoop {
+            condition, body, ..
+        }
+        | Statement::RepeatUntilLoop {
+            condition, body, ..
+        } => {
+            collect_calls_in_expression(condition, out);
+            collect_calls_in_statements(body, out);
+        }
+        Statement::ForeverLoop { body, .. } | Statement::MainLoop { body, .. } => {
+            collect_calls_in_statements(body, out);
+        }
+        Statement::ActionDefinition { body, .. } => {
+            collect_calls_in_statements(body, out);
+        }
+        Statement::TryStatement {
+            body,
+            when_clauses,
+            otherwise_block,
+            finally_block,
+            ..
+        } => {
+            collect_calls_in_statements(body, out);
+            for clause in when_clauses {
+                collect_calls_in_statements(&clause.body, out);
+            }
+            if let Some(otherwise_block) = otherwise_block {
+                collect_calls_in_statements(otherwise_block, out);
+            }
+            if let Some(finally_block) = finally_block {
+                collect_calls_in_statements(finally_block, out);
+            }
+        }
+        Statement::TestBlock { body, .. } => {
+            collect_calls_in_statements(body, out);
+        }
+        Statement::DescribeBlock {
+            setup,
+            teardown,
+            tests,
+            ..
+        } => {
+            if let Some(setup) = setup {
+                collect_calls_in_statements(setup, out);
+            }
+            if let Some(teardown) = teardown {
+                collect_calls_in_statements(teardown, out);
+            }
+            collect_calls_in_statements(tests, out);
+        }
+        Statement::WebSocketHandlerStatement { body, .. } => {
+            collect_calls_in_statements(body, out);
+        }
+        Statement::EventHandler { handler_body, .. } => {
+            collect_calls_in_statements(handler_body, out);
+        }
+        Statement::ContainerDefinition {
+            methods,
+            static_methods,
+            ..
+        } => {
+            for method in methods.iter().chain(static_methods.iter()) {
+                collect_calls_in_statement(method, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_calls_in_expression(expr: &Expression, out: &mut Vec<CallSite>) {
+    match expr {
+        Expression::FunctionCall {
+            function,
+            arguments,
+            line,
+            column,
+        } => {
+            if let Expression::Variable(name, ..) = function.as_ref() {
+                out.push(CallSite {
+                    name: name.clone(),
+                    line: *line,
+                    column: *column,
+                });
+            }
+            collect_calls_in_expression(function, out);
+            for arg in arguments {
+                collect_calls_in_expression(&arg.value, out);
+            }
+        }
+        Expression::ActionCall {
+            name,
+            arguments,
+            line,
+            column,
+        } => {
+            out.push(CallSite {
+                name: name.clone(),
+                line: *line,
+                column: *column,
+            });
+            for arg in arguments {
+                collect_calls_in_expression(&arg.value, out);
+            }
+        }
+        Expression::BinaryOperation { left, right, .. }
+        | Expression::Concatenation { left, right, .. } => {
+            collect_calls_in_expression(left, out);
+            collect_calls_in_expression(right, out);
+        }
+        Expression::UnaryOperation { expression, .. }
+        | Expression::AwaitExpression { expression, .. } => {
+            collect_calls_in_expression(expression, out);
+        }
+        Expression::MemberAccess { object, .. } => {
+            collect_calls_in_expression(object, out);
+        }
+        Expression::IndexAccess {
+            collection, index, ..
+        } => {
+            collect_calls_in_expression(collection, out);
+            collect_calls_in_expression(index, out);
+        }
+        Expression::PatternMatch { text, pattern, .. }
+        | Expression::PatternFind { text, pattern, .. }
+        | Expression::PatternSplit { text, pattern, .. } => {
+            collect_calls_in_expression(text, out);
+            collect_calls_in_expression(pattern, out);
+        }
+        Expression::PatternReplace {
+            text,
+            pattern,
+            replacement,
+            ..
+        } => {
+            collect_calls_in_expression(text, out);
+            collect_calls_in_expression(pattern, out);
+            collect_calls_in_expression(replacement, out);
+        }
+        Expression::StringSplit {
+            text, delimiter, ..
+        } => {
+            collect_calls_in_expression(text, out);
+            collect_calls_in_expression(delimiter, out);
+        }
+        Expression::Literal(crate::parser::ast::Literal::List(elements), ..) => {
+            for element in elements {
+                collect_calls_in_expression(element, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 impl StaticAnalyzer for Analyzer {
@@ -220,6 +481,7 @@ impl StaticAnalyzer for Analyzer {
         diagnostics.extend(self.check_unreachable_code(program, file_id));
         diagnostics.extend(self.check_shadowing(program, file_id));
         diagnostics.extend(self.check_inconsistent_returns(program, file_id));
+        diagnostics.extend(self.check_insecure_rng_seeding(program, file_id));
 
         diagnostics
     }
@@ -414,6 +676,48 @@ impl StaticAnalyzer for Analyzer {
         }
 
         diagnostics
+    }
+
+    /// Flag `random_seed` usage in a file that also performs cryptographic,
+    /// authentication, or session operations. Seeding the RNG makes its output
+    /// deterministic; in security-sensitive code that means predictable salts,
+    /// session identifiers, and tokens. This is the analyzer half of the CI rule
+    /// that keeps `random_seed` out of auth/session/crypto modules.
+    fn check_insecure_rng_seeding(&self, program: &Program, file_id: usize) -> Vec<WflDiagnostic> {
+        let mut calls = Vec::new();
+        collect_calls_in_statements(&program.statements, &mut calls);
+
+        // Only flag seeding when the same file also does security-sensitive work.
+        let uses_security_builtin = calls
+            .iter()
+            .any(|call| SECURITY_SENSITIVE_BUILTINS.contains(&call.name.as_str()));
+        if !uses_security_builtin {
+            return Vec::new();
+        }
+
+        calls
+            .iter()
+            .filter(|call| call.name == "random_seed")
+            .map(|call| {
+                WflDiagnostic::new(
+                    Severity::Error,
+                    "random_seed must not be used in authentication, session, or cryptographic code"
+                        .to_string(),
+                    Some(
+                        "Seeding the random number generator makes its output predictable, which \
+                         undermines salts, session IDs, and tokens. Remove the random_seed call; \
+                         use secure_random_bytes for cryptographic randomness. Seeding is only for \
+                         reproducible non-security code such as simulations or tests."
+                            .to_string(),
+                    ),
+                    "ANALYZE-SECURITY".to_string(),
+                    file_id,
+                    call.line,
+                    call.column,
+                    None,
+                )
+            })
+            .collect()
     }
 }
 
@@ -2058,5 +2362,59 @@ mod tests {
             !diagnostics.iter().any(|d| d.message.contains("last_index")),
             "last_index should not be reported as unused when used in array access"
         );
+    }
+
+    // ===== random_seed-in-crypto-context lint (ANALYZE-SECURITY) =====
+
+    fn parse_program(input: &str) -> Program {
+        let tokens = crate::lexer::lex_wfl_with_positions(input);
+        crate::parser::Parser::new(&tokens).parse().unwrap()
+    }
+
+    #[test]
+    fn test_random_seed_flagged_in_crypto_context() {
+        // random_seed next to a crypto builtin is an error: it makes the CSPRNG predictable.
+        let program = parse_program(
+            "store x as random_seed of 42\nstore h as hash_password of \"pw\"\ndisplay h",
+        );
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "ANALYZE-SECURITY");
+        assert_eq!(diagnostics[0].severity, Severity::Error);
+        assert!(diagnostics[0].message.contains("random_seed"));
+    }
+
+    #[test]
+    fn test_random_seed_flagged_inside_action_body() {
+        // The walker must reach into action bodies, not only top-level statements.
+        let program = parse_program(
+            "define action called make_token:\n  store s as random_seed of 1\n  store t as secure_random_bytes of 16\n  give back t\nend action",
+        );
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "ANALYZE-SECURITY");
+    }
+
+    #[test]
+    fn test_random_seed_allowed_without_crypto() {
+        // Seeding is legitimate in ordinary non-security code (simulations, reproducible demos).
+        let program = parse_program("store s as random_seed of 42\nstore r as random\ndisplay r");
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_crypto_without_random_seed_is_clean() {
+        let program = parse_program("store h as hash_password of \"pw\"\ndisplay h");
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert!(diagnostics.is_empty());
     }
 }

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -107,6 +107,13 @@ pub trait StaticAnalyzer {
 /// Builtins whose presence marks a file as an auth/session/crypto module. If any
 /// of these is called, seeding the RNG with `random_seed` makes the CSPRNG
 /// predictable and is flagged as an error.
+///
+/// Deliberately limited to builtins whose *purpose* is authentication, secrets,
+/// or message authentication. General-purpose hashes (`sha256`, the WFLHASH
+/// family) are excluded: their documented use is checksums, deduplication, and
+/// data integrity, so a program that hashes a file and separately seeds the RNG
+/// for a reproducible simulation should not be flagged. MACs (`hmac_sha256`,
+/// `wflmac256`) stay in the list because they authenticate, not just hash.
 const SECURITY_SENSITIVE_BUILTINS: &[&str] = &[
     "hash_password",
     "verify_password",
@@ -122,11 +129,7 @@ const SECURITY_SENSITIVE_BUILTINS: &[&str] = &[
     "constant_time_equals",
     "secure_random_bytes",
     "generate_csrf_token",
-    "sha256",
     "hmac_sha256",
-    "wflhash256",
-    "wflhash512",
-    "wflhash256_with_salt",
     "wflmac256",
 ];
 
@@ -265,6 +268,26 @@ fn collect_calls_in_statement(stmt: &Statement, out: &mut Vec<CallSite>) {
         }
         Statement::EventHandler { handler_body, .. } => {
             collect_calls_in_statements(handler_body, out);
+        }
+        Statement::RespondStatement {
+            request,
+            content,
+            status,
+            content_type,
+            headers,
+            ..
+        } => {
+            collect_calls_in_expression(request, out);
+            collect_calls_in_expression(content, out);
+            if let Some(status) = status {
+                collect_calls_in_expression(status, out);
+            }
+            if let Some(content_type) = content_type {
+                collect_calls_in_expression(content_type, out);
+            }
+            if let Some(headers) = headers {
+                collect_calls_in_expression(headers, out);
+            }
         }
         Statement::ContainerDefinition {
             methods,
@@ -2416,5 +2439,42 @@ mod tests {
         let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
 
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_sha256_checksum_does_not_trigger_lint() {
+        // sha256 is a general-purpose hash (checksums/content-addressing), not an
+        // auth signal, so hashing + seeding for a reproducible run must not fire.
+        let program =
+            parse_program("store c as sha256 of \"data\"\nstore s as random_seed of 1\ndisplay c");
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_wflhash_checksum_does_not_trigger_lint() {
+        let program = parse_program(
+            "store c as wflhash256 of \"data\"\nstore s as random_seed of 1\ndisplay c",
+        );
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn test_random_seed_flagged_inside_respond_statement() {
+        // A web handler that responds with a freshly generated token and also
+        // seeds the RNG must be flagged: the walker has to descend into `respond`.
+        let program = parse_program(
+            "store s as random_seed of 1\nrespond to req with secure_random_bytes of 16",
+        );
+        let analyzer = Analyzer::new();
+        let diagnostics = analyzer.check_insecure_rng_seeding(&program, 0);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "ANALYZE-SECURITY");
     }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -38,6 +38,10 @@ const BUILTIN_FUNCTIONS: &[&str] = &[
     "sha256",
     "hmac_sha256",
     "generate_csrf_token",
+    // Low-level auth/session primitives (implemented in stdlib/crypto.rs)
+    "pbkdf2_hmac_sha256",
+    "constant_time_equals",
+    "secure_random_bytes",
     // Password hashing (implemented in stdlib/crypto.rs)
     "hash_password",
     "verify_password",
@@ -282,9 +286,11 @@ pub fn get_function_arity(name: &str) -> usize {
         // Zero argument functions
         "generate_csrf_token" => 0,
         // Single argument functions
-        "wflhash256" | "wflhash512" | "sha256" => 1,
+        "wflhash256" | "wflhash512" | "sha256" | "secure_random_bytes" => 1,
         // Two argument functions
-        "wflhash256_with_salt" | "wflmac256" | "hmac_sha256" => 2,
+        "wflhash256_with_salt" | "wflmac256" | "hmac_sha256" | "constant_time_equals" => 2,
+        // Four argument functions: (password, salt, iterations, length)
+        "pbkdf2_hmac_sha256" => 4,
 
         // === PASSWORD HASHING FUNCTIONS ===
         // Single argument functions (the password)

--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -1,4 +1,4 @@
-use super::helpers::{check_arg_count, expect_text};
+use super::helpers::{check_arg_count, expect_number, expect_text};
 use crate::interpreter::environment::Environment;
 use crate::interpreter::error::RuntimeError;
 use crate::interpreter::value::Value;
@@ -8,7 +8,7 @@ use argon2::Argon2;
 use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use hkdf::Hkdf;
 use hmac::{Hmac, Mac};
-use pbkdf2::Pbkdf2;
+use pbkdf2::{Pbkdf2, pbkdf2_hmac};
 use scrypt::Scrypt;
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -568,6 +568,169 @@ pub fn native_generate_csrf_token(args: Vec<Value>) -> Result<Value, RuntimeErro
 }
 
 // ============================================================================
+// Low-level auth/session primitives
+//
+// These are the native building blocks that auth and session code should reach
+// for instead of hand-rolling them in interpreted WFL:
+//   - `pbkdf2_hmac_sha256` runs the 600k-iteration KDF loop in Rust so a login
+//     handler can't turn a password check into a whole-site DoS.
+//   - `constant_time_equals` gives a timing-safe comparison so verifying a MAC,
+//     token, or reset code doesn't leak a byte-by-byte oracle through timing.
+//   - `secure_random_bytes` exposes the OS CSPRNG for salts, session IDs, CSRF
+//     tokens, and reset tokens without composing them from biased numeric RNG.
+// ============================================================================
+
+/// Upper bound on PBKDF2 iterations. High enough for any realistic KDF setting
+/// (OWASP recommends 600k), but bounded so a runaway value can't hang the process.
+const MAX_PBKDF2_ITERATIONS: u32 = 100_000_000;
+
+/// Upper bound on the derived-key length in bytes. Any symmetric key or token
+/// fits comfortably; this bounds the output allocation.
+const MAX_PBKDF2_KEY_LENGTH: usize = 1024;
+
+/// Upper bound on `secure_random_bytes` output. Salts, session IDs and tokens are
+/// tens of bytes; this cap prevents an accidental huge allocation.
+const MAX_SECURE_RANDOM_BYTES: usize = 4096;
+
+/// Convert a WFL number argument into a non-negative integer count, rejecting
+/// non-finite, negative, or fractional values with a clear message.
+fn expect_count(func: &str, name: &str, value: &Value) -> Result<u64, RuntimeError> {
+    let n = expect_number(value)?;
+    if !n.is_finite() || n < 0.0 || n.fract() != 0.0 {
+        return Err(RuntimeError::new(
+            format!("{func}: {name} must be a non-negative whole number, got {n}"),
+            0,
+            0,
+        ));
+    }
+    Ok(n as u64)
+}
+
+/// PBKDF2-HMAC-SHA256 key derivation with caller-supplied salt, iteration count,
+/// and output length. Returns the derived key as a lowercase hex string.
+///
+/// Unlike `pbkdf2_hash` (which generates its own salt, pins OWASP's iteration
+/// count, and returns a self-describing PHC string), this is the raw KDF: use it
+/// to derive keys or to interoperate with a stored PBKDF2 hash produced elsewhere.
+/// The iteration loop runs in native Rust, bounding per-call cost.
+///
+/// Usage: pbkdf2_hmac_sha256 of password and salt and iterations and length
+pub fn native_pbkdf2_hmac_sha256(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("pbkdf2_hmac_sha256", &args, 4)?;
+
+    let password = expect_text(&args[0])?;
+    let salt = expect_text(&args[1])?;
+    let iterations = expect_count("pbkdf2_hmac_sha256", "iterations", &args[2])?;
+    let length = expect_count("pbkdf2_hmac_sha256", "length", &args[3])? as usize;
+
+    if password.len() > MAX_INPUT_SIZE || salt.len() > MAX_INPUT_SIZE {
+        return Err(RuntimeError::new(
+            format!(
+                "pbkdf2_hmac_sha256: input exceeds maximum allowed size ({MAX_INPUT_SIZE} bytes)"
+            ),
+            0,
+            0,
+        ));
+    }
+    if iterations < 1 {
+        return Err(RuntimeError::new(
+            "pbkdf2_hmac_sha256: iterations must be at least 1".to_string(),
+            0,
+            0,
+        ));
+    }
+    if iterations > MAX_PBKDF2_ITERATIONS as u64 {
+        return Err(RuntimeError::new(
+            format!("pbkdf2_hmac_sha256: iterations exceeds maximum ({MAX_PBKDF2_ITERATIONS})"),
+            0,
+            0,
+        ));
+    }
+    if length < 1 {
+        return Err(RuntimeError::new(
+            "pbkdf2_hmac_sha256: length must be at least 1 byte".to_string(),
+            0,
+            0,
+        ));
+    }
+    if length > MAX_PBKDF2_KEY_LENGTH {
+        return Err(RuntimeError::new(
+            format!("pbkdf2_hmac_sha256: length exceeds maximum ({MAX_PBKDF2_KEY_LENGTH} bytes)"),
+            0,
+            0,
+        ));
+    }
+
+    let mut derived = vec![0u8; length];
+    pbkdf2_hmac::<Sha256>(
+        password.as_bytes(),
+        salt.as_bytes(),
+        iterations as u32,
+        &mut derived,
+    );
+    let hex = bytes_to_hex(&derived);
+    derived.zeroize();
+    Ok(Value::Text(Arc::from(hex)))
+}
+
+/// Compare two strings in constant time, returning a boolean.
+///
+/// The comparison takes the same amount of time whether the strings match or
+/// differ at the first byte or the last, so it does not leak how much of a secret
+/// a caller guessed correctly. Use it whenever comparing a secret to attacker-
+/// supplied input: MACs, CSRF tokens, session IDs, password-reset codes. Length
+/// is not secret, so unequal-length inputs short-circuit to `no`.
+///
+/// Usage: constant_time_equals of a and b
+pub fn native_constant_time_equals(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("constant_time_equals", &args, 2)?;
+
+    let a = expect_text(&args[0])?;
+    let b = expect_text(&args[1])?;
+
+    // `ct_eq` on byte slices compares in constant time for equal-length inputs and
+    // returns `0` immediately when the lengths differ (length is not a secret).
+    let equal: bool = a.as_bytes().ct_eq(b.as_bytes()).into();
+    Ok(Value::Bool(equal))
+}
+
+/// Generate `n` cryptographically secure random bytes from the OS CSPRNG,
+/// returned as a lowercase hex string (so the result is `2 * n` characters).
+///
+/// Use this for salts, session identifiers, CSRF tokens, and password-reset
+/// tokens. Building such values out of `random_int` risks modulo bias and
+/// under-entropy; this draws uniform bytes directly from the operating system.
+///
+/// Usage: secure_random_bytes of n
+pub fn native_secure_random_bytes(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("secure_random_bytes", &args, 1)?;
+
+    use rand::RngCore;
+
+    let n = expect_count("secure_random_bytes", "n", &args[0])? as usize;
+    if n < 1 {
+        return Err(RuntimeError::new(
+            "secure_random_bytes: n must be at least 1".to_string(),
+            0,
+            0,
+        ));
+    }
+    if n > MAX_SECURE_RANDOM_BYTES {
+        return Err(RuntimeError::new(
+            format!("secure_random_bytes: n exceeds maximum ({MAX_SECURE_RANDOM_BYTES} bytes)"),
+            0,
+            0,
+        ));
+    }
+
+    let mut buf = vec![0u8; n];
+    rand::rng().fill_bytes(&mut buf);
+    let hex = bytes_to_hex(&buf);
+    buf.zeroize();
+    Ok(Value::Text(Arc::from(hex)))
+}
+
+// ============================================================================
 // Password hashing (Argon2id, bcrypt, scrypt, PBKDF2)
 //
 // Unlike the fast hashes above (sha256/wflhash), these are deliberately *slow*,
@@ -800,6 +963,10 @@ pub fn register_crypto(env: &mut Environment) {
     env.define_native("sha256", native_sha256);
     env.define_native("hmac_sha256", native_hmac_sha256);
     env.define_native("generate_csrf_token", native_generate_csrf_token);
+    // Low-level auth/session primitives
+    env.define_native("pbkdf2_hmac_sha256", native_pbkdf2_hmac_sha256);
+    env.define_native("constant_time_equals", native_constant_time_equals);
+    env.define_native("secure_random_bytes", native_secure_random_bytes);
     // Password hashing
     env.define_native("hash_password", native_hash_password);
     env.define_native("verify_password", native_verify_password);

--- a/src/stdlib/typechecker.rs
+++ b/src/stdlib/typechecker.rs
@@ -51,6 +51,7 @@ pub fn register_stdlib_types(analyzer: &mut Analyzer) {
     register_wflmac256(analyzer);
     register_sha256(analyzer);
     register_hmac_sha256(analyzer);
+    register_auth_primitives(analyzer);
     register_password_hashing(analyzer);
     register_count_lines(analyzer);
     register_path_extension(analyzer);
@@ -287,6 +288,23 @@ fn register_hmac_sha256(analyzer: &mut Analyzer) {
     let param_types = vec![Type::Text, Type::Text];
 
     analyzer.register_builtin_function("hmac_sha256", param_types, return_type);
+}
+
+fn register_auth_primitives(analyzer: &mut Analyzer) {
+    // pbkdf2_hmac_sha256 of password and salt and iterations and length -> Text
+    analyzer.register_builtin_function(
+        "pbkdf2_hmac_sha256",
+        vec![Type::Text, Type::Text, Type::Number, Type::Number],
+        Type::Text,
+    );
+    // constant_time_equals of a and b -> Boolean
+    analyzer.register_builtin_function(
+        "constant_time_equals",
+        vec![Type::Text, Type::Text],
+        Type::Boolean,
+    );
+    // secure_random_bytes of n -> Text (hex)
+    analyzer.register_builtin_function("secure_random_bytes", vec![Type::Number], Type::Text);
 }
 
 fn register_password_hashing(analyzer: &mut Analyzer) {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -199,7 +199,12 @@ impl TypeChecker {
             | "sha256"
             | "hmac_sha256"
             | "generate_uuid"
-            | "generate_csrf_token" => Type::Text,
+            | "generate_csrf_token"
+            | "pbkdf2_hmac_sha256"
+            | "secure_random_bytes" => Type::Text,
+
+            // Timing-safe comparison returns a boolean
+            "constant_time_equals" => Type::Boolean,
 
             // Password hashing: *_hash produce a string, *_verify produce a boolean
             "hash_password" | "argon2_hash" | "bcrypt_hash" | "scrypt_hash" | "pbkdf2_hash" => {

--- a/tests/crypto_kdf_test.rs
+++ b/tests/crypto_kdf_test.rs
@@ -1,0 +1,222 @@
+// TDD tests for launch-blocking crypto builtins (section 13.1):
+//   - pbkdf2_hmac_sha256 of password and salt and iterations and length
+//   - constant_time_equals of a and b
+//   - secure_random_bytes of n
+//
+// These move the auth hot-path (KDF), the timing-safe comparison, and CSPRNG
+// byte generation into native Rust so WFL auth/session code has a correct,
+// non-DoS-prone primitive instead of hand-rolling them in interpreted WFL.
+
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+/// Run WFL source and return the value stored in the `result` variable.
+async fn run_wfl_code(code: &str) -> Result<Value, String> {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser
+        .parse()
+        .map_err(|e| format!("Parse error: {:?}", e))?;
+
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&ast)
+        .await
+        .map_err(|e| format!("Runtime error: {:?}", e))?;
+
+    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
+        Ok(result_value)
+    } else {
+        Err("Variable 'result' not found after execution".to_string())
+    }
+}
+
+fn expect_text(result: Result<Value, String>) -> String {
+    match result {
+        Ok(Value::Text(t)) => t.to_string(),
+        other => panic!("Expected text result, got {:?}", other),
+    }
+}
+
+fn expect_bool(result: Result<Value, String>) -> bool {
+    match result {
+        Ok(Value::Bool(b)) => b,
+        other => panic!("Expected boolean result, got {:?}", other),
+    }
+}
+
+// === PBKDF2-HMAC-SHA256 (well-known / RFC-style vectors) ===
+// Vectors: P="password", S="salt". These are the canonical PBKDF2-HMAC-SHA256
+// test vectors published alongside RFC 6070's PBKDF2-HMAC-SHA1 vectors.
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_c1_dklen32() {
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "password" and "salt" and 1 and 32
+    "#;
+    let dk = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        dk, "120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b",
+        "PBKDF2-HMAC-SHA256(password, salt, c=1, dkLen=32) must match the standard vector"
+    );
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_c2_dklen32() {
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "password" and "salt" and 2 and 32
+    "#;
+    let dk = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        dk,
+        "ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43"
+    );
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_c4096_dklen32() {
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "password" and "salt" and 4096 and 32
+    "#;
+    let dk = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        dk,
+        "c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"
+    );
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_long_vector_dklen40() {
+    // P="passwordPASSWORDpassword", S="saltSALTsaltSALTsaltSALTsaltSALTsalt",
+    // c=4096, dkLen=40.
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "passwordPASSWORDpassword" and "saltSALTsaltSALTsaltSALTsaltSALTsalt" and 4096 and 40
+    "#;
+    let dk = expect_text(run_wfl_code(code).await);
+    assert_eq!(
+        dk,
+        "348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c4e2a1fb8dd53e1c635518c7dac47e9"
+    );
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_output_length_matches_request() {
+    // dkLen=16 bytes -> 32 hex chars
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "pw" and "sa" and 1000 and 16
+    "#;
+    let dk = expect_text(run_wfl_code(code).await);
+    assert_eq!(dk.len(), 32);
+    assert!(
+        dk.chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    );
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_rejects_zero_iterations() {
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "pw" and "salt" and 0 and 32
+    "#;
+    assert!(run_wfl_code(code).await.is_err());
+}
+
+#[tokio::test]
+async fn test_pbkdf2_hmac_sha256_rejects_zero_length() {
+    let code = r#"
+        store result as pbkdf2_hmac_sha256 of "pw" and "salt" and 1000 and 0
+    "#;
+    assert!(run_wfl_code(code).await.is_err());
+}
+
+// === constant_time_equals ===
+
+#[tokio::test]
+async fn test_constant_time_equals_equal_strings() {
+    let code = r#"
+        store result as constant_time_equals of "abc123" and "abc123"
+    "#;
+    assert!(expect_bool(run_wfl_code(code).await));
+}
+
+#[tokio::test]
+async fn test_constant_time_equals_different_strings() {
+    let code = r#"
+        store result as constant_time_equals of "abc123" and "abc124"
+    "#;
+    assert!(!expect_bool(run_wfl_code(code).await));
+}
+
+#[tokio::test]
+async fn test_constant_time_equals_different_lengths() {
+    let code = r#"
+        store result as constant_time_equals of "short" and "longer string"
+    "#;
+    assert!(!expect_bool(run_wfl_code(code).await));
+}
+
+#[tokio::test]
+async fn test_constant_time_equals_empty_strings() {
+    let code = r#"
+        store result as constant_time_equals of "" and ""
+    "#;
+    assert!(expect_bool(run_wfl_code(code).await));
+}
+
+#[tokio::test]
+async fn test_constant_time_equals_verifies_hmac_signature() {
+    // The intended use: compare a computed MAC against a received one safely.
+    let code = r#"
+        store expected as hmac_sha256 of "payload" and "secret"
+        store received as hmac_sha256 of "payload" and "secret"
+        store result as constant_time_equals of expected and received
+    "#;
+    assert!(expect_bool(run_wfl_code(code).await));
+}
+
+// === secure_random_bytes ===
+
+#[tokio::test]
+async fn test_secure_random_bytes_length() {
+    // 16 bytes -> 32 hex chars
+    let code = r#"
+        store result as secure_random_bytes of 16
+    "#;
+    let bytes = expect_text(run_wfl_code(code).await);
+    assert_eq!(bytes.len(), 32);
+    assert!(
+        bytes
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    );
+}
+
+#[tokio::test]
+async fn test_secure_random_bytes_are_unpredictable() {
+    let a = expect_text(run_wfl_code("store result as secure_random_bytes of 32").await);
+    let b = expect_text(run_wfl_code("store result as secure_random_bytes of 32").await);
+    assert_ne!(
+        a, b,
+        "Two calls must (with overwhelming probability) differ"
+    );
+}
+
+#[tokio::test]
+async fn test_secure_random_bytes_rejects_zero() {
+    assert!(
+        run_wfl_code("store result as secure_random_bytes of 0")
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn test_secure_random_bytes_rejects_excessive() {
+    assert!(
+        run_wfl_code("store result as secure_random_bytes of 100000")
+            .await
+            .is_err()
+    );
+}


### PR DESCRIPTION
## Summary

This change closes three launch-blocking gaps in section 13.1 by adding three new native cryptographic builtins and a static-analysis rule to prevent insecure RNG seeding in security-sensitive code.

## Key Changes

**New Builtins (src/stdlib/crypto.rs):**
- `pbkdf2_hmac_sha256` — Raw PBKDF2-HMAC-SHA256 key derivation with caller-supplied salt, iteration count, and output length. Runs the iteration loop in native Rust to bound per-call cost and prevent DoS on login endpoints. Validated against RFC/NIST standard test vectors.
- `constant_time_equals` — Timing-safe string comparison for MACs, CSRF tokens, session IDs, and password-reset codes. Uses the `subtle` crate to prevent timing-based side-channel attacks.
- `secure_random_bytes` — CSPRNG byte generation from the OS, returned as lowercase hex. Provides uniform entropy for salts, session identifiers, and tokens without modulo bias.

**Static Analysis Rule (src/analyzer/static_analyzer.rs):**
- New `check_insecure_rng_seeding` method flags `random_seed` calls in files that also perform cryptographic, authentication, or session work. The heuristic: if a file calls any security-sensitive builtin (hash_password, verify_password, sha256, hmac_sha256, etc.) *and* calls `random_seed`, every `random_seed` call site is reported as an error with code `ANALYZE-SECURITY`. This prevents seeding the general-purpose RNG in security code where predictable output undermines salts, tokens, and session IDs.
- AST walker (`collect_calls_in_statements`, `collect_calls_in_expression`) traverses all statement and expression types, including nested scopes (actions, loops, if/try blocks, test blocks, websocket/event handlers, container methods).

**Type Registration (src/stdlib/typechecker.rs, src/typechecker/mod.rs):**
- Registered the three new builtins with their signatures: all return `Text`; `pbkdf2_hmac_sha256` takes 4 arguments (password, salt, iterations, length); `constant_time_equals` takes 2 (a, b); `secure_random_bytes` takes 1 (n).

**Builtin Registry (src/builtins.rs):**
- Added the three new functions to `BUILTIN_FUNCTIONS`.

**Documentation (Docs/05-standard-library/crypto-module.md, Docs/reference/builtin-functions-reference.md):**
- Documented all three builtins with signatures, parameters, return types, use cases, and examples.
- Updated webhook-verification example to use `constant_time_equals` instead of `is` for signature comparison.
- Added guidance on when to use `pbkdf2_hmac_sha256` (raw KDF) vs. `pbkdf2_hash` (self-describing hash).

**Tests:**
- `tests/crypto_kdf_test.rs` — Comprehensive test suite validating PBKDF2 against standard vectors (c=1/2/4096, dkLen=32/40), constant-time equality (equal/unequal/length-mismatch, HMAC verification), and secure random bytes (length, unpredictability, bounds).
- `TestPrograms/crypto_auth_primitives_test.wfl` — End-to-end WFL program demonstrating all three primitives and a complete password-storage round-trip.
- Unit tests in `src/analyzer/static_analyzer.rs` for the RNG seeding lint: flagged in crypto context, flagged inside action bodies, allowed without crypto, clean with crypto but no seeding.

## Implementation Details

- **Output encoding:** All three builtins return lowercase hexadecimal strings, consistent with the rest of the crypto module.
- **Bounds:** Iterations ≤ 100,000,000; derived-key length ≤ 1024 bytes; `secure_random_bytes` n ≤ 4096. Zero is rejected for all three.
-

https://claude.ai/code/session_01Com1byUspKRzYbAEDs1B1v
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/595" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new auth/session crypto functions for password hashing, constant-time comparisons, and secure random bytes.
  * Expanded built-in references and standard library docs with usage examples and safety guidance.

* **Bug Fixes**
  * Added a security check that flags weak random seeding in files using cryptography or session-related features.
  * Updated signature/token comparison guidance to use constant-time matching.

* **Tests**
  * Added coverage for key derivation, constant-time equality, secure randomness, and security-rule detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->