### PR TITLE
Fix web_server_bind_address being ignored from .wflcfg

### DIFF
--- a/Dev diary/2026-07-10-web-server-bind-address-issue-466.md
+++ b/Dev diary/2026-07-10-web-server-bind-address-issue-466.md
@@ -1,0 +1,70 @@
+# Dev Diary — 2026-07-10: Pass loaded `.wflcfg` to the interpreter (#466)
+
+## Context
+
+Deploying a WFL web server to a public host surfaced a long-standing bug:
+`web_server_bind_address` in `.wflcfg` was silently ignored. No matter what an
+operator configured, `listen on port N` always bound `127.0.0.1`, so WFL web
+servers were effectively loopback-only in any real deployment that relied on
+the config file to open the bind address.
+
+The config file *was* parsed correctly — the value simply never reached the
+interpreter. In the script-run path, `src/main.rs` built the interpreter with:
+
+```rust
+let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
+```
+
+`with_timeout` constructs a **fresh** `WflConfig` with only the timeout copied
+across; every other field — including `web_server_bind_address`,
+`web_server_max_body_size`, and the logging settings — fell back to
+`WflConfig::default()`. So `.wflcfg` was loaded, then thrown away.
+
+This was originally reported and patched in PR #466, which was closed without
+merging. This change applies the fix and adds an end-to-end regression test.
+
+## What changed
+
+### `src/main.rs`
+
+```rust
+- let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
++ let mut interpreter =
++     Interpreter::with_config(std::sync::Arc::new(config.clone()));
+```
+
+`Interpreter::with_config(Arc<WflConfig>)` already existed and already reads the
+full config (bind address, body size, timeout, io_client settings); it just
+wasn't being called from the script-run path. The `.clone()` is required because
+`config` is read again later in `main.rs` (e.g. `if config.logging_enabled`) —
+without it the move fails to compile (`E0382`).
+
+`with_timeout` is unchanged and still used by the REPL and tests, so there is no
+API surface change.
+
+## Tests
+
+New `tests/web_server_bind_address_cli_test.rs` drives the **compiled binary**
+against a real `.wflcfg` and asserts the configured bind address reaches the
+listening socket, inspecting `/proc/net/tcp` (Linux-gated):
+
+- `.wflcfg` `= 127.0.0.1` → socket bound to `0100007F` (loopback).
+- `.wflcfg` `= 0.0.0.0`   → socket bound to `00000000` (all interfaces).
+
+Verified this test **fails on the pre-fix code** (the `0.0.0.0` case bound
+`0100007F`, reproducing the bug) and passes after the fix. A portable
+`wflcfg_server_is_reachable` smoke test also confirms the server comes up and is
+connectable when launched via the binary with a `.wflcfg`.
+
+The existing interpreter-level suite (`tests/web_server_bind_address_test.rs`,
+which exercises `with_config` directly) continues to pass.
+
+## Notes
+
+- No docs change to the config option itself: `web_server_bind_address` is
+  already documented in `Docs/reference/configuration-reference.md` and
+  `Docs/04-advanced-features/web-servers.md`. This fix makes the documented
+  behavior actually happen.
+- Backward compatible: programs that never set `web_server_bind_address` keep
+  the `127.0.0.1` default; only configs that explicitly change it are affected —
+  which is the intended, previously-broken behavior.

--- a/Dev diary/2026-07-10-web-server-bind-address-issue-466.md
+++ b/Dev diary/2026-07-10-web-server-bind-address-issue-466.md
@@ -42,6 +42,25 @@ without it the move fails to compile (`E0382`).
 `with_timeout` is unchanged and still used by the REPL and tests, so there is no
 API surface change.
 
+### Preserving the 300-second timeout cap
+
+`with_timeout` clamped the execution timeout to 300 seconds
+(`if seconds > 300 { 300 } else { seconds }`). To keep this change *purely
+additive* — i.e. new config fields propagate, but nothing else about execution
+changes — the script-run path re-applies that same cap before building the
+interpreter:
+
+```rust
+let mut run_config = config.clone();
+run_config.timeout_seconds = run_config.timeout_seconds.min(300);
+let mut interpreter = Interpreter::with_config(std::sync::Arc::new(run_config));
+```
+
+Note this cap never affected web servers in the first place: `check_time` skips
+the timeout entirely while `in_main_loop` is set (see
+`src/interpreter/mod.rs`), and web servers run inside a `main loop`. The cap only
+bounds ordinary, non-main-loop scripts, exactly as before.
+
 ## Tests
 
 New `tests/web_server_bind_address_cli_test.rs` drives the **compiled binary**

--- a/src/main.rs
+++ b/src/main.rs
@@ -1184,7 +1184,14 @@ async fn main() -> io::Result<()> {
                 // settings like `web_server_bind_address` from `.wflcfg` actually reach
                 // the interpreter. `config.clone()` is needed because `config` is read
                 // again later (e.g. `if config.logging_enabled`). See issue #466.
-                let mut interpreter = Interpreter::with_config(std::sync::Arc::new(config.clone()));
+                //
+                // Preserve the 300-second execution-timeout safety cap that the previous
+                // `Interpreter::with_timeout` path enforced, so this change only *adds*
+                // config propagation without altering timeout semantics. (The cap never
+                // affects web servers: `check_time` skips the timeout inside a main loop.)
+                let mut run_config = config.clone();
+                run_config.timeout_seconds = run_config.timeout_seconds.min(300);
+                let mut interpreter = Interpreter::with_config(std::sync::Arc::new(run_config));
                 interpreter.set_step_mode(step_mode); // Set step mode from CLI flag
                 interpreter.set_test_mode(test_mode); // Set test mode from CLI flag
                 interpreter.set_script_args(script_args); // Pass script arguments

--- a/src/main.rs
+++ b/src/main.rs
@@ -1180,7 +1180,11 @@ async fn main() -> io::Result<()> {
                 // Log execution start if execution logging is enabled
                 exec_trace!("Starting execution of script: {}", &file_path);
 
-                let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
+                // Pass the full loaded configuration (not just the timeout) so that
+                // settings like `web_server_bind_address` from `.wflcfg` actually reach
+                // the interpreter. `config.clone()` is needed because `config` is read
+                // again later (e.g. `if config.logging_enabled`). See issue #466.
+                let mut interpreter = Interpreter::with_config(std::sync::Arc::new(config.clone()));
                 interpreter.set_step_mode(step_mode); // Set step mode from CLI flag
                 interpreter.set_test_mode(test_mode); // Set test mode from CLI flag
                 interpreter.set_script_args(script_args); // Pass script arguments

--- a/tests/web_server_bind_address_cli_test.rs
+++ b/tests/web_server_bind_address_cli_test.rs
@@ -1,0 +1,170 @@
+//! End-to-end regression test for issue #466.
+//!
+//! Before the fix, `src/main.rs` built the interpreter with
+//! `Interpreter::with_timeout(config.timeout_seconds)`, which copied *only* the
+//! timeout out of the loaded `.wflcfg` and reset every other field to its
+//! default. The most visible symptom was that `web_server_bind_address` was
+//! silently ignored: `listen on port N` always bound `127.0.0.1` regardless of
+//! the config file, making WFL web servers loopback-only in any deployment that
+//! relied on `.wflcfg` to change the bind address.
+//!
+//! These tests drive the *actual compiled binary* against a real `.wflcfg` and
+//! assert that the configured bind address reaches the listening socket. They
+//! would have failed before the switch to `Interpreter::with_config(...)`.
+//!
+//! Socket inspection uses `/proc/net/tcp`, so the assertions run on Linux only;
+//! on other platforms the harness still boots the binary but skips the
+//! address check (the interpreter-level behavior is covered portably in
+//! `web_server_bind_address_test.rs`).
+
+use std::io::Write;
+use std::process::{Child, Command};
+use std::thread::sleep;
+use std::time::Duration;
+
+/// Write a `.wflcfg` with the given bind address plus a tiny server program
+/// into a fresh temp directory, then launch the compiled `wfl` binary on it.
+fn spawn_server(dir: &std::path::Path, bind_address: &str, port: u16) -> Child {
+    std::fs::write(
+        dir.join(".wflcfg"),
+        format!("web_server_bind_address = {bind_address}\n"),
+    )
+    .expect("write .wflcfg");
+
+    let program = format!(
+        "listen on port {port} as s\n\
+         wait for request comes in on s as r with timeout 4000\n\
+         respond to r with \"hi\"\n\
+         close server s\n"
+    );
+    let script = dir.join("server.wfl");
+    std::fs::write(&script, program).expect("write server.wfl");
+
+    Command::new(env!("CARGO_BIN_EXE_wfl"))
+        .arg(&script)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("spawn wfl binary")
+}
+
+/// Create a unique temp directory without pulling in extra dev-dependencies.
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("wfl_bind_cli_{tag}_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Read the hex local-address of the listening (state 0A) socket bound to
+/// `port` from `/proc/net/tcp`. Returns the `HHHHHHHH` local-address field
+/// (little-endian IPv4), e.g. `00000000` for 0.0.0.0 or `0100007F` for
+/// 127.0.0.1.
+#[cfg(target_os = "linux")]
+fn listening_local_addr(port: u16) -> Option<String> {
+    let hex_port = format!("{port:04X}");
+    let contents = std::fs::read_to_string("/proc/net/tcp").ok()?;
+    for line in contents.lines().skip(1) {
+        let mut cols = line.split_whitespace();
+        let _sl = cols.next()?; // leading slot index, e.g. "3:"
+        let local = cols.next()?; // e.g. "0100007F:20A9"
+        let _remote = cols.next()?;
+        let state = cols.next()?; // "0A" == LISTEN
+        if state == "0A"
+            && let Some((addr, prt)) = local.split_once(':')
+            && prt.eq_ignore_ascii_case(&hex_port)
+        {
+            return Some(addr.to_uppercase());
+        }
+    }
+    None
+}
+
+fn kill(mut child: Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+/// Poll `/proc/net/tcp` until the server is listening on `port` (or we give up).
+/// Startup latency varies a lot under a parallel `cargo test` run, so a fixed
+/// sleep is unreliable; poll for up to ~4s instead.
+#[cfg(target_os = "linux")]
+fn wait_for_listen(port: u16) -> Option<String> {
+    for _ in 0..40 {
+        if let Some(addr) = listening_local_addr(port) {
+            return Some(addr);
+        }
+        sleep(Duration::from_millis(100));
+    }
+    None
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn wflcfg_bind_address_reaches_listening_socket() {
+    // Loopback default: `.wflcfg` says 127.0.0.1 -> socket bound to 127.0.0.1.
+    {
+        let dir = temp_dir("loopback");
+        let port = 8471;
+        let child = spawn_server(&dir, "127.0.0.1", port);
+        let addr = wait_for_listen(port);
+        kill(child);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            addr.as_deref(),
+            Some("0100007F"),
+            "server with `web_server_bind_address = 127.0.0.1` should bind loopback"
+        );
+    }
+
+    // The regression itself: `.wflcfg` says 0.0.0.0 -> socket must bind all
+    // interfaces (00000000). Before issue #466 was fixed this bound 0100007F
+    // because the config never reached the interpreter.
+    {
+        let dir = temp_dir("allifaces");
+        let port = 8472;
+        let child = spawn_server(&dir, "0.0.0.0", port);
+        let addr = wait_for_listen(port);
+        kill(child);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(
+            addr.as_deref(),
+            Some("00000000"),
+            "server with `web_server_bind_address = 0.0.0.0` must bind all interfaces \
+             (regression for issue #466: loaded .wflcfg was being discarded)"
+        );
+    }
+}
+
+/// Portable smoke test: the binary honors a `.wflcfg` and comes up listening on
+/// loopback so a client can reach it. Runs everywhere; the address-level
+/// distinction above is Linux-only.
+#[test]
+fn wflcfg_server_is_reachable() {
+    let dir = temp_dir("reachable");
+    let port = 8473;
+    let child = spawn_server(&dir, "0.0.0.0", port);
+    let target: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+    // Poll the connection: startup latency varies under a parallel test run.
+    let mut ok = false;
+    for _ in 0..40 {
+        if let Ok(mut stream) =
+            std::net::TcpStream::connect_timeout(&target, Duration::from_millis(300))
+        {
+            // Send a request so the server's `wait for request` completes and it exits.
+            let _ = stream.write_all(b"GET / HTTP/1.0\r\n\r\n");
+            ok = true;
+            break;
+        }
+        sleep(Duration::from_millis(100));
+    }
+
+    kill(child);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert!(
+        ok,
+        "server launched via the compiled binary with a .wflcfg should be reachable on loopback"
+    );
+}

--- a/tests/web_server_bind_address_cli_test.rs
+++ b/tests/web_server_bind_address_cli_test.rs
@@ -57,6 +57,19 @@ fn temp_dir(tag: &str) -> std::path::PathBuf {
     dir
 }
 
+/// Ask the OS for a currently-free TCP port instead of hardcoding one, so
+/// parallel test runs (or unrelated processes) can't collide on a fixed port
+/// and make these tests flaky. Binds an ephemeral port, reads it back, and
+/// releases it; the small reuse window before the WFL server binds is
+/// acceptable for a test.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("read local_addr")
+        .port()
+}
+
 /// Read the hex local-address of the listening (state 0A) socket bound to
 /// `port` from `/proc/net/tcp`. Returns the `HHHHHHHH` local-address field
 /// (little-endian IPv4), e.g. `00000000` for 0.0.0.0 or `0100007F` for
@@ -106,7 +119,7 @@ fn wflcfg_bind_address_reaches_listening_socket() {
     // Loopback default: `.wflcfg` says 127.0.0.1 -> socket bound to 127.0.0.1.
     {
         let dir = temp_dir("loopback");
-        let port = 8471;
+        let port = free_port();
         let child = spawn_server(&dir, "127.0.0.1", port);
         let addr = wait_for_listen(port);
         kill(child);
@@ -123,7 +136,7 @@ fn wflcfg_bind_address_reaches_listening_socket() {
     // because the config never reached the interpreter.
     {
         let dir = temp_dir("allifaces");
-        let port = 8472;
+        let port = free_port();
         let child = spawn_server(&dir, "0.0.0.0", port);
         let addr = wait_for_listen(port);
         kill(child);
@@ -143,7 +156,7 @@ fn wflcfg_bind_address_reaches_listening_socket() {
 #[test]
 fn wflcfg_server_is_reachable() {
     let dir = temp_dir("reachable");
-    let port = 8473;
+    let port = free_port();
     let child = spawn_server(&dir, "0.0.0.0", port);
     let target: std::net::SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
 


### PR DESCRIPTION
## Summary

Fixes issue #466: the `web_server_bind_address` configuration option in `.wflcfg` was being silently ignored when running WFL scripts. The interpreter was constructed with only the timeout value, causing all other config settings to fall back to defaults.

## Root Cause

In `src/main.rs`, the script-run path built the interpreter with:
```rust
let mut interpreter = Interpreter::with_timeout(config.timeout_seconds);
```

This constructor creates a fresh `WflConfig` with only the timeout copied across; all other fields (including `web_server_bind_address`, `web_server_max_body_size`, and logging settings) reset to `WflConfig::default()`. The loaded `.wflcfg` was parsed correctly but then discarded.

## Changes

- **src/main.rs**: Replace `Interpreter::with_timeout(config.timeout_seconds)` with `Interpreter::with_config(std::sync::Arc::new(config.clone()))` to pass the full loaded configuration to the interpreter. The `with_config` method already existed and reads the complete config; it just wasn't being called from the script-run path. The `.clone()` is necessary because `config` is read again later in `main.rs` (e.g., `if config.logging_enabled`).

- **tests/web_server_bind_address_cli_test.rs** (new): End-to-end regression test that drives the compiled binary against a real `.wflcfg` and verifies the configured bind address reaches the listening socket:
  - Linux-gated tests inspect `/proc/net/tcp` to confirm socket binding matches config (e.g., `127.0.0.1` → `0100007F`, `0.0.0.0` → `00000000`)
  - Portable smoke test confirms the server is reachable when launched via the binary with a `.wflcfg`
  - Verified to fail on pre-fix code (reproducing the bug) and pass after the fix

- **Dev diary/2026-07-10-web-server-bind-address-issue-466.md** (new): Documents the issue, fix, and testing approach.

## Impact

- **Backward compatible**: Programs that never set `web_server_bind_address` retain the `127.0.0.1` default; only configs that explicitly change it are affected (the intended, previously-broken behavior).
- **No API surface change**: `with_timeout` remains unchanged and is still used by the REPL and tests.
- **Existing tests pass**: The interpreter-level suite (`tests/web_server_bind_address_test.rs`, which exercises `with_config` directly) continues to pass.

https://claude.ai/code/session_012t3m4FA8XJ49E2smwyFzRp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script-run web servers ignoring the configured bind address from `.wflcfg` files.
  * Ensured runtime execution respects all applicable configuration settings, not just timeout values.

* **Tests**
  * Added end-to-end coverage confirming configured addresses are used.
  * Added connectivity checks to verify the web server starts and accepts requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->