### PR TITLE
fix: widen Nothing-typed variables on reassignment (#605)

### DIFF
--- a/Dev diary/2026-07-11-nothing-reassign-widen-issue-605.md
+++ b/Dev diary/2026-07-11-nothing-reassign-widen-issue-605.md
@@ -1,0 +1,56 @@
+# Issue #605: Nothing-Initialized Variables Widen on Reassignment
+
+**Date:** 2026-07-11
+
+## Background
+
+The static type checker reported a false `Cannot index into Nothing` when a
+variable was initialized to `nothing`, later reassigned via `change`, and then
+indexed. Runtime was always correct; the diagnostic cluttered load-time output
+(notably wfl-web's admin media-upload path).
+
+```wfl
+store file_part as nothing
+for each part in parts:
+    change file_part to part
+end for
+store file_bytes as file_part["content_bytes"]  // false: Cannot index into Nothing
+```
+
+## Root causes
+
+Two cooperating bugs:
+
+1. **Pinned `Nothing` on assignment.** `Statement::Assignment` checked
+   compatibility against the existing type but never updated it. After
+   `store x as nothing`, `x` stayed `Nothing` forever, even when
+   `change x to <map-or-value>` ran successfully at runtime. Assigning a
+   concrete non-Nothing value onto Nothing was also rejected as incompatible.
+
+2. **`get_symbol_mut` only mutated the innermost scope.** Loop bodies push a
+   child scope. Even after (1) tried to widen the outer variable, the update
+   hit only the current scope's map (where the outer name is not bound) and
+   was silently dropped. On `pop_scope` the outer binding was still `Nothing`.
+
+## Fix
+
+- On `change` of a `Nothing`-typed variable, replace the stored type with the
+  assigned expression's type (skipping `Error`; leaving pure `Nothing` alone).
+  Concrete type mismatches on non-Nothing variables still error (e.g. Number →
+  Text).
+- `Scope::resolve_mut` / `Analyzer::get_symbol_mut` walk parent scopes so type
+  refinements from loop/try bodies update the real binding and survive
+  `pop_scope` (the boxed parent clone is what pop restores).
+
+Unassigned `nothing` still rejects indexing — only reassignment widens.
+
+## Verification (TDD)
+
+`tests/nothing_reassign_widen_test.rs` was written first and confirmed failing
+(3/5) before the fix:
+
+- nothing → reassign in for-each → index (issue minimal repro)
+- nothing → change to map → index (wfl-web shape)
+- nothing → change to text is allowed
+- nothing without reassign still rejects indexing
+- Number → Text reassignment still errors

--- a/Dev diary/2026-07-11-nothing-reassign-widen-issue-605.md
+++ b/Dev diary/2026-07-11-nothing-reassign-widen-issue-605.md
@@ -54,3 +54,26 @@ Unassigned `nothing` still rejects indexing — only reassignment widens.
 - nothing → change to text is allowed
 - nothing without reassign still rejects indexing
 - Number → Text reassignment still errors
+
+## Follow-up (PR #606 review)
+
+1. **When-clause scope (Devin).** Parent-walking `get_symbol_mut` made a latent
+   TryStatement gap more dangerous: the type checker used to call
+   `get_symbol_mut` on a `when` error name without a child scope, so a
+   colliding outer name could be rewritten to `Text`. Fixed by pushing a
+   when-clause scope and binding the error name (and `error_message` alias)
+   with `define_or_replace_symbol` so only the child scope is written —
+   matching runtime's `Environment::define_or_replace`.
+
+2. **Action / method bodies must not permanently widen outer bindings
+   (Codex).** Type-checking an action definition walks its body; with parent-
+   walking mutability that could refine outer `nothing` bindings even if the
+   action is never called. Snapshot symbol types before the body and restore
+   after (top-level actions and container methods). Loop bodies still keep
+   refinements — that is the intended #605 fix for the idiomatic pattern.
+
+3. **Loop test (CodeRabbit minor).** Loop regression no longer indexes a
+   list-of-text element as a map; it uses `length of item` after the widen.
+
+Covered by `test_when_error_name_does_not_clobber_outer_variable_type` and
+`test_action_body_does_not_permanently_widen_outer_nothing`.

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -2103,6 +2103,52 @@ impl Analyzer {
         self.current_scope.define(symbol)
     }
 
+    /// Bind or overwrite a symbol in the *current* scope only (no parent walk,
+    /// no "already defined in outer scope" error). Used for implicit bindings
+    /// such as `when error as e` error names that must shadow for the clause
+    /// body without clobbering an outer variable of the same name.
+    pub fn define_or_replace_symbol(&mut self, symbol: Symbol) {
+        self.current_scope.define_or_replace(symbol);
+    }
+
+    /// Snapshot `symbol_type` for every symbol in the current scope chain
+    /// (innermost first). Used to restore outer bindings after type-checking
+    /// a definition body that must not permanently refine them (uncalled
+    /// actions / container methods — PR #606 review).
+    pub fn snapshot_symbol_types(&self) -> Vec<HashMap<String, Option<Type>>> {
+        let mut layers = Vec::new();
+        let mut scope = Some(&self.current_scope);
+        while let Some(s) = scope {
+            let mut map = HashMap::new();
+            for (name, sym) in &s.symbols {
+                map.insert(name.clone(), sym.symbol_type.clone());
+            }
+            layers.push(map);
+            scope = s.parent.as_deref();
+        }
+        layers
+    }
+
+    /// Restore `symbol_type` values previously captured by
+    /// [`snapshot_symbol_types`]. Only updates symbols that still exist; does
+    /// not remove symbols defined after the snapshot.
+    pub fn restore_symbol_types(&mut self, snapshot: Vec<HashMap<String, Option<Type>>>) {
+        let mut scope = Some(&mut self.current_scope);
+        let mut i = 0;
+        while let Some(s) = scope {
+            if i >= snapshot.len() {
+                break;
+            }
+            for (name, ty) in &snapshot[i] {
+                if let Some(sym) = s.symbols.get_mut(name) {
+                    sym.symbol_type = ty.clone();
+                }
+            }
+            i += 1;
+            scope = s.parent.as_mut().map(|p| p.as_mut());
+        }
+    }
+
     pub fn register_builtin_function(
         &mut self,
         name: &str,

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -132,6 +132,20 @@ impl Scope {
             None
         }
     }
+
+    /// Mutable resolve: current scope first, then parents. Used when refining a
+    /// symbol's type from an inner scope (e.g. `change` of an outer variable
+    /// inside a loop body — issue #605). Mutations reach the boxed parent that
+    /// `pop_scope` restores, so type updates survive the scope pop.
+    pub fn resolve_mut(&mut self, name: &str) -> Option<&mut Symbol> {
+        if self.symbols.contains_key(name) {
+            self.symbols.get_mut(name)
+        } else if let Some(parent) = self.parent.as_mut() {
+            parent.resolve_mut(name)
+        } else {
+            None
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -2077,7 +2091,12 @@ impl Analyzer {
     }
 
     pub fn get_symbol_mut(&mut self, name: &str) -> Option<&mut Symbol> {
-        self.current_scope.symbols.get_mut(name)
+        // Walk parent scopes so type refinements (e.g. widening away from
+        // Nothing on reassignment inside a loop) update the real binding and
+        // survive `pop_scope` (issue #605). Previously only the innermost
+        // scope was mutable, so outer-variable updates from loop/try bodies
+        // were silently dropped.
+        self.current_scope.resolve_mut(name)
     }
 
     pub fn define_symbol(&mut self, symbol: Symbol) -> Result<(), SemanticError> {

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -455,15 +455,37 @@ impl TypeChecker {
                     self.check_statement_types(stmt);
                 }
 
-                // Type check each when clause
+                // Type check each when clause in its own scope so the bound
+                // error name cannot clobber an outer variable of the same
+                // name. Required now that get_symbol_mut walks parents
+                // (issue #605 / PR review on #606). Use define_or_replace so
+                // the binding lives only in the child scope (runtime does the
+                // same via Environment::define_or_replace).
                 for when_clause in when_clauses {
-                    if let Some(symbol) = self.analyzer.get_symbol_mut(&when_clause.error_name) {
-                        symbol.symbol_type = Some(Type::Text); // Errors are represented as text
+                    self.analyzer.push_scope();
+                    self.analyzer.define_or_replace_symbol(Symbol {
+                        name: when_clause.error_name.clone(),
+                        kind: SymbolKind::Variable { mutable: false },
+                        symbol_type: Some(Type::Text), // Errors are represented as text
+                        line: *_line,
+                        column: *_column,
+                    });
+                    // `error_message` is always available as an alias, matching
+                    // the analyzer and runtime.
+                    if when_clause.error_name != "error_message" {
+                        self.analyzer.define_or_replace_symbol(Symbol {
+                            name: "error_message".to_string(),
+                            kind: SymbolKind::Variable { mutable: false },
+                            symbol_type: Some(Type::Text),
+                            line: *_line,
+                            column: *_column,
+                        });
                     }
 
                     for stmt in &when_clause.body {
                         self.check_statement_types(stmt);
                     }
+                    self.analyzer.pop_scope();
                 }
 
                 if let Some(otherwise_stmts) = otherwise_block {
@@ -804,15 +826,18 @@ impl TypeChecker {
                     let _ = self.analyzer.define_symbol(param_symbol);
                 }
 
+                // Snapshot before the body so Nothing-widening (and other
+                // refinements) of outer variables during the definition check
+                // do not permanently stick after the action is defined but
+                // never called (PR #606 Codex review).
+                let outer_type_snapshot = self.analyzer.snapshot_symbol_types();
+
                 for stmt in body {
                     self.check_statement_types(stmt);
                 }
 
                 // Infer the return type while body-locals and parameters are
-                // still in scope. Apply it after pop so the action symbol (in the
-                // parent scope) is updated without relying on in-scope parent
-                // mutation during the body check (issue #569; parent-walking
-                // `get_symbol_mut` from #605 would also work pre-pop).
+                // still in scope (and still see any in-body widenings).
                 let inferred_return = if return_type.is_none() {
                     Some(self.infer_action_return_type(body))
                 } else {
@@ -823,6 +848,7 @@ impl TypeChecker {
                     self.check_return_statements(body, ret_type, *_line, *_column);
                 }
 
+                self.analyzer.restore_symbol_types(outer_type_snapshot);
                 self.analyzer.pop_scope();
 
                 // Update the action's symbol so call sites see the real result
@@ -1799,6 +1825,11 @@ impl TypeChecker {
                             let _ = self.analyzer.define_symbol(param_symbol);
                         }
 
+                        // Same as top-level actions: do not permanently refine
+                        // outer bindings while checking an uncalled method body
+                        // (PR #606 review).
+                        let outer_type_snapshot = self.analyzer.snapshot_symbol_types();
+
                         for stmt in body {
                             self.check_statement_types(stmt);
                         }
@@ -1820,6 +1851,7 @@ impl TypeChecker {
                             }
                         }
 
+                        self.analyzer.restore_symbol_types(outer_type_snapshot);
                         self.analyzer.pop_scope();
 
                         // Restore previous container context

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -697,24 +697,51 @@ impl TypeChecker {
             } => {
                 let inferred_type = self.infer_expression_type(value);
 
-                if let Some(symbol) = self.analyzer.get_symbol(name) {
-                    if let Some(variable_type) = &symbol.symbol_type {
-                        if !self.are_types_compatible(variable_type, &inferred_type) {
+                // Clone the existing type first so we can re-borrow mutably below
+                // when widening away from Nothing (issue #605).
+                let existing_type = self
+                    .analyzer
+                    .get_symbol(name)
+                    .and_then(|s| s.symbol_type.clone());
+
+                match existing_type {
+                    // `store x as nothing` is the idiomatic "uninitialized"
+                    // sentinel. Reassignment must widen the stored type to the
+                    // new value's type; otherwise later indexing/use stays
+                    // pinned to Nothing and raises false
+                    // "Cannot index into Nothing" diagnostics (issue #605).
+                    Some(Type::Nothing) => {
+                        if inferred_type != Type::Nothing
+                            && inferred_type != Type::Error
+                            && let Some(symbol) = self.analyzer.get_symbol_mut(name)
+                        {
+                            symbol.symbol_type = Some(inferred_type);
+                        }
+                    }
+                    Some(variable_type) => {
+                        if !self.are_types_compatible(&variable_type, &inferred_type) {
                             self.type_error(
                                 format!(
                                     "Cannot assign value of incompatible type to variable '{name}'"
                                 ),
-                                Some(variable_type.clone()),
+                                Some(variable_type),
                                 Some(inferred_type),
                                 *line,
                                 *column,
                             );
                         }
-                    } else if inferred_type != Type::Error
-                        && inferred_type != Type::Unknown
-                        && let Some(symbol) = self.analyzer.get_symbol_mut(name)
-                    {
-                        symbol.symbol_type = Some(inferred_type);
+                    }
+                    None => {
+                        // Symbol exists but has no recorded type yet, or the
+                        // name is unresolved (undefined-variable is reported
+                        // elsewhere). Record a concrete type when available.
+                        if self.analyzer.get_symbol(name).is_some()
+                            && inferred_type != Type::Error
+                            && inferred_type != Type::Unknown
+                            && let Some(symbol) = self.analyzer.get_symbol_mut(name)
+                        {
+                            symbol.symbol_type = Some(inferred_type);
+                        }
                     }
                 }
             }
@@ -782,11 +809,10 @@ impl TypeChecker {
                 }
 
                 // Infer the return type while body-locals and parameters are
-                // still in scope, but defer applying it to the action's symbol
-                // until after the scope is popped: `get_symbol_mut` only reaches
-                // the current (innermost) scope, so the action symbol — which
-                // lives in the parent scope — is only reachable once the param
-                // scope is gone (issue #569).
+                // still in scope. Apply it after pop so the action symbol (in the
+                // parent scope) is updated without relying on in-scope parent
+                // mutation during the body check (issue #569; parent-walking
+                // `get_symbol_mut` from #605 would also work pre-pop).
                 let inferred_return = if return_type.is_none() {
                     Some(self.infer_action_return_type(body))
                 } else {

--- a/tests/nothing_reassign_widen_test.rs
+++ b/tests/nothing_reassign_widen_test.rs
@@ -1,0 +1,124 @@
+//! Regression tests for issue #605: a variable initialized to `nothing` and
+//! later reassigned must not stay pinned as `Nothing`.
+//!
+//! The idiomatic pattern is:
+//!
+//! ```wfl
+//! store item as nothing
+//! for each x in items:
+//!     change item to x
+//! end for
+//! store value as item["key"]
+//! ```
+//!
+//! Before the fix the type checker recorded `Nothing` from the initializer and
+//! never widened it on `change`, so the index raised a false
+//! `Cannot index into Nothing` diagnostic even though the program is correct
+//! at runtime.
+
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::typechecker::TypeChecker;
+
+/// Type-check `code` and assert it produces zero diagnostics.
+fn assert_typechecks_clean(code: &str) {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().expect("Should parse");
+
+    let mut type_checker = TypeChecker::new();
+    let result = type_checker.check_types(&program);
+
+    assert!(
+        result.is_ok(),
+        "Program should type-check clean; got: {:?}",
+        result.err()
+    );
+}
+
+/// Type-check `code` and assert at least one diagnostic mentions `needle`.
+fn assert_type_error_contains(code: &str, needle: &str) {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser.parse().expect("Should parse");
+
+    let mut type_checker = TypeChecker::new();
+    let result = type_checker.check_types(&program);
+
+    let errors = result.expect_err("Expected at least one type error");
+    assert!(
+        errors.iter().any(|e| e.message.contains(needle)),
+        "Expected a type error containing {needle:?}, got: {errors:?}"
+    );
+}
+
+/// Minimal repro from issue #605: init to nothing, reassign in a for-each,
+/// then index. Must not report "Cannot index into Nothing".
+#[test]
+fn test_nothing_then_reassign_in_loop_allows_indexing() {
+    assert_typechecks_clean(
+        r#"
+store item as nothing
+store items as ["a"]
+for each x in items:
+    change item to x
+end for
+display item["k"]
+"#,
+    );
+}
+
+/// Same pattern without a loop: `change` of a nothing-initialized variable
+/// must widen the type so later indexing is not rejected.
+#[test]
+fn test_nothing_then_change_to_map_allows_indexing() {
+    assert_typechecks_clean(
+        r#"
+store file_part as nothing
+create map part:
+    "name" is "file"
+    "content_bytes" is "abc"
+end map
+change file_part to part
+store file_bytes as file_part["content_bytes"]
+display file_bytes
+"#,
+    );
+}
+
+/// Direct reassignment of a concrete non-Nothing value still works and does
+/// not leave a false Nothing diagnostic on subsequent uses.
+#[test]
+fn test_nothing_then_change_to_text_is_allowed() {
+    assert_typechecks_clean(
+        r#"
+store item as nothing
+change item to "hello"
+display item
+"#,
+    );
+}
+
+/// A variable that stays Nothing (never reassigned) must still reject indexing.
+#[test]
+fn test_nothing_without_reassign_still_rejects_indexing() {
+    assert_type_error_contains(
+        r#"
+store item as nothing
+display item["k"]
+"#,
+        "Cannot index into",
+    );
+}
+
+/// Concrete type mismatches on reassignment remain errors (Number -> Text).
+#[test]
+fn test_incompatible_reassignment_still_errors() {
+    assert_type_error_contains(
+        r#"
+store x as 10
+change x to "hello"
+"#,
+        "incompatible type",
+    );
+}

--- a/tests/nothing_reassign_widen_test.rs
+++ b/tests/nothing_reassign_widen_test.rs
@@ -52,8 +52,10 @@ fn assert_type_error_contains(code: &str, needle: &str) {
     );
 }
 
-/// Minimal repro from issue #605: init to nothing, reassign in a for-each,
-/// then index. Must not report "Cannot index into Nothing".
+/// Minimal repro from issue #605: init to nothing, reassign in a for-each.
+/// After the loop the variable must not stay pinned as Nothing.
+/// (List literals are `List of Any`, so we assert via a use that would fail
+/// on Nothing — length — rather than a map index on a text element.)
 #[test]
 fn test_nothing_then_reassign_in_loop_allows_indexing() {
     assert_typechecks_clean(
@@ -63,7 +65,7 @@ store items as ["a"]
 for each x in items:
     change item to x
 end for
-display item["k"]
+display length of item
 "#,
     );
 }
@@ -120,5 +122,85 @@ store x as 10
 change x to "hello"
 "#,
         "incompatible type",
+    );
+}
+
+/// Defining an action that would widen an outer Nothing binding must not
+/// permanently refine that outer binding — the action may never be called
+/// (PR #606 Codex review).
+#[test]
+fn test_action_body_does_not_permanently_widen_outer_nothing() {
+    assert_type_error_contains(
+        r#"
+store item as nothing
+define action called widen:
+    change item to "x"
+end action
+display item["k"]
+"#,
+        "Cannot index into",
+    );
+}
+
+/// Parent-walking `get_symbol_mut` must not let a `when` error binding
+/// overwrite an outer variable of the same name (PR #606 review).
+///
+/// Full-pipeline analysis already rejects `when error as msg` when outer
+/// `msg` exists (shadowing), so this builds the AST and uses a pre-seeded
+/// analyzer to exercise the type checker path in isolation.
+#[test]
+fn test_when_error_name_does_not_clobber_outer_variable_type() {
+    use wfl::analyzer::{Analyzer, Symbol, SymbolKind};
+    use wfl::parser::ast::{ErrorType, Expression, Literal, Program, Statement, Type, WhenClause};
+
+    let mut analyzer = Analyzer::new();
+    analyzer
+        .define_symbol(Symbol {
+            name: "msg".to_string(),
+            kind: SymbolKind::Variable { mutable: true },
+            symbol_type: Some(Type::Number),
+            line: 1,
+            column: 1,
+        })
+        .expect("define outer msg");
+
+    let program = Program {
+        statements: vec![
+            Statement::TryStatement {
+                body: vec![Statement::DisplayStatement {
+                    value: Expression::Literal(Literal::String("ok".into()), 2, 1),
+                    line: 2,
+                    column: 1,
+                }],
+                when_clauses: vec![WhenClause {
+                    error_type: ErrorType::General,
+                    error_name: "msg".to_string(),
+                    body: vec![Statement::DisplayStatement {
+                        value: Expression::Variable("msg".to_string(), 4, 1),
+                        line: 4,
+                        column: 1,
+                    }],
+                }],
+                otherwise_block: None,
+                finally_block: None,
+                line: 1,
+                column: 1,
+            },
+            // After the try, outer `msg` must still be Number.
+            Statement::Assignment {
+                name: "msg".to_string(),
+                value: Expression::Literal(Literal::Integer(20), 6, 1),
+                line: 6,
+                column: 1,
+            },
+        ],
+    };
+
+    let mut type_checker = TypeChecker::with_analyzer(analyzer);
+    let result = type_checker.check_types(&program);
+    assert!(
+        result.is_ok(),
+        "when error binding must not clobber outer Number type; got: {:?}",
+        result.err()
     );
 }


### PR DESCRIPTION
## Summary
- Fixes #605: false `Cannot index into Nothing` when a variable is initialized to `nothing`, reassigned via `change` (including inside a loop), then indexed.
- On assignment, `Nothing`-typed variables widen to the new value's type instead of staying pinned.
- `get_symbol_mut` now walks parent scopes so type refinements from loop bodies update the real binding and survive `pop_scope`.

## Root causes
1. `Statement::Assignment` never updated a variable's type after the first inference, so `store x as nothing` left `x` as `Nothing` forever.
2. `Analyzer::get_symbol_mut` only mutated the innermost scope, so even a widen inside a `for each` body was silently dropped when the scope was popped.

## Test plan
- [x] TDD: `tests/nothing_reassign_widen_test.rs` failed before the fix (3 cases), all pass after
  - nothing → reassign in for-each → index (issue minimal repro)
  - nothing → change to map → index (wfl-web shape)
  - nothing → change to text is allowed
  - nothing without reassign still rejects indexing
  - Number → Text reassignment still errors
- [x] Related residuals / recursive return-type tests still pass
- [x] Typechecker unit tests pass
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type-checking for variables initialized as `nothing` and later reassigned to usable values.
  * Improved type updates across loops and nested scopes, preventing incorrect indexing errors.
  * Preserved diagnostics for indexing unchanged `nothing` values and incompatible reassignment types.

* **Tests**
  * Added coverage for loop reassignment, map and text values, unchanged `nothing`, and invalid type changes.

* **Documentation**
  * Added a development diary entry documenting the issue and resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->