### PR TITLE
fix: close web server gaps for real apps (#597)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
+- HTTP request query string access: raw query is available as `query` / `query of req` (no leading `?`) so `parse_query_string of query` works on real requests (#597)
+- Configurable request body size limit via `.wflcfg` `web_server_max_body_size` (default still 1 MiB) (#597)
+- `parse_multipart of <body> and <content_type>` returns a list of part objects (`name`, `filename`, `content_type`, `content`, `content_bytes`) for multipart form uploads (#597)
 - HTTPS support for the built-in web server: `listen on port 8443 secured with certificate "cert.pem" and key "key.pem" as server` (PEM files; paths may be expressions)
 - Bare `secured` form takes certificate/key paths from new `.wflcfg` settings `web_server_tls_cert_file` / `web_server_tls_key_file`; in-language paths always win, and a plain `listen` never becomes HTTPS via config
 - HTTP→HTTPS auto-redirect servers: `listen on port 8080 redirecting to port 8443 as redirect_server` answers every request natively with `301 Moved Permanently`, preserving host, path, and query (target port omitted when 443)
@@ -35,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New documentation: `Docs/04-advanced-features/databases.md`; route-parameters section in `Docs/04-advanced-features/web-servers.md`
 
 ### Fixed
+- `header "<Name>" of <request>` now reads headers from the request object, so it works inside actions that receive `req` as a parameter (previously looked only at loop-scoped `headers` and failed with "no request in scope") (#597)
 - `respond to ... with <content> and status <code> and content_type <type>` previously parsed the status as the boolean expression `<code> and content_type`, which failed at runtime and left the HTTP request unanswered; status/content_type values now parse as primary expressions
 - `header "<Name>" of <request>` is now case-insensitive; warp normalizes header names to lowercase, so canonically-spelled names like `User-Agent` always returned nothing on real requests. Absent headers now compare equal to `nothing`
 - The static analyzer now marks variables inside list literals (e.g. `parameters [user_name]`) as used

--- a/Dev diary/2026-07-10-web-server-gaps-issue-597.md
+++ b/Dev diary/2026-07-10-web-server-gaps-issue-597.md
@@ -1,0 +1,54 @@
+# Dev Diary — 2026-07-10: Web server gaps for real apps (#597)
+
+## Context
+
+Building the Scriptorium CMS in pure WFL surfaced three concrete web-server
+gaps that forced workarounds or blocked features:
+
+1. No query-string access on requests (`?page=2` was unreadable).
+2. Hard-coded 1 MiB body cap and no multipart parser (media uploads blocked).
+3. `header` / path / method / body only worked in the top-level request loop,
+   not inside actions that receive `req`.
+
+## What changed
+
+### Query string
+
+- Warp now captures the raw query via `warp::query::raw()`.
+- `WflHttpRequest` carries a `query` field (no leading `?`; empty when absent).
+- Exposed as loop-scoped `query` and as `query of req`, ready for
+  `parse_query_string of query`.
+- `execute file ... with <request>` also injects `query`.
+
+### Configurable body size
+
+- New `.wflcfg` key: `web_server_max_body_size` (default still `1048576`).
+- The listen handler uses the config value instead of a hard-coded constant.
+
+### Multipart parsing
+
+- New builtin: `parse_multipart of <body> and <content_type>`.
+- Accepts text or binary body; Content-Type supplies the boundary.
+- Returns a list of part objects: `name`, `filename`, `content_type`,
+  `content`, `content_bytes`.
+
+### Request access inside actions
+
+- `header "X" of req` now resolves headers from the **request object** first
+  (then falls back to the loop-scoped `headers` binding).
+- `path of req` / `method of req` / `body of req` already worked via property
+  access once `req` is passed in; docs now steer handlers to that form.
+
+## Tests
+
+- `tests/web_server_query_and_request_access_test.rs` — query, action access,
+  default body-limit rejection.
+- `tests/parse_multipart_test.rs` — WFL-level wiring + error path.
+- Unit tests in `src/stdlib/web.rs` for boundary extraction and part shape.
+- Config tests for `web_server_max_body_size` default and override.
+
+## Docs
+
+- `Docs/04-advanced-features/web-servers.md` — query, multipart, body limit,
+  action-scoped request access.
+- `Docs/reference/configuration-reference.md` — `web_server_max_body_size`.

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -188,6 +188,30 @@ display "User agent: " with user_agent
 respond to req with "ok"
 ```
 
+`header "Name" of req` reads from the **request object**, so it also works
+inside actions that receive `req` as a parameter (you do not need the
+loop-scoped `headers` binding).
+
+### Query String
+
+The raw query string (without the leading `?`) is available as `query` in the
+request loop, or as `query of req` when you have a request object. Feed it to
+`parse_query_string` for key/value access:
+
+```wfl
+listen on port 8080 as web_server
+wait for request comes in on web_server as req
+
+store params as parse_query_string of query
+store page as params["page"]
+// or equivalently:
+// store params as parse_query_string of query of req
+
+respond to req with "Page: " with page
+```
+
+An URL without a query string yields empty text (`""`).
+
 ### Request Body
 
 The request body is available two ways:
@@ -207,6 +231,68 @@ close file out_file
 
 respond to req with "Uploaded"
 ```
+
+Bodies larger than the configured limit (default **1 MiB**) are rejected before
+they reach your handler. Raise the limit in `.wflcfg` when you need larger
+uploads:
+
+```ini
+web_server_max_body_size = 10485760
+```
+
+### Multipart Form Uploads
+
+Parse `multipart/form-data` bodies with `parse_multipart`. Pass the body
+(text or `body_bytes`) and the `Content-Type` header (needed for the boundary):
+
+```wfl
+wait for request comes in on web_server as req
+
+store content_type as header "Content-Type" of req
+store parts as parse_multipart of body_bytes and content_type
+
+for each part in parts:
+    store field_name as part["name"]
+    store filename as part["filename"]
+    // Text fields: part["content"]
+    // File bytes:  part["content_bytes"]
+    // Optional:    part["content_type"]
+end for
+
+respond to req with "Uploaded"
+```
+
+Each part is an object with:
+
+| Field | Type | Notes |
+|-------|------|--------|
+| `name` | text or nothing | Form field name |
+| `filename` | text or nothing | Present for file parts |
+| `content_type` | text or nothing | Part's Content-Type, if any |
+| `content` | text | Lossy UTF-8 view of the part body |
+| `content_bytes` | binary | Exact bytes (use for files) |
+
+### Using the request object inside actions
+
+`method`, `path`, `query`, `body`, and `body_bytes` are also properties of the
+request object. Prefer `path of req` (and friends) inside actions so handlers
+stay self-contained:
+
+```wfl
+define action called handle with parameters req:
+    store p as path of req
+    store m as method of req
+    store ua as header "User-Agent" of req
+    respond to req with m with " " with p with " " with ua
+end action
+
+listen on port 8080 as web_server
+wait for request comes in on web_server as req
+call handle with req
+```
+
+Bare names like `path` and `method` only exist in the request loop scope after
+`wait for request`; they are not visible inside actions.
 
 ## Response Options
 

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -298,6 +298,16 @@ Default TLS private key file used by `listen on port ... secured` statements tha
 
 **Security Note:** Protect the private key with restrictive file permissions (e.g. `chmod 600`). WFL validates both files at `listen` time and reports missing or malformed files with the offending path.
 
+#### web_server_max_body_size
+
+Maximum HTTP request body size accepted by `listen on port` servers, in bytes. Requests larger than this limit are rejected before the body reaches your WFL handler (DoS protection).
+
+- **Type:** Integer (bytes, at least 1)
+- **Default:** `1048576` (1 MiB)
+- **Example:** `web_server_max_body_size = 10485760` (10 MiB, suitable for media uploads)
+
+Raise this when accepting file uploads via `parse_multipart` or raw `body_bytes`. Keep it as small as practical for public-facing APIs.
+
 ## Example Configuration Files
 
 ### Development Configuration

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1637,6 +1637,7 @@ impl Analyzer {
                 let request_properties = [
                     ("method", Type::Text),
                     ("path", Type::Text),
+                    ("query", Type::Text),
                     ("client_ip", Type::Text),
                     ("body", Type::Text),
                     ("body_bytes", Type::Binary),

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -65,6 +65,7 @@ const BUILTIN_FUNCTIONS: &[&str] = &[
     "path_params",
     "path_matches",
     "mime_type",
+    "parse_multipart",
     // Math functions (implemented in stdlib/math.rs)
     "min",
     "max",
@@ -308,8 +309,8 @@ pub fn get_function_arity(name: &str) -> usize {
         "parse_query_string" | "parse_cookies" | "parse_form_urlencoded" => 1,
 
         // === WEB ROUTING HELPERS ===
-        // Two argument functions: (path, template)
-        "path_params" | "path_matches" => 2,
+        // Two argument functions: (path, template) or (body, content_type)
+        "path_params" | "path_matches" | "parse_multipart" => 2,
         // Single argument: (name)
         "mime_type" => 1,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,9 @@ pub struct WflConfig {
     // statement does not name certificate/key files itself
     pub web_server_tls_cert_file: Option<String>,
     pub web_server_tls_key_file: Option<String>,
+    /// Maximum accepted HTTP request body size in bytes (DoS protection).
+    /// Default 1 MiB; raise for media uploads via `.wflcfg`.
+    pub web_server_max_body_size: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -123,6 +126,8 @@ impl Default for WflConfig {
             // name its certificate/key files or these must be set in .wflcfg
             web_server_tls_cert_file: None,
             web_server_tls_key_file: None,
+            // 1 MiB default body limit (DoS protection); raise for uploads
+            web_server_max_body_size: 1_048_576,
         }
     }
 }
@@ -617,6 +622,41 @@ fn parse_config_text(config: &mut WflConfig, text: &str, file: &Path) {
                         );
                     }
                 }
+                "web_server_max_body_size" => {
+                    if let Ok(size) = value.parse::<usize>() {
+                        // Reject zero so a misconfigured limit cannot lock out all POSTs
+                        if size == 0 {
+                            log::warn!(
+                                "Invalid web_server_max_body_size '0' in {}: must be at least 1. Keeping {}",
+                                file.display(),
+                                config.web_server_max_body_size
+                            );
+                        } else {
+                            if config.web_server_max_body_size
+                                != WflConfig::default().web_server_max_body_size
+                            {
+                                log::debug!(
+                                    "Overriding web_server_max_body_size: {} -> {} from {}",
+                                    config.web_server_max_body_size,
+                                    size,
+                                    file.display()
+                                );
+                            }
+                            config.web_server_max_body_size = size;
+                            log::debug!(
+                                "Loaded web_server_max_body_size: {} from {}",
+                                config.web_server_max_body_size,
+                                file.display()
+                            );
+                        }
+                    } else {
+                        log::warn!(
+                            "Invalid web_server_max_body_size '{}' in {}: expected a positive integer",
+                            value,
+                            file.display()
+                        );
+                    }
+                }
                 _ => {
                     log::warn!("Unknown configuration key: {} in {}", key, file.display());
                 }
@@ -1056,6 +1096,42 @@ mod tests {
         assert_eq!(
             config.web_server_tls_key_file, None,
             "Default web_server_tls_key_file should be None"
+        );
+    }
+
+    #[test]
+    fn test_web_server_max_body_size_default() {
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let config = with_test_global_path(|| {
+            set_test_env_var(Some("/non/existent/path"));
+            load_config(temp_dir.path())
+        });
+
+        assert_eq!(
+            config.web_server_max_body_size, 1_048_576,
+            "Default web_server_max_body_size should be 1 MiB"
+        );
+    }
+
+    #[test]
+    fn test_web_server_max_body_size_custom() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let config_path = temp_dir.path().join(".wflcfg");
+
+        let config_content = "web_server_max_body_size = 10485760\n";
+
+        let mut file = fs::File::create(&config_path).unwrap();
+        file.write_all(config_content.as_bytes()).unwrap();
+
+        let config = with_test_global_path(|| {
+            set_test_env_var(Some("/non/existent/path"));
+            load_config(temp_dir.path())
+        });
+
+        assert_eq!(
+            config.web_server_max_body_size, 10_485_760,
+            "web_server_max_body_size should load from .wflcfg"
         );
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -72,6 +72,10 @@ pub struct WflHttpRequest {
     pub id: String,
     pub method: String,
     pub path: String,
+    /// Raw query string without the leading `?` (empty when the URL has none).
+    /// Exposed as the `query` request property / loop-scoped variable so
+    /// handlers can feed it to `parse_query_string`.
+    pub query: String,
     pub client_ip: String,
     /// Raw request body bytes. Exposed to WFL both as a lossy-UTF-8 `body`
     /// text variable (backward compatible) and as a lossless `body_bytes`
@@ -90,6 +94,25 @@ pub struct WflHttpResponse {
     pub status: u16,
     pub content_type: String,
     pub headers: HashMap<String, String>,
+}
+
+/// Look up an HTTP header by name in a request headers map.
+///
+/// Header names are case-insensitive (RFC 7230). Warp stores them lowercase,
+/// while WFL programs typically use canonical forms like `User-Agent`, so an
+/// exact-key miss falls back to a case-insensitive scan. Extracted as a pure
+/// function so unit tests pin the regression without spinning up a server.
+pub(crate) fn lookup_header_case_insensitive(
+    headers: &HashMap<String, Value>,
+    header_name: &str,
+) -> Option<Value> {
+    headers.get(header_name).cloned().or_else(|| {
+        let lowered = header_name.to_lowercase();
+        headers
+            .iter()
+            .find(|(key, _)| key.to_lowercase() == lowered)
+            .map(|(_, value)| value.clone())
+    })
 }
 
 #[derive(Debug)]
@@ -5362,30 +5385,33 @@ impl Interpreter {
 
                 // Create warp routes that handle all HTTP methods and paths
                 // Note: Body size validation is performed manually in the handler below
-                // to allow GET requests without Content-Length headers
+                // to allow GET requests without Content-Length headers. The limit is
+                // configurable via `.wflcfg` `web_server_max_body_size` (default 1 MB).
                 let request_sender_clone = request_sender.clone();
+                let max_body_size = self.config.web_server_max_body_size;
                 let routes = warp::any()
                     .and(warp::method())
                     .and(warp::path::full())
+                    .and(warp::query::raw().or(warp::any().map(String::new)).unify())
                     .and(warp::header::headers_cloned())
                     .and(warp::body::bytes())
                     .and(warp::addr::remote())
                     .and_then(
                         move |method: warp::http::Method,
                               path: warp::path::FullPath,
+                              query: String,
                               headers: warp::http::HeaderMap,
                               body: bytes::Bytes,
                               remote_addr: Option<std::net::SocketAddr>| {
                             let sender = request_sender_clone.clone();
                             async move {
-                                // DoS PROTECTION: Enforce 1MB body size limit
-                                // This maintains the security requirement from web_server_body_limit_test.wfl
-                                const MAX_BODY_SIZE: usize = 1_048_576; // 1MB
-                                if body.len() > MAX_BODY_SIZE {
+                                // DoS PROTECTION: Enforce configurable body size limit
+                                // Default 1 MB; override with web_server_max_body_size in .wflcfg
+                                if body.len() > max_body_size {
                                     return Err(warp::reject::custom(ServerError(format!(
                                         "Request body too large: {} bytes (limit: {} bytes)",
                                         body.len(),
-                                        MAX_BODY_SIZE
+                                        max_body_size
                                     ))));
                                 }
 
@@ -5419,6 +5445,7 @@ impl Interpreter {
                                     id: request_id,
                                     method: method.to_string(),
                                     path: path.as_str().to_string(),
+                                    query,
                                     client_ip,
                                     body: body_bytes,
                                     headers: header_map,
@@ -5902,6 +5929,10 @@ impl Interpreter {
                     Value::Text(Arc::from(request.path.clone())),
                 );
                 request_properties.insert(
+                    "query".to_string(),
+                    Value::Text(Arc::from(request.query.clone())),
+                );
+                request_properties.insert(
                     "client_ip".to_string(),
                     Value::Text(Arc::from(request.client_ip.clone())),
                 );
@@ -5925,6 +5956,8 @@ impl Interpreter {
                 env_mut.define_or_replace("method", Value::Text(Arc::from(request.method.clone())));
 
                 env_mut.define_or_replace("path", Value::Text(Arc::from(request.path.clone())));
+
+                env_mut.define_or_replace("query", Value::Text(Arc::from(request.query.clone())));
 
                 env_mut.define_or_replace(
                     "client_ip",
@@ -6680,7 +6713,7 @@ impl Interpreter {
                         Value::Object(props) => {
                             let props = props.borrow();
                             let mut vars = Vec::new();
-                            for key in ["method", "path", "client_ip", "body", "headers"] {
+                            for key in ["method", "path", "query", "client_ip", "body", "headers"] {
                                 let value = props.get(key).ok_or_else(|| {
                                     RuntimeError::new(
                                         format!(
@@ -8955,37 +8988,54 @@ impl Interpreter {
             }
             Expression::HeaderAccess {
                 header_name,
-                request: _,
+                request,
                 line,
                 column,
             } => {
-                // Access the headers object from the environment
-                // Headers are stored as a global variable when wait for request is executed
-                let headers_val = match env.borrow().get("headers") {
-                    Some(val) => val.clone(),
-                    None => {
-                        return Err(RuntimeError::new(
-                            "Cannot access headers: no request in scope. Use 'wait for request comes in' first.".to_string(),
-                            *line,
-                            *column,
-                        ));
+                // Resolve headers from the request object first so
+                // `header "X" of req` works inside actions that receive
+                // `req` as a parameter (issue #597). Fall back to the
+                // loop-scoped `headers` binding for backward compatibility
+                // when the request expression is not a request object.
+                let headers_val = {
+                    let request_val = self.evaluate_expression(request, Rc::clone(&env)).await?;
+                    match &request_val {
+                        Value::Object(obj) => {
+                            let map = obj.borrow();
+                            if let Some(headers) = map.get("headers") {
+                                headers.clone()
+                            } else {
+                                // Not a request object — try env fallback
+                                match env.borrow().get("headers") {
+                                    Some(val) => val.clone(),
+                                    None => {
+                                        return Err(RuntimeError::new(
+                                            "Cannot access headers: no request in scope. Use 'wait for request comes in' first, or pass a request object to the action.".to_string(),
+                                            *line,
+                                            *column,
+                                        ));
+                                    }
+                                }
+                            }
+                        }
+                        _ => match env.borrow().get("headers") {
+                            Some(val) => val.clone(),
+                            None => {
+                                return Err(RuntimeError::new(
+                                    "Cannot access headers: no request in scope. Use 'wait for request comes in' first, or pass a request object to the action.".to_string(),
+                                    *line,
+                                    *column,
+                                ));
+                            }
+                        },
                     }
                 };
 
-                // Get the specific header from the headers object. HTTP
-                // header names are case-insensitive (and warp normalizes
-                // them to lowercase), so fall back to a case-insensitive
-                // scan when the exact key is absent.
+                // Get the specific header from the headers object.
                 match &headers_val {
                     Value::Object(headers_map) => {
                         let map = headers_map.borrow();
-                        let header_value = map.get(header_name).cloned().or_else(|| {
-                            let lowered = header_name.to_lowercase();
-                            map.iter()
-                                .find(|(key, _)| key.to_lowercase() == lowered)
-                                .map(|(_, value)| value.clone())
-                        });
-                        match header_value {
+                        match lookup_header_case_insensitive(&map, header_name) {
                             Some(header_value) => Ok(header_value),
                             // Value::Null is the runtime value of WFL's
                             // `nothing` literal
@@ -9601,6 +9651,76 @@ impl Interpreter {
         }
 
         Ok(files)
+    }
+}
+
+#[cfg(test)]
+mod header_lookup_tests {
+    use super::*;
+
+    fn text(s: &str) -> Value {
+        Value::Text(Arc::from(s))
+    }
+
+    fn headers_with(pairs: &[(&str, &str)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), text(v)))
+            .collect()
+    }
+
+    #[test]
+    fn exact_key_match_returns_value() {
+        let headers = headers_with(&[("user-agent", "exact")]);
+        let got = lookup_header_case_insensitive(&headers, "user-agent");
+        assert!(
+            matches!(got, Some(Value::Text(t)) if t.as_ref() == "exact"),
+            "exact key should hit without scanning"
+        );
+    }
+
+    #[test]
+    fn canonical_name_finds_lowercase_warp_key() {
+        // Regression: warp normalizes to lowercase; programs use "User-Agent".
+        let headers = headers_with(&[("user-agent", "wfl-header-test")]);
+        let got = lookup_header_case_insensitive(&headers, "User-Agent");
+        assert!(
+            matches!(got, Some(Value::Text(t)) if t.as_ref() == "wfl-header-test"),
+            "header \"User-Agent\" must resolve the lowercase 'user-agent' entry"
+        );
+    }
+
+    #[test]
+    fn mixed_case_lookup_against_mixed_case_key() {
+        let headers = headers_with(&[("Content-Type", "application/json")]);
+        let got = lookup_header_case_insensitive(&headers, "content-type");
+        assert!(
+            matches!(got, Some(Value::Text(t)) if t.as_ref() == "application/json"),
+            "lookup should be case-insensitive in both directions"
+        );
+    }
+
+    #[test]
+    fn uppercase_lookup_against_lowercase_key() {
+        let headers = headers_with(&[("x-custom-header", "present")]);
+        let got = lookup_header_case_insensitive(&headers, "X-CUSTOM-HEADER");
+        assert!(
+            matches!(got, Some(Value::Text(t)) if t.as_ref() == "present"),
+            "full uppercase name should still match"
+        );
+    }
+
+    #[test]
+    fn missing_header_returns_none() {
+        let headers = headers_with(&[("user-agent", "bot")]);
+        let got = lookup_header_case_insensitive(&headers, "Accept");
+        assert!(got.is_none(), "absent header should return None (maps to nothing)");
+    }
+
+    #[test]
+    fn empty_headers_map_returns_none() {
+        let headers = HashMap::new();
+        assert!(lookup_header_case_insensitive(&headers, "User-Agent").is_none());
     }
 }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -5383,17 +5383,38 @@ impl Interpreter {
                     mpsc::unbounded_channel::<WflHttpRequest>();
                 let request_receiver = Arc::new(tokio::sync::Mutex::new(request_receiver));
 
-                // Create warp routes that handle all HTTP methods and paths
-                // Note: Body size validation is performed manually in the handler below
-                // to allow GET requests without Content-Length headers. The limit is
-                // configurable via `.wflcfg` `web_server_max_body_size` (default 1 MB).
+                // Create warp routes that handle all HTTP methods and paths.
+                // Body size: reject oversized Content-Length *before* buffering
+                // (when the header is present), then re-check after
+                // `body::bytes()` for missing/wrong Content-Length. GET and
+                // other no-body requests still work without Content-Length.
+                // Limit is configurable via `.wflcfg` `web_server_max_body_size`
+                // (default 1 MB).
                 let request_sender_clone = request_sender.clone();
                 let max_body_size = self.config.web_server_max_body_size;
+                let max_body_size_u64 = max_body_size as u64;
                 let routes = warp::any()
                     .and(warp::method())
                     .and(warp::path::full())
                     .and(warp::query::raw().or(warp::any().map(String::new)).unify())
                     .and(warp::header::headers_cloned())
+                    // Early reject when the client advertises an oversized body,
+                    // so we never allocate for that payload. Optional header so
+                    // GETs without Content-Length are unaffected.
+                    .and(
+                        warp::header::optional::<u64>("content-length").and_then(
+                            move |len: Option<u64>| async move {
+                                if let Some(len) = len
+                                    && len > max_body_size_u64
+                                {
+                                    return Err(warp::reject::custom(ServerError(format!(
+                                        "Request body too large: {len} bytes (limit: {max_body_size_u64} bytes)"
+                                    ))));
+                                }
+                                Ok::<(), warp::Rejection>(())
+                            },
+                        ),
+                    )
                     .and(warp::body::bytes())
                     .and(warp::addr::remote())
                     .and_then(
@@ -5401,12 +5422,13 @@ impl Interpreter {
                               path: warp::path::FullPath,
                               query: String,
                               headers: warp::http::HeaderMap,
+                              (),
                               body: bytes::Bytes,
                               remote_addr: Option<std::net::SocketAddr>| {
                             let sender = request_sender_clone.clone();
                             async move {
-                                // DoS PROTECTION: Enforce configurable body size limit
-                                // Default 1 MB; override with web_server_max_body_size in .wflcfg
+                                // Safety net when Content-Length was absent or lied:
+                                // still refuse after buffering so the limit holds.
                                 if body.len() > max_body_size {
                                     return Err(warp::reject::custom(ServerError(format!(
                                         "Request body too large: {} bytes (limit: {} bytes)",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -9714,7 +9714,10 @@ mod header_lookup_tests {
     fn missing_header_returns_none() {
         let headers = headers_with(&[("user-agent", "bot")]);
         let got = lookup_header_case_insensitive(&headers, "Accept");
-        assert!(got.is_none(), "absent header should return None (maps to nothing)");
+        assert!(
+            got.is_none(),
+            "absent header should return None (maps to nothing)"
+        );
     }
 
     #[test]

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -510,3 +510,76 @@ async fn test_finally_runs_after_caught_error_with_binding() {
         other => panic!("expected text, got {other:?}"),
     }
 }
+
+/// End-to-end unit regression for case-insensitive `header "Name" of req`
+/// without spinning up an HTTP server. Builds a synthetic request object
+/// whose headers map uses warp-style lowercase keys — the same shape
+/// `wait for request` produces — and asserts canonical names still resolve.
+#[tokio::test]
+async fn test_header_access_case_insensitive_via_request_object() {
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    let interpreter = Interpreter::new();
+    let env = Environment::new_global();
+
+    // Mimic warp: header names stored lowercase on the request object.
+    let mut headers_map = HashMap::new();
+    headers_map.insert(
+        "user-agent".to_string(),
+        Value::Text(Arc::from("wfl-header-test")),
+    );
+    headers_map.insert(
+        "content-type".to_string(),
+        Value::Text(Arc::from("text/plain")),
+    );
+    let headers_object = Value::Object(Rc::new(RefCell::new(headers_map)));
+
+    let mut request_props = HashMap::new();
+    request_props.insert("headers".to_string(), headers_object);
+    let request_object = Value::Object(Rc::new(RefCell::new(request_props)));
+    env.borrow_mut()
+        .define("req", request_object)
+        .expect("define req");
+
+    let tokens = lex_wfl_with_positions(r#"header "User-Agent" of req"#);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().expect("parse header access");
+    let expr = match program.statements.first() {
+        Some(crate::parser::ast::Statement::ExpressionStatement { expression, .. }) => expression,
+        other => panic!("expected expression statement, got {other:?}"),
+    };
+
+    let result = interpreter
+        .evaluate_expression(expr, Rc::clone(&env))
+        .await
+        .expect("header access should succeed");
+
+    match result {
+        Value::Text(s) => assert_eq!(
+            s.as_ref(),
+            "wfl-header-test",
+            "header \"User-Agent\" of req must find lowercase 'user-agent'"
+        ),
+        other => panic!("expected text, got {other:?}"),
+    }
+
+    // Missing header → nothing (Value::Null)
+    let tokens = lex_wfl_with_positions(r#"header "X-Missing" of req"#);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().expect("parse missing header access");
+    let expr = match program.statements.first() {
+        Some(crate::parser::ast::Statement::ExpressionStatement { expression, .. }) => expression,
+        other => panic!("expected expression statement, got {other:?}"),
+    };
+    let result = interpreter
+        .evaluate_expression(expr, env)
+        .await
+        .expect("missing header should not error");
+    assert!(
+        matches!(result, Value::Null),
+        "absent header should be nothing, got {result:?}"
+    );
+}

--- a/src/stdlib/typechecker.rs
+++ b/src/stdlib/typechecker.rs
@@ -41,6 +41,7 @@ pub fn register_stdlib_types(analyzer: &mut Analyzer) {
 
     register_path_params(analyzer);
     register_path_matches(analyzer);
+    register_parse_multipart(analyzer);
 
     register_generate_uuid(analyzer);
     register_generate_csrf_token(analyzer);
@@ -447,6 +448,14 @@ fn register_path_matches(analyzer: &mut Analyzer) {
     let return_type = Type::Boolean;
 
     analyzer.register_builtin_function("path_matches", param_types, return_type);
+}
+
+fn register_parse_multipart(analyzer: &mut Analyzer) {
+    // body (text or binary) + Content-Type header value
+    let param_types = vec![Type::Any, Type::Text];
+    let return_type = Type::List(Box::new(Type::Unknown)); // list of part objects
+
+    analyzer.register_builtin_function("parse_multipart", param_types, return_type);
 }
 
 fn register_generate_uuid(analyzer: &mut Analyzer) {

--- a/src/stdlib/web.rs
+++ b/src/stdlib/web.rs
@@ -151,10 +151,249 @@ pub fn native_mime_type(args: Vec<Value>) -> Result<Value, RuntimeError> {
     Ok(Value::Text(Arc::from(content_type_for_extension(ext))))
 }
 
+/// Extract the `boundary=` parameter from a Content-Type header value.
+/// Accepts both `multipart/form-data; boundary=...` and a bare boundary string.
+fn extract_multipart_boundary(content_type: &str) -> Option<String> {
+    let trimmed = content_type.trim();
+    // Bare boundary (no semicolon / no type) is accepted for convenience in tests
+    if !trimmed.contains(';') && !trimmed.contains('/') {
+        if trimmed.is_empty() {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
+    for part in trimmed.split(';').skip(1) {
+        let part = part.trim();
+        if let Some((key, value)) = part.split_once('=')
+            && key.trim().eq_ignore_ascii_case("boundary")
+        {
+            let value = value.trim().trim_matches('"');
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Parse a single multipart Content-Disposition header for name and optional filename.
+fn parse_content_disposition(header: &str) -> (Option<String>, Option<String>) {
+    let mut name = None;
+    let mut filename = None;
+    for part in header.split(';').skip(1) {
+        let part = part.trim();
+        if let Some((key, value)) = part.split_once('=') {
+            let key = key.trim();
+            let value = value.trim().trim_matches('"').to_string();
+            if key.eq_ignore_ascii_case("name") {
+                name = Some(value);
+            } else if key.eq_ignore_ascii_case("filename") || key.eq_ignore_ascii_case("filename*")
+            {
+                // filename* can be charset'lang'value — take the raw value for now
+                let value = value
+                    .rsplit_once('\'')
+                    .map(|(_, v)| v.to_string())
+                    .unwrap_or(value);
+                filename = Some(value);
+            }
+        }
+    }
+    (name, filename)
+}
+
+/// Minimal multipart/form-data parser.
+///
+/// Splits the body on the boundary delimiter and returns each part's headers
+/// and raw content bytes. Tolerates both CRLF and LF line endings.
+fn parse_multipart_body(body: &[u8], boundary: &str) -> Result<Vec<Value>, RuntimeError> {
+    // Boundary markers: --boundary  and  --boundary--
+    let delim = format!("--{boundary}");
+    let delim_bytes = delim.as_bytes();
+    let close_delim = format!("--{boundary}--");
+    let close_bytes = close_delim.as_bytes();
+
+    // Find all boundary occurrences
+    let mut parts: Vec<Value> = Vec::new();
+    let mut search_from = 0;
+
+    // Locate the first boundary
+    let Some(mut pos) = find_bytes(body, delim_bytes, search_from) else {
+        return Err(RuntimeError::new(
+            "parse_multipart: no boundary found in body".to_string(),
+            0,
+            0,
+        ));
+    };
+
+    loop {
+        // Skip past the boundary line (and optional trailing whitespace / CRLF)
+        let mut content_start = pos + delim_bytes.len();
+        // Closing boundary ends the parse
+        if body.get(pos..pos + close_bytes.len()) == Some(close_bytes) {
+            break;
+        }
+        // Consume trailing spaces/tabs then CRLF or LF after the boundary
+        while content_start < body.len()
+            && (body[content_start] == b' ' || body[content_start] == b'\t')
+        {
+            content_start += 1;
+        }
+        if body.get(content_start..content_start + 2) == Some(b"\r\n") {
+            content_start += 2;
+        } else if body.get(content_start) == Some(&b'\n') {
+            content_start += 1;
+        }
+
+        // Find the next boundary
+        search_from = content_start;
+        let next = match find_bytes(body, delim_bytes, search_from) {
+            Some(n) => n,
+            None => break,
+        };
+
+        // Part data ends just before the next boundary; strip trailing CRLF/LF
+        let mut content_end = next;
+        if content_end >= 2 && &body[content_end - 2..content_end] == b"\r\n" {
+            content_end -= 2;
+        } else if content_end >= 1 && body[content_end - 1] == b'\n' {
+            content_end -= 1;
+        }
+
+        let part_bytes = &body[content_start..content_end];
+        // Split headers from body at the first blank line
+        let (headers_bytes, body_bytes) = split_headers_and_body(part_bytes);
+
+        let headers_text = String::from_utf8_lossy(headers_bytes);
+        let mut part_name: Option<String> = None;
+        let mut part_filename: Option<String> = None;
+        let mut part_content_type: Option<String> = None;
+
+        for line in headers_text.split(['\r', '\n']) {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some((key, value)) = line.split_once(':') {
+                let key = key.trim();
+                let value = value.trim();
+                if key.eq_ignore_ascii_case("Content-Disposition") {
+                    let (n, f) = parse_content_disposition(value);
+                    part_name = n;
+                    part_filename = f;
+                } else if key.eq_ignore_ascii_case("Content-Type") {
+                    part_content_type = Some(value.to_string());
+                }
+            }
+        }
+
+        let mut part_map = HashMap::new();
+        part_map.insert(
+            "name".to_string(),
+            match part_name {
+                Some(n) => Value::Text(Arc::from(n.as_str())),
+                None => Value::Null,
+            },
+        );
+        part_map.insert(
+            "filename".to_string(),
+            match part_filename {
+                Some(f) => Value::Text(Arc::from(f.as_str())),
+                None => Value::Null,
+            },
+        );
+        part_map.insert(
+            "content_type".to_string(),
+            match part_content_type {
+                Some(ct) => Value::Text(Arc::from(ct.as_str())),
+                None => Value::Null,
+            },
+        );
+        // Lossy text view + lossless binary view, mirroring request body
+        let content_text = String::from_utf8_lossy(body_bytes).into_owned();
+        part_map.insert(
+            "content".to_string(),
+            Value::Text(Arc::from(content_text.as_str())),
+        );
+        part_map.insert(
+            "content_bytes".to_string(),
+            Value::Binary(Arc::from(body_bytes)),
+        );
+
+        parts.push(Value::Object(Rc::new(RefCell::new(part_map))));
+        pos = next;
+    }
+
+    Ok(parts)
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() {
+        return None;
+    }
+    haystack[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|p| start + p)
+}
+
+fn split_headers_and_body(part: &[u8]) -> (&[u8], &[u8]) {
+    // Prefer CRLF blank line, then LF blank line
+    if let Some(idx) = find_bytes(part, b"\r\n\r\n", 0) {
+        return (&part[..idx], &part[idx + 4..]);
+    }
+    if let Some(idx) = find_bytes(part, b"\n\n", 0) {
+        return (&part[..idx], &part[idx + 2..]);
+    }
+    // No body separator — treat entire part as headers with empty body
+    (part, &[])
+}
+
+/// parse_multipart(body, content_type) -> list of part objects
+///
+/// Usage:
+///   store parts as parse_multipart of body_bytes and content_type
+///   // or with the Content-Type header value:
+///   store parts as parse_multipart of body and header "Content-Type" of req
+///
+/// Each part is an object with:
+///   name, filename (or nothing), content_type (or nothing),
+///   content (text, lossy UTF-8), content_bytes (binary)
+pub fn native_parse_multipart(args: Vec<Value>) -> Result<Value, RuntimeError> {
+    check_arg_count("parse_multipart", &args, 2)?;
+
+    let body_bytes: Vec<u8> = match &args[0] {
+        Value::Binary(b) => b.to_vec(),
+        Value::Text(t) => t.as_bytes().to_vec(),
+        other => {
+            return Err(RuntimeError::new(
+                format!(
+                    "parse_multipart expects text or binary body, got {}",
+                    other.type_name()
+                ),
+                0,
+                0,
+            ));
+        }
+    };
+    let content_type = expect_text(&args[1])?;
+
+    let boundary = extract_multipart_boundary(&content_type).ok_or_else(|| {
+        RuntimeError::new(
+            format!("parse_multipart: could not find boundary in Content-Type '{content_type}'"),
+            0,
+            0,
+        )
+    })?;
+
+    let parts = parse_multipart_body(&body_bytes, &boundary)?;
+    Ok(Value::List(Rc::new(RefCell::new(parts))))
+}
+
 pub fn register_web(env: &mut Environment) {
     env.define_native("path_params", native_path_params);
     env.define_native("path_matches", native_path_matches);
     env.define_native("mime_type", native_mime_type);
+    env.define_native("parse_multipart", native_parse_multipart);
 }
 
 #[cfg(test)]
@@ -177,6 +416,85 @@ mod tests {
     fn rejects_segment_count_mismatch() {
         assert!(match_path_template("/users", "/users/:id").is_none());
         assert!(match_path_template("/users/1/2", "/users/:id").is_none());
+    }
+
+    #[test]
+    fn extract_boundary_from_content_type() {
+        assert_eq!(
+            extract_multipart_boundary("multipart/form-data; boundary=----WebKitFormBoundary"),
+            Some("----WebKitFormBoundary".to_string())
+        );
+        assert_eq!(
+            extract_multipart_boundary("multipart/form-data; boundary=\"abc123\""),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            extract_multipart_boundary("abc123"),
+            Some("abc123".to_string())
+        );
+        assert!(extract_multipart_boundary("application/json").is_none());
+    }
+
+    #[test]
+    fn parse_multipart_text_and_file_parts() {
+        let body = "------bound\r\n\
+Content-Disposition: form-data; name=\"title\"\r\n\
+\r\n\
+Hello\r\n\
+------bound\r\n\
+Content-Disposition: form-data; name=\"file\"; filename=\"hi.txt\"\r\n\
+Content-Type: text/plain\r\n\
+\r\n\
+file body\r\n\
+------bound--\r\n";
+
+        let result = native_parse_multipart(vec![
+            Value::Text(Arc::from(body)),
+            Value::Text(Arc::from("multipart/form-data; boundary=----bound")),
+        ])
+        .expect("parse_multipart should succeed");
+
+        match result {
+            Value::List(list) => {
+                let parts = list.borrow();
+                assert_eq!(parts.len(), 2);
+
+                match &parts[0] {
+                    Value::Object(obj) => {
+                        let m = obj.borrow();
+                        assert!(
+                            matches!(m.get("name"), Some(Value::Text(t)) if t.as_ref() == "title")
+                        );
+                        assert!(
+                            matches!(m.get("content"), Some(Value::Text(t)) if t.as_ref() == "Hello")
+                        );
+                        assert!(matches!(m.get("filename"), Some(Value::Null)));
+                    }
+                    other => panic!("expected object part, got {other:?}"),
+                }
+
+                match &parts[1] {
+                    Value::Object(obj) => {
+                        let m = obj.borrow();
+                        assert!(
+                            matches!(m.get("name"), Some(Value::Text(t)) if t.as_ref() == "file")
+                        );
+                        assert!(
+                            matches!(m.get("filename"), Some(Value::Text(t)) if t.as_ref() == "hi.txt")
+                        );
+                        assert!(
+                            matches!(m.get("content_type"), Some(Value::Text(t)) if t.as_ref() == "text/plain")
+                        );
+                        assert!(
+                            matches!(m.get("content"), Some(Value::Text(t)) if t.as_ref() == "file body")
+                        );
+                        assert!(matches!(m.get("content_bytes"), Some(Value::Binary(_))));
+                    }
+                    other => panic!("expected object part, got {other:?}"),
+                }
+            }
+            other => panic!("expected list, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/stdlib/web.rs
+++ b/src/stdlib/web.rs
@@ -177,28 +177,105 @@ fn extract_multipart_boundary(content_type: &str) -> Option<String> {
 }
 
 /// Parse a single multipart Content-Disposition header for name and optional filename.
+///
+/// Parameters may contain `=` inside the value (e.g. `filename="report=2024.pdf"`).
+/// Values are taken as everything after the first `=` of each parameter; quoted
+/// values keep internal `;` by scanning for the closing quote instead of splitting
+/// on every semicolon.
 fn parse_content_disposition(header: &str) -> (Option<String>, Option<String>) {
     let mut name = None;
     let mut filename = None;
-    for part in header.split(';').skip(1) {
-        let part = part.trim();
-        if let Some((key, value)) = part.split_once('=') {
-            let key = key.trim();
-            let value = value.trim().trim_matches('"').to_string();
-            if key.eq_ignore_ascii_case("name") {
-                name = Some(value);
-            } else if key.eq_ignore_ascii_case("filename") || key.eq_ignore_ascii_case("filename*")
-            {
-                // filename* can be charset'lang'value — take the raw value for now
-                let value = value
-                    .rsplit_once('\'')
-                    .map(|(_, v)| v.to_string())
-                    .unwrap_or(value);
-                filename = Some(value);
-            }
+
+    // Skip the disposition type (form-data) and walk `;`-separated params,
+    // respecting double-quoted values so `filename="a;b=c.pdf"` stays intact.
+    let mut rest = header;
+    // Drop the disposition token before the first `;`
+    if let Some((_, after)) = rest.split_once(';') {
+        rest = after;
+    } else {
+        return (None, None);
+    }
+
+    while !rest.is_empty() {
+        rest = rest.trim_start();
+        if rest.is_empty() {
+            break;
+        }
+
+        let (key, value, next) = match parse_disposition_param(rest) {
+            Some(parsed) => parsed,
+            None => break,
+        };
+        rest = next;
+
+        if key.eq_ignore_ascii_case("name") {
+            name = Some(value);
+        } else if key.eq_ignore_ascii_case("filename") || key.eq_ignore_ascii_case("filename*") {
+            // filename* can be charset'lang'value — take the raw value for now
+            let value = value
+                .rsplit_once('\'')
+                .map(|(_, v)| v.to_string())
+                .unwrap_or(value);
+            filename = Some(value);
         }
     }
     (name, filename)
+}
+
+/// Parse one `key=value` (or `key="quoted value"`) parameter from a
+/// Content-Disposition parameter list. Returns (key, value, remainder).
+fn parse_disposition_param(input: &str) -> Option<(String, String, &str)> {
+    let input = input.trim_start();
+    let eq = input.find('=')?;
+    let key = input[..eq].trim().to_string();
+    if key.is_empty() {
+        return None;
+    }
+    let after_eq = input[eq + 1..].trim_start();
+
+    let (value, remainder) = if let Some(rest) = after_eq.strip_prefix('"') {
+        // Quoted value: scan to the next unescaped `"`
+        let mut end = None;
+        let mut i = 0;
+        let bytes = rest.as_bytes();
+        while i < bytes.len() {
+            if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+            if bytes[i] == b'"' {
+                end = Some(i);
+                break;
+            }
+            i += 1;
+        }
+        let end = end?;
+        // Unescape simple \" and \\ sequences in the quoted value
+        let raw = &rest[..end];
+        let mut unescaped = String::with_capacity(raw.len());
+        let mut chars = raw.chars();
+        while let Some(c) = chars.next() {
+            if c == '\\' {
+                if let Some(next) = chars.next() {
+                    unescaped.push(next);
+                }
+            } else {
+                unescaped.push(c);
+            }
+        }
+        let after_quote = &rest[end + 1..];
+        let remainder = after_quote.strip_prefix(';').unwrap_or(after_quote);
+        (unescaped, remainder)
+    } else {
+        // Token value: ends at next `;` or end of string
+        if let Some((val, after)) = after_eq.split_once(';') {
+            (val.trim().to_string(), after)
+        } else {
+            (after_eq.trim().to_string(), "")
+        }
+    };
+
+    Some((key, value, remainder))
 }
 
 /// Minimal multipart/form-data parser.
@@ -251,12 +328,17 @@ fn parse_multipart_body(body: &[u8], boundary: &str) -> Result<Vec<Value>, Runti
             None => break,
         };
 
-        // Part data ends just before the next boundary; strip trailing CRLF/LF
+        // Part data ends just before the next boundary; strip trailing CRLF/LF.
+        // Guard against empty parts (consecutive boundaries) where stripping
+        // would leave content_end < content_start and panic on the slice.
         let mut content_end = next;
         if content_end >= 2 && &body[content_end - 2..content_end] == b"\r\n" {
             content_end -= 2;
         } else if content_end >= 1 && body[content_end - 1] == b'\n' {
             content_end -= 1;
+        }
+        if content_end < content_start {
+            content_end = content_start;
         }
 
         let part_bytes = &body[content_start..content_end];
@@ -495,6 +577,42 @@ file body\r\n\
             }
             other => panic!("expected list, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_multipart_empty_parts_do_not_panic() {
+        // Consecutive boundaries (empty part) used to panic when CRLF stripping
+        // left content_end < content_start. Must return without crashing.
+        let body = b"--bound\r\n--bound\r\n--bound--\r\n";
+        let result = parse_multipart_body(body, "bound");
+        assert!(
+            result.is_ok(),
+            "empty parts between boundaries must not panic: {result:?}"
+        );
+    }
+
+    #[test]
+    fn content_disposition_preserves_equals_in_filename() {
+        let (name, filename) =
+            parse_content_disposition(r#"form-data; name="file"; filename="report=2024.pdf""#);
+        assert_eq!(name.as_deref(), Some("file"));
+        assert_eq!(
+            filename.as_deref(),
+            Some("report=2024.pdf"),
+            "filename values may contain '='"
+        );
+    }
+
+    #[test]
+    fn content_disposition_preserves_semicolon_in_quoted_filename() {
+        let (name, filename) =
+            parse_content_disposition(r#"form-data; name="file"; filename="a;b=c.pdf""#);
+        assert_eq!(name.as_deref(), Some("file"));
+        assert_eq!(
+            filename.as_deref(),
+            Some("a;b=c.pdf"),
+            "quoted filenames may contain ';' and '='"
+        );
     }
 
     #[test]

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -224,6 +224,7 @@ impl TypeChecker {
             "path_params" => Type::Map(Box::new(Type::Text), Box::new(Type::Text)),
             "path_matches" => Type::Boolean,
             "mime_type" => Type::Text,
+            "parse_multipart" => Type::List(Box::new(Type::Any)),
 
             // Text functions registered under stdlib-specific names
             "string_split" => Type::List(Box::new(Type::Text)),

--- a/src/wfl_config/checker.rs
+++ b/src/wfl_config/checker.rs
@@ -488,6 +488,19 @@ impl ConfigChecker {
             },
         );
 
+        expected_settings.insert(
+            "web_server_max_body_size".to_string(),
+            ExpectedSetting {
+                name: "web_server_max_body_size".to_string(),
+                config_type: ConfigType::Integer,
+                required: false,
+                default_value: Some("1048576".to_string()),
+                description: "Maximum HTTP request body size in bytes (default 1 MiB)".to_string(),
+                valid_values: None,
+                category: "Web Server".to_string(),
+            },
+        );
+
         Self { expected_settings }
     }
 

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -226,6 +226,7 @@ async fn test_execute_file_passes_request_context() {
         concat!(
             "display method\n",
             "display path\n",
+            "display query\n",
             "display body\n",
             "display client_ip\n",
         ),
@@ -248,6 +249,7 @@ async fn test_execute_file_passes_request_context() {
         let mut props = HashMap::new();
         props.insert("method".to_string(), Value::Text(Arc::from("POST")));
         props.insert("path".to_string(), Value::Text(Arc::from("/hello")));
+        props.insert("query".to_string(), Value::Text(Arc::from("q=1")));
         props.insert("body".to_string(), Value::Text(Arc::from("name=World")));
         props.insert("client_ip".to_string(), Value::Text(Arc::from("127.0.0.1")));
         props.insert(
@@ -269,7 +271,7 @@ async fn test_execute_file_passes_request_context() {
 
     assert_eq!(
         get_global_text(&interpreter, "page_output"),
-        "POST\n/hello\nname=World\n127.0.0.1\n"
+        "POST\n/hello\nq=1\nname=World\n127.0.0.1\n"
     );
 }
 

--- a/tests/parse_multipart_test.rs
+++ b/tests/parse_multipart_test.rs
@@ -1,0 +1,68 @@
+// Integration tests for parse_multipart (issue #597).
+// Detailed part-shape assertions live in stdlib/web.rs unit tests;
+// these confirm the builtin is wired into the interpreter and errors cleanly.
+
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+async fn run_wfl(code: &str) -> Result<(), String> {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().map_err(|e| format!("parse error: {e:?}"))?;
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&program)
+        .await
+        .map_err(|e| format!("runtime error: {e:?}"))?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_parse_multipart_runs_from_wfl() {
+    // WFL string escapes: \r \n \"
+    let code = r#"
+        store body as "------bound\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nHello\r\n------bound--\r\n"
+        store ct as "multipart/form-data; boundary=----bound"
+        store parts as parse_multipart of body and ct
+        store count as length of parts
+        check if count is equal to 1:
+            store first as parts[0]
+            store field_name as first["name"]
+            store field_text as first["content"]
+            check if field_name is equal to "title":
+                check if field_text is equal to "Hello":
+                    display "ok"
+                otherwise:
+                    display "bad content"
+                end check
+            otherwise:
+                display "bad name"
+            end check
+        otherwise:
+            display "bad count"
+        end check
+    "#;
+
+    run_wfl(code)
+        .await
+        .expect("parse_multipart should be callable from WFL");
+}
+
+#[tokio::test]
+async fn test_parse_multipart_missing_boundary_errors() {
+    let code = r#"
+        store body as "not multipart"
+        store ct as "application/json"
+        store parts as parse_multipart of body and ct
+    "#;
+
+    let err = run_wfl(code)
+        .await
+        .expect_err("should error without boundary");
+    let lower = err.to_lowercase();
+    assert!(
+        lower.contains("boundary") || lower.contains("parse_multipart"),
+        "error should mention boundary, got: {err}"
+    );
+}

--- a/tests/web_server_query_and_request_access_test.rs
+++ b/tests/web_server_query_and_request_access_test.rs
@@ -1,0 +1,206 @@
+// Integration tests for issue #597 web-server gaps:
+// 1. Query string exposed as `query` / `query of req`
+// 2. Request property access inside actions (header / path / method / body of req)
+// 3. parse_multipart of body and content_type
+
+use std::time::Duration;
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("Failed to create runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("Failed to parse WFL code");
+            let mut interpreter = Interpreter::new();
+            let _ = interpreter.interpret(&ast).await;
+        });
+    })
+}
+
+#[tokio::test]
+async fn test_query_string_accessible_on_request() {
+    let port = 8131;
+    let server_code = format!(
+        r#"
+        listen on port {port} as test_server
+        wait for request comes in on test_server as req with timeout 10000
+        store raw as query of req
+        store params as parse_query_string of raw
+        store page as params["page"]
+        store reply as "page=" with page
+        respond to req with reply
+        close server test_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/blog?page=2&q=hello"))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    let body = response.text().await.expect("Failed to read body");
+    assert_eq!(
+        body, "page=2",
+        "query of req should expose the raw query string for parse_query_string"
+    );
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_bare_query_variable_in_request_loop() {
+    let port = 8132;
+    let server_code = format!(
+        r#"
+        listen on port {port} as test_server
+        wait for request comes in on test_server as req with timeout 10000
+        respond to req with query
+        close server test_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/search?q=wfl"))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    let body = response.text().await.expect("Failed to read body");
+    assert_eq!(
+        body, "q=wfl",
+        "bare `query` variable should be the raw query string"
+    );
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_empty_query_string_is_empty_text() {
+    let port = 8133;
+    let server_code = format!(
+        r#"
+        listen on port {port} as test_server
+        wait for request comes in on test_server as req with timeout 10000
+        check if query is equal to "":
+            respond to req with "empty"
+        otherwise:
+            respond to req with query
+        end check
+        close server test_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/"))
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    let body = response.text().await.expect("Failed to read body");
+    assert_eq!(body, "empty", "missing query string should be empty text");
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_header_path_method_body_accessible_inside_action() {
+    let port = 8134;
+    let server_code = format!(
+        r#"
+        define action called handle with parameters req:
+            store ua as header "User-Agent" of req
+            store p as path of req
+            store m as method of req
+            store b as body of req
+            store reply as m with " " with p with " " with ua with " " with b
+            respond to req with reply
+        end action
+
+        listen on port {port} as test_server
+        wait for request comes in on test_server as req with timeout 10000
+        call handle with req
+        close server test_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let response = client
+        .post(format!("http://127.0.0.1:{port}/submit"))
+        .header("User-Agent", "wfl-action-test")
+        .body("payload")
+        .send()
+        .await
+        .expect("Failed to send request");
+
+    let body = response.text().await.expect("Failed to read body");
+    assert_eq!(
+        body, "POST /submit wfl-action-test payload",
+        "header/path/method/body of req must resolve inside actions from the passed request object"
+    );
+
+    let _ = server_handle.join();
+}
+
+#[tokio::test]
+async fn test_body_size_limit_rejects_oversized_request() {
+    let port = 8135;
+    let server_code = format!(
+        r#"
+        listen on port {port} as test_server
+        wait for request comes in on test_server as req with timeout 5000
+        respond to req with "accepted"
+        close server test_server
+    "#
+    );
+
+    let server_handle = start_server_thread(server_code);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // Default limit is 1 MiB; send just over 1 MiB
+    let large_body = vec![b'x'; 1_048_576 + 1];
+    let client = reqwest::Client::new();
+    let result = client
+        .post(format!("http://127.0.0.1:{port}/upload"))
+        .body(large_body)
+        .send()
+        .await;
+
+    // Warp rejects oversized bodies; the client should see an error or non-success
+    match result {
+        Ok(response) => {
+            assert!(
+                !response.status().is_success(),
+                "oversized body should not be accepted with default 1 MiB limit, got {}",
+                response.status()
+            );
+        }
+        Err(_) => {
+            // Connection reset / reject is also fine — the body was not processed
+        }
+    }
+
+    // Clean up: send a small request so the server can exit if it is still waiting,
+    // otherwise the timeout will end the wait.
+    let _ = client.get(format!("http://127.0.0.1:{port}/")).send().await;
+    let _ = server_handle.join();
+}


### PR DESCRIPTION
## Summary
- Expose HTTP query strings as `query` / `query of req` so `parse_query_string` works on real requests
- Make body size limit configurable via `.wflcfg` `web_server_max_body_size` (default still 1 MiB)
- Add `parse_multipart of body and content_type` for multipart form / file uploads
- Fix `header "X" of req` (and path/method/body of req) to resolve from the request object inside actions
- Unit tests for case-insensitive header lookup to prevent regression

Closes #597

## Test plan
- [x] `cargo test --lib header_lookup_tests`
- [x] `cargo test --lib test_header_access_case_insensitive`
- [x] `cargo test --test web_server_query_and_request_access_test`
- [x] `cargo test --test parse_multipart_test`
- [x] `cargo test --test header_access_runtime_test`
- [x] `cargo test --lib config::tests::test_web_server_max_body_size`
- [x] `cargo clippy -p wfl --lib --tests -- -D warnings`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->