### PR TITLE
Fix test-framework failure accounting for runtime errors

### DIFF
--- a/Dev diary/2026-07-10-test-mode-failure-accounting.md
+++ b/Dev diary/2026-07-10-test-mode-failure-accounting.md
@@ -1,0 +1,68 @@
+# `wfl --test` Failure Accounting: Runtime Errors Now Count, Assertions No Longer Double-Reported
+
+**Date:** 2026-07-10
+
+## What Changed
+
+Two bugs in the built-in test framework's result accounting were fixed. Both
+lived in the `TestBlock` error handler in `src/interpreter/mod.rs`.
+
+### Bug 1 — a runtime error in a test silently "passed"
+
+When a `test` body failed with a *runtime* error (anything other than a failed
+`expect`, e.g. an undefined variable), the failure was pushed to the failures
+list but `failed_tests` was **never incremented** — that counter was only ever
+bumped by the `ExpectStatement` handler. The consequence:
+
+- the summary printed `Failed: 0` even though the failure was listed, and
+- `results.failed_tests > 0` was false, so the process **exited 0**.
+
+A crashing test therefore looked green to CI. This is the test-mode analog of
+the exit-code bug fixed on 2026-07-03 for the normal execution path.
+
+### Bug 2 — a failing assertion was reported twice
+
+The handler tried to avoid re-recording assertion failures (already recorded by
+`ExpectStatement`) with this guard:
+
+```rust
+let error_msg = e.to_string();
+if !error_msg.starts_with("Assertion failed:") { /* record */ }
+```
+
+But `RuntimeError`'s `Display` prepends `"Runtime error at line L, column C: "`,
+so the string is `"Runtime error at line …: Assertion failed: …"` and the guard
+**never matched**. Every failing assertion was pushed to the failures list a
+second time (once clean from `ExpectStatement`, once with the `Runtime error …`
+prefix from `TestBlock`).
+
+## The Fix
+
+Inspect the raw `RuntimeError::message` field (which really does begin with
+`"Assertion failed:"`) instead of the `Display` string, and — when the error is
+*not* an assertion failure — increment `failed_tests` alongside pushing the
+failure:
+
+```rust
+if !e.message.starts_with("Assertion failed:") {
+    let context = self.current_describe_stack.borrow().clone();
+    let failure = TestFailure { /* … */, assertion_message: e.to_string(), /* … */ };
+    let mut results = self.test_results.borrow_mut();
+    results.failures.push(failure);
+    results.failed_tests += 1;
+}
+```
+
+Assertion failures now match the guard and are recorded exactly once; runtime
+errors are recorded once *and* counted, so `total == passed + failed` holds and
+the exit code is 1 whenever any test fails. The runtime-error message keeps its
+`Display` form so its real line/column (which differ from the `test` block's
+line) are still shown.
+
+## Tests
+
+Added `tests/test_framework_counting_test.rs` covering: a runtime error counting
+as a failure, a failing assertion recorded exactly once, a mixed suite where
+`total == passed + failed`, and short-circuiting on the first failing assertion.
+All existing `.test.wfl` programs and the repo's test-framework validation
+programs continue to pass.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -7114,20 +7114,27 @@ impl Interpreter {
                         Err(e) => {
                             test_passed = false;
 
-                            // Only record failure if not already recorded by expect statement
-                            // Check if this is an assertion failure (which has already been recorded)
-                            let error_msg = e.to_string();
-                            if !error_msg.starts_with("Assertion failed:") {
-                                // This is a non-assertion error (e.g., runtime error in test code)
+                            // Assertion failures are already recorded (failure entry +
+                            // failed_tests increment) by the ExpectStatement handler; its
+                            // raw message begins with "Assertion failed:". We must inspect
+                            // the raw `message` field here rather than the Display string,
+                            // which is prefixed with "Runtime error at line ...:" and would
+                            // otherwise never match the guard, causing the assertion to be
+                            // recorded twice. Any error that is NOT an assertion failure is a
+                            // runtime error in the test body that we record and count here so
+                            // it is reflected in the failure count and the process exit code.
+                            if !e.message.starts_with("Assertion failed:") {
                                 let context = self.current_describe_stack.borrow().clone();
                                 let failure = TestFailure {
                                     describe_context: context,
                                     test_name: description.clone(),
-                                    assertion_message: error_msg,
+                                    assertion_message: e.to_string(),
                                     line: *line,
                                     column: *column,
                                 };
-                                self.test_results.borrow_mut().failures.push(failure);
+                                let mut results = self.test_results.borrow_mut();
+                                results.failures.push(failure);
+                                results.failed_tests += 1;
                             }
 
                             // Don't propagate the error - continue running other tests

--- a/tests/test_framework_counting_test.rs
+++ b/tests/test_framework_counting_test.rs
@@ -1,0 +1,158 @@
+//! Regression tests for the `wfl --test` test-framework result accounting.
+//!
+//! These guard two bugs in the `TestBlock` error handler:
+//!
+//! 1. A test that fails due to a *runtime* error (not an assertion) was recorded
+//!    in the failures list but never counted in `failed_tests`. The summary showed
+//!    `Failed: 0` and the process exited 0, so CI treated a crashing test as passing.
+//!
+//! 2. A failing *assertion* was recorded twice. The guard meant to skip
+//!    already-recorded assertion failures compared the `Display` string (prefixed
+//!    with "Runtime error at line ...:") against `"Assertion failed:"`, which never
+//!    matched, so every assertion failure was pushed to the failures list a second
+//!    time.
+
+use wfl::interpreter::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+async fn run_tests(code: &str) -> wfl::interpreter::TestResults {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().expect("Should parse test program");
+
+    let mut interpreter = Interpreter::new();
+    interpreter.set_test_mode(true);
+    interpreter
+        .interpret(&program)
+        .await
+        .expect("Test-mode programs catch in-test errors and should not error overall");
+
+    interpreter.get_test_results()
+}
+
+/// A runtime error inside a test body must count as a failed test and appear
+/// exactly once in the failures list (Bug #1).
+#[tokio::test]
+async fn runtime_error_in_test_is_counted_as_failure() {
+    let code = r#"
+describe "runtime errors":
+    test "passing test":
+        expect 1 to equal 1
+    end test
+
+    test "runtime error test":
+        store x as undefined_variable_that_does_not_exist
+    end test
+end describe
+"#;
+
+    let results = run_tests(code).await;
+
+    assert_eq!(results.total_tests, 2, "two tests should run");
+    assert_eq!(results.passed_tests, 1, "one test passes");
+    assert_eq!(
+        results.failed_tests, 1,
+        "the runtime-error test must count as a failure (was 0 before the fix)"
+    );
+    assert_eq!(
+        results.total_tests,
+        results.passed_tests + results.failed_tests,
+        "total must equal passed + failed"
+    );
+    assert_eq!(
+        results.failures.len(),
+        1,
+        "the runtime error should be recorded exactly once"
+    );
+}
+
+/// A failing assertion must be recorded exactly once, not duplicated (Bug #2).
+#[tokio::test]
+async fn failing_assertion_is_recorded_once() {
+    let code = r#"
+describe "assertions":
+    test "failing assertion":
+        expect 5 to equal 6
+    end test
+end describe
+"#;
+
+    let results = run_tests(code).await;
+
+    assert_eq!(results.total_tests, 1);
+    assert_eq!(results.passed_tests, 0);
+    assert_eq!(results.failed_tests, 1, "one assertion failure");
+    assert_eq!(
+        results.failures.len(),
+        1,
+        "a failing assertion must be recorded exactly once, not duplicated"
+    );
+}
+
+/// Mixed suite: passing tests, assertion failures, and runtime errors must all
+/// be counted consistently so that total == passed + failed and the failures
+/// list has one entry per failing test.
+#[tokio::test]
+async fn mixed_results_are_counted_consistently() {
+    let code = r#"
+describe "mixed":
+    test "pass one":
+        expect 2 plus 2 to equal 4
+    end test
+
+    test "assertion fail":
+        expect 1 to equal 2
+    end test
+
+    test "runtime fail":
+        store y as some_missing_variable
+    end test
+
+    test "pass two":
+        expect "hi" to equal "hi"
+    end test
+end describe
+"#;
+
+    let results = run_tests(code).await;
+
+    assert_eq!(results.total_tests, 4);
+    assert_eq!(results.passed_tests, 2);
+    assert_eq!(results.failed_tests, 2);
+    assert_eq!(
+        results.total_tests,
+        results.passed_tests + results.failed_tests,
+        "total must equal passed + failed"
+    );
+    assert_eq!(
+        results.failures.len(),
+        2,
+        "exactly one failure entry per failing test"
+    );
+}
+
+/// Only the first failing assertion in a test runs (the test stops on first
+/// failure), so a test with several failing assertions still counts once.
+#[tokio::test]
+async fn only_first_failing_assertion_recorded_per_test() {
+    let code = r#"
+describe "short circuit":
+    test "multiple failing assertions":
+        expect 1 to equal 2
+        expect 3 to equal 4
+        expect 5 to equal 6
+    end test
+end describe
+"#;
+
+    let results = run_tests(code).await;
+
+    assert_eq!(results.total_tests, 1);
+    assert_eq!(results.failed_tests, 1, "one failed test, not three");
+    assert_eq!(
+        results.failures.len(),
+        1,
+        "only the first failing assertion is recorded"
+    );
+}


### PR DESCRIPTION
## Summary

Fixed two bugs in the `wfl --test` test-framework result accounting that caused runtime errors to be silently treated as passing tests and assertion failures to be double-reported in the failures list.

## Key Changes

- **Bug 1 — Runtime errors now count as failures**: When a test body failed with a runtime error (e.g., undefined variable), the failure was recorded but `failed_tests` was never incremented. This caused the summary to show `Failed: 0` and the process to exit 0, making crashing tests appear green to CI. Now runtime errors increment `failed_tests` alongside being recorded in the failures list.

- **Bug 2 — Assertion failures no longer double-reported**: The guard to skip already-recorded assertion failures compared the `Display` string (which is prefixed with `"Runtime error at line ...:"`) against `"Assertion failed:"`, which never matched. Now the guard inspects the raw `RuntimeError::message` field, which correctly begins with `"Assertion failed:"` for assertion failures, preventing duplicate entries.

## Implementation Details

In `src/interpreter/mod.rs`, the `TestBlock` error handler now:
1. Inspects `e.message` (the raw error message) instead of `e.to_string()` (the Display form with line/column prefix) to correctly identify assertion failures
2. Increments `results.failed_tests` when recording non-assertion runtime errors, ensuring the failure count is accurate
3. Preserves the full `Display` string in the failure record so line/column information is still visible to users

## Testing

Added comprehensive regression tests in `tests/test_framework_counting_test.rs`:
- Runtime errors are counted as failures and appear exactly once
- Failing assertions are recorded exactly once (not duplicated)
- Mixed test suites maintain the invariant `total == passed + failed`
- Short-circuiting on first assertion failure is preserved

All existing `.test.wfl` programs and test-framework validation continue to pass.

https://claude.ai/code/session_01EcnZgma17a36Wc7VazYWG2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected test-mode failure counts so runtime errors are included in failed test totals.
  * Test runs now return a failure status when runtime errors occur.
  * Prevented failed assertions from being reported more than once.
  * Test execution now stops the current test after its first failure while continuing with the remaining tests.
  * Improved consistency between total, passed, and failed test counts.

* **Documentation**
  * Added documentation describing test failure accounting and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->