### PR TITLE
Fix REPL variable storage and multi-line block detection

### DIFF
--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -73,11 +73,36 @@ The implementation change is entirely in `src/repl.rs`; the REPL guide
     real safeguards (the security lint, definition-time reference checks, and
     cross-line type contracts). This accumulated-program approach restores them
     while keeping cross-line references working.
-  - *Known limitation:* the security lint is evaluated per submission's
-    accumulated view, so seeding the RNG in one command and doing crypto in a
-    *separate later* command is not flagged (the seed already executed; flagging
-    the prior line would wrongly block every later command). Doing both in one
-    submission — the file-equivalent case — is caught.
+
+- **Session-level security gate (owns `ANALYZE-SECURITY`).** The insecure-RNG
+  seeding control is *not* left to the accumulated-source analysis, because that
+  analysis has two blind spots the maintainer's second review flagged:
+  1. It reports only diagnostics whose line falls inside the *new* submission, so
+     an `ANALYZE-SECURITY` attached to a `random_seed` on an *earlier* line was
+     filtered out — seeding in one command and doing crypto in a separate later
+     command slipped through.
+  2. When the accumulated source exceeds the size cap, or the combined source
+     fails to lex/parse, analysis falls back to the current submission alone,
+     which returned "advisory, never blocks" — downgrading even self-contained
+     fatal errors, so a long session could execute what a short one would block.
+  The fix tracks the two ingredients of the lint — an insecure `random_seed` and
+  any [security-sensitive builtin](../src/analyzer/static_analyzer.rs) — as
+  session state (`rng_insecurely_seeded`, `security_builtin_used`), folded in
+  after each executed submission. Before running any submission, the REPL blocks
+  when the session (state + this submission) has *both* ingredients. This runs on
+  every path, independent of the capped combined analysis, so:
+  - Seeding then crypto in **separate** submissions is blocked (either order); the
+    completing submission is fatal, so it is not recorded, and the session never
+    accumulates both ingredients — a later *innocent* command is not over-blocked.
+  - The **fallback** path (over-cap or lex/parse failure) still blocks the
+    combination: the security control is a separate pass, not a source-size mode
+    switch. Only context-dependent name-resolution stays advisory in the fallback
+    (it genuinely can't be judged without the earlier lines).
+  - Seeding **without** any security-sensitive builtin remains allowed
+    (reproducible simulations), matching the file lint.
+  The scan (`rng_security_ingredients`) reuses the analyzer's own call collector
+  and `SECURITY_SENSITIVE_BUILTINS` list, so REPL and `wfl <file>` agree on what
+  counts as seeding and as security-sensitive.
 
 - **Robust multi-line detection.** `error_means_more_input_needed` replaces the
   fragile string match with two case-insensitive signals: the parser ran out of
@@ -135,6 +160,23 @@ Session-aware analysis (from the maintainer review):
   earlier-line variable is reported (advisory).
 - `re_storing_a_variable_is_allowed` — re-`store` is not blocked by the file-only
   "already defined" error.
+
+Session-level security gate (second maintainer review):
+
+- `insecure_seed_then_crypto_in_separate_submissions_is_blocked`,
+  `crypto_then_insecure_seed_in_separate_submissions_is_blocked` — the seed +
+  crypto combination is blocked when split across separate submissions, in either
+  order (the whole-program lint could not see this).
+- `innocent_command_after_a_blocked_crypto_op_is_not_over_blocked` — the blocked
+  (completing) submission is not recorded, so a later unrelated command still runs.
+- `insecure_seed_alone_is_still_allowed` — seeding without any crypto/auth op is
+  not blocked.
+- `fallback_path_still_blocks_insecure_seeding` — forcing the isolated fallback
+  (tiny `max_session_analysis_bytes`) still blocks the combination, same-submission
+  and cross-submission; the performance fallback is not a security mode switch.
+- `rng_security_ingredients_reports_each_half_independently` (analyzer) — the
+  ingredient scan reports seeding and security-builtin use independently and
+  captures call sites.
 
 `cargo test --lib`, `cargo fmt --all -- --check`, and
 `cargo clippy --all-targets --all-features -- -D warnings` are green.

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -174,26 +174,43 @@ Session-level security gate (second maintainer review):
 - `fallback_path_still_blocks_insecure_seeding` — forcing the isolated fallback
   (tiny `max_session_analysis_bytes`) still blocks the combination, same-submission
   and cross-submission; the performance fallback is not a security mode switch.
-- `fallback_downgrades_earlier_session_reference_but_does_not_block` — in the same
-  forced fallback, a reference to an earlier-session variable is downgraded to
-  advisory (not blocked), so cross-line references keep working in the degraded path.
+- `fallback_does_not_block_reference_to_a_live_earlier_session_binding` — in the same
+  forced fallback, a reference to a live earlier-session variable is dropped (no
+  error, not blocked), so cross-line references keep working in the degraded path.
+- `fallback_blocks_undefined_reference_inside_a_deferred_action_body` — a genuine
+  typo inside a not-yet-called action body is still fatal at definition time in the
+  fallback (the name is absent from the live session).
+- `fallback_allows_action_referencing_a_valid_earlier_session_binding` — the
+  companion: an action body referencing a live earlier-session binding is accepted.
 - `rng_security_ingredients_reports_each_half_independently` (analyzer) — the
   ingredient scan reports seeding and security-builtin use independently and
   captures call sites.
 
 The isolated fallback (`static_check_isolated`) blocks per diagnostic rather than
-relaxing wholesale: **self-contained fatal errors still block**, while only
-**context-dependent name resolution** (an undefined variable/action/handler/list
-reference, which may name an earlier-session symbol we can't see when analysing
-the submission alone) is downgraded to advisory. Type checking is intentionally
-skipped in the fallback: its diagnostics are advisory (never block), and without
-the earlier-session symbols it would emit false-positive "undefined" type
-diagnostics for valid earlier-session references. Today the analyzer's only fatal
-semantic diagnostics are duplicate-definition (ignored interactively) and those
-name-resolution errors, so this changes no current behavior — it keeps the
-fallback correct-by-construction if a self-contained fatal semantic check is
-added later, and the insecure-RNG control is enforced regardless by the session
-gate above.
+relaxing wholesale: **self-contained fatal errors still block**. For an
+**undefined-name** diagnostic (variable/action/handler/list reference) the fallback
+consults the **live interpreter environment** — the source of truth for what the
+session actually holds — to decide:
+
+- Name **is** a live earlier-session binding → the "undefined" is a false positive
+  from losing the prefix; drop it (no noise, no block), so cross-line references
+  keep working in the degraded path.
+- Name is **not** in the session → a genuine undefined reference; keep it fatal.
+
+The second case is what a maintainer review (head `52c16b2`) required: defining an
+action stores its body *without running it*, so a genuine typo inside a not-yet-called
+action/handler body is not validated by execution. An earlier version downgraded
+*all* undefined-name diagnostics to advisory, which let a broken deferred definition
+through at the cap boundary — re-opening the "caught at definition time" invariant
+specifically after the fallback. Keying the decision on live-env membership (rather
+than diagnostic position) preserves that invariant, avoids false blocks for valid
+earlier-session references, and keeps the fallback consistent with the full-analysis
+path (which likewise treats a name absent from the session as a genuine error).
+
+Type checking is intentionally skipped in the fallback: its diagnostics are advisory
+(never block), and without the earlier-session symbols it would emit false-positive
+"undefined" type diagnostics for valid earlier-session references. The insecure-RNG
+control is enforced regardless by the session gate above.
 
 `cargo test --lib`, `cargo fmt --all -- --check`, and
 `cargo clippy --all-targets --all-features -- -D warnings` are green.

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -46,30 +46,38 @@ positives about the live session.
 The implementation change is entirely in `src/repl.rs`; the REPL guide
 (`Docs/02-getting-started/repl-guide.md`) and this diary are updated alongside it.
 
-- **The interpreter is the source of truth, and static analysis is filtered by
-  diagnostic code — not blanket-dropped.** The REPL no longer lets the stateless
-  analyzer/type-checker reject valid session code, but it still preserves the
-  diagnostics that are genuinely valid line-by-line:
-  - `ANALYZE-SEMANTIC` (context-dependent name resolution: undefined name, "not
-    an action", already-defined, undefined-inside-`try`) is dropped — a name
-    defined on an earlier line looks undefined to the per-line analyzer. The
-    interpreter re-checks these against the real environment and reports genuine
-    ones at run time. This fixes causes #1 and #2: `store` stores and later lines
-    can use what earlier lines defined.
-  - `ANALYZE-UNUSED` is dropped — a stored binding is available to the next line,
-    so "unused" is always a false positive interactively.
-  - **everything else is kept exactly as `wfl <file>` treats it.** Advisory
-    warnings (unreachable code, dead branch, shadowing, inconsistent returns) are
-    shown, and any self-contained **error** — notably the `ANALYZE-SECURITY` lint
-    that blocks seeding the RNG (`random_seed`) inside crypto/auth code — is shown
-    **and blocks execution**. These lints depend only on the current line's own
-    code, never on session state, so weakening them would be wrong. (An earlier
-    revision of this fix incorrectly filtered on `Severity::Warning`, which
-    silently discarded the fatal `ANALYZE-SECURITY` lint in the REPL; caught in
-    review and corrected to the code-based filter above.)
-  - The type checker is skipped: its diagnostics are the same context-dependent
-    name/type kind that would be noise on every line referring back to the
-    session.
+- **Session-aware static analysis (accumulated program).** The REPL keeps one
+  persistent interpreter but the analyzer/type-checker are whole-program tools;
+  running them on a single line makes earlier-line names look "undefined". The
+  fix runs the *same* `analyze → type-check → execute` pipeline `wfl <file>`
+  uses, but over `session_inputs + this submission` as one program, then reports
+  only the diagnostics that fall inside the new submission (their line numbers
+  translated back to the submission's own coordinates). Only the new submission
+  is executed — earlier ones already ran against the persistent interpreter.
+  - A name/action defined on an earlier line is in scope, so cross-line
+    references resolve (fixes the core bug) — but the checks the interpreter
+    *cannot* do still run: the insecure-RNG `ANALYZE-SECURITY` lint (even when the
+    submission references an earlier-line variable — previously the analyzer bailed
+    on the "undefined" session symbol before the lint ran), undefined references
+    inside a not-yet-called action body (caught at definition time, not deferred
+    to invocation), and cross-line type mismatches (e.g. `store n as 5` then
+    `change n to "text"`).
+  - Semantic **errors are fatal** (they abort a file too); **type diagnostics are
+    advisory** — shown but non-blocking, exactly as `wfl <file>` treats them.
+  - Two file-only diagnostics are intentionally suppressed in the REPL:
+    `ANALYZE-UNUSED` (a binding is available to a *future* submission) and
+    "already defined" (re-`store`/re-defining a name is normal interactively — the
+    interpreter reassigns).
+  - *Design history:* the first version of this PR disabled the static gates and
+    relied on the interpreter alone. Maintainer review showed that dropped three
+    real safeguards (the security lint, definition-time reference checks, and
+    cross-line type contracts). This accumulated-program approach restores them
+    while keeping cross-line references working.
+  - *Known limitation:* the security lint is evaluated per submission's
+    accumulated view, so seeding the RNG in one command and doing crypto in a
+    *separate later* command is not flagged (the seed already executed; flagging
+    the prior line would wrongly block every later command). Doing both in one
+    submission — the file-equivalent case — is caught.
 
 - **Robust multi-line detection.** `error_means_more_input_needed` replaces the
   fragile string match with two case-insensitive signals: the parser ran out of
@@ -101,14 +109,32 @@ Added regression tests in `src/repl.rs`:
 - `variable_defined_on_an_earlier_line_is_usable_later`,
   `action_defined_earlier_can_be_called_later_without_null_echo` — cross-line
   references and calls work, and void calls don't echo `null`.
-- `undefined_variable_is_reported_as_a_runtime_error`, `syntax_error_is_reported`
-  — genuine mistakes are still surfaced.
+- `undefined_variable_is_reported`, `syntax_error_is_reported` — genuine mistakes
+  are still surfaced.
 - `expression_result_is_echoed`, `boolean_echo_uses_yes_no_not_true_false` — echo
   format.
 - `incomplete_blocks_request_more_input`,
   `complete_statements_are_not_treated_as_incomplete`,
-  `multiline_if_block_runs_only_once_closed` — multi-line detection across block
-  forms.
+  `multiline_if_block_buffers_across_lines_and_runs_on_close` — multi-line
+  detection across block forms.
+- `render_diagnostic_snaps_span_to_char_boundaries`,
+  `render_diagnostic_points_at_source_even_at_eof` — the synthesized caret span
+  stays on UTF-8 boundaries and still points at the source at EOF.
+
+Session-aware analysis (from the maintainer review):
+
+- `insecure_rng_is_blocked_even_when_referencing_an_earlier_line_variable`,
+  `self_contained_security_lint_still_blocks` — the `ANALYZE-SECURITY` lint fires
+  and blocks, including when the submission references an earlier-line variable.
+- `undefined_reference_inside_an_action_body_is_blocked_at_definition` — a typo
+  inside a deferred action body is caught when defined, not at invocation.
+- `earlier_session_variable_is_usable_inside_a_definition`,
+  `self_recursive_action_is_accepted` — valid earlier-session and self references
+  resolve.
+- `cross_line_type_mismatch_is_surfaced` — an incompatible assignment against an
+  earlier-line variable is reported (advisory).
+- `re_storing_a_variable_is_allowed` — re-`store` is not blocked by the file-only
+  "already defined" error.
 
 `cargo test --lib`, `cargo fmt --all -- --check`, and
 `cargo clippy --all-targets --all-features -- -D warnings` are green.

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -43,7 +43,8 @@ positives about the live session.
 
 ## What changed
 
-All changes are in `src/repl.rs` (plus a tiny cleanup in `src/interpreter/mod.rs`).
+The implementation change is entirely in `src/repl.rs`; the REPL guide
+(`Docs/02-getting-started/repl-guide.md`) and this diary are updated alongside it.
 
 - **The interpreter is the source of truth, and static analysis is filtered by
   diagnostic code — not blanket-dropped.** The REPL no longer lets the stateless

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -182,6 +182,13 @@ Session-level security gate (second maintainer review):
   fallback (the name is absent from the live session).
 - `fallback_allows_action_referencing_a_valid_earlier_session_binding` — the
   companion: an action body referencing a live earlier-session binding is accepted.
+- `fallback_blocks_undefined_action_call_inside_a_deferred_body`,
+  `fallback_allows_earlier_session_action_call_inside_a_deferred_body` — the same
+  guarantee for an undefined *action call* (a second undefined-name shape) inside a
+  stored body: a call to a nonexistent action is fatal at definition time, while a
+  call to an action defined on an earlier line is accepted. The env check keys on
+  the *name*, not its syntactic role or position, so it covers every deferred body
+  (action/handler/route/event) by construction.
 - `rng_security_ingredients_reports_each_half_independently` (analyzer) — the
   ingredient scan reports seeding and security-builtin use independently and
   captures call sites.

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -1,0 +1,125 @@
+# Dev Diary — 2026-07-14: REPL error rules, warnings, and the "store doesn't store" bug
+
+## Context
+
+A user reported that the interactive REPL (`wfl` with no file) misbehaved when
+storing a variable from the command line: it printed a warning and then the
+variable did not appear to be stored at all. The ask was to (1) make the REPL's
+errors and warnings follow WFL's error rules, (2) fix the storage bug, and
+(3) exercise a range of programs and lines so the REPL works reliably.
+
+## Root causes
+
+Everything traced back to one design mismatch: **the REPL keeps a single
+persistent interpreter for the whole session, but it ran the lexer, parser,
+analyzer, and type checker fresh on every line.** Those front-end passes are
+whole-program tools; against a single interactive line they produce false
+positives about the live session.
+
+1. **`store x as 5` was discarded by its own warning.** The per-line analyzer
+   flagged the just-declared variable as an "unused variable" *warning*, and
+   `process_complete_input` returned early on **any** non-empty diagnostic list
+   — warning or error alike. So the command was reported and then dropped before
+   the interpreter ever ran. The variable was never stored. (The `wfl <file>`
+   path already got this right: it only aborts on `Severity::Error`.)
+
+2. **A variable/action from an earlier line looked "not defined".** Because the
+   analyzer and type checker saw only the current line, `display x` on the line
+   after `store x as 5` was a fatal "Variable 'x' is not defined" — even though
+   `x` was alive in the session. The same happened to `call greet with "..."`
+   after an action definition ("'greet' is not an action").
+
+3. **Multi-line blocks silently broke.** `is_input_incomplete` matched parser
+   error strings case-sensitively (`contains("expected")`). `check if …:` reports
+   "Expected 'end' after if block, found end of input" and `define action …:`
+   reports a bare "Expected 'end' after action body" — neither matched, so those
+   blocks were treated as complete and errored instead of waiting for their
+   `end`. (Count loops happened to work only because "unexpected" contains the
+   substring "expected".)
+
+4. **Analyzer diagnostics had no source snippet.** Parser/type/runtime errors
+   rendered with the Elm-style caret; analyzer diagnostics (built with no label)
+   printed as a bare message with no location.
+
+## What changed
+
+All changes are in `src/repl.rs` (plus a tiny cleanup in `src/interpreter/mod.rs`).
+
+- **The interpreter is the source of truth.** The REPL no longer lets the
+  stateless analyzer/type-checker gate execution. Static analysis is kept only
+  for advisory **warnings** that are self-contained within one line (unreachable
+  code, shadowing, insecure RNG seeding, inconsistent returns). Analyzer
+  *errors* (undefined name, "not an action", already-defined) are context
+  dependent, so they are not reported here — the interpreter re-checks them
+  against the real session environment and reports genuine ones at run time with
+  the standard formatting. The type checker is skipped for the same reason. This
+  fixes causes #1 and #2 together: `store` stores, and later lines can use what
+  earlier lines defined.
+
+- **"Unused variable" warnings are suppressed in the REPL.** A stored binding is
+  available to the next line, so "unused" is always a false positive
+  interactively.
+
+- **Robust multi-line detection.** `error_means_more_input_needed` replaces the
+  fragile string match with two case-insensitive signals: the parser ran out of
+  tokens (`end of input`), or it is still waiting for a block terminator
+  (`expected 'end`) without having stopped on a concrete token. This covers
+  `check if`, `count`, `for each`, `repeat while/until`, and `define action`
+  blocks; a real mid-stream mistake (`… found <Token>`) is still surfaced
+  immediately.
+
+- **Every diagnostic gets a caret.** `render_diagnostic` synthesizes a
+  one-character span from an analyzer diagnostic's line/column when it has no
+  label, so all REPL diagnostics follow the same "point at the source"
+  convention (WFL Fundamental #4).
+
+- **Cleaner value echo.** A bare expression echoes its value with `Display`
+  (`yes`/`no`, unquoted text, `[1, 2, 3]`) instead of Rust's debug spelling, and
+  void results (`nothing`/null) are not echoed — so `call greet with "World"`
+  prints its output with no stray `null` underneath.
+
+- The four near-identical codespan rendering blocks were collapsed into the one
+  `render_diagnostic` helper.
+
+## Tests
+
+Added regression tests in `src/repl.rs`:
+
+- `store_persists_and_prints_nothing` — the reported bug: `store` produces no
+  output and the variable is actually in the session env.
+- `variable_defined_on_an_earlier_line_is_usable_later`,
+  `action_defined_earlier_can_be_called_later_without_null_echo` — cross-line
+  references and calls work, and void calls don't echo `null`.
+- `undefined_variable_is_reported_as_a_runtime_error`, `syntax_error_is_reported`
+  — genuine mistakes are still surfaced.
+- `expression_result_is_echoed`, `boolean_echo_uses_yes_no_not_true_false` — echo
+  format.
+- `incomplete_blocks_request_more_input`,
+  `complete_statements_are_not_treated_as_incomplete`,
+  `multiline_if_block_runs_only_once_closed` — multi-line detection across block
+  forms.
+
+`cargo test --lib`, `cargo fmt --all -- --check`, and
+`cargo clippy --all-targets --all-features -- -D warnings` are green.
+
+## Docs
+
+`Docs/02-getting-started/repl-guide.md` had several claims that never matched the
+implementation; corrected them while here (Docs-Must-Be-Honest):
+
+- Startup banner and prompt (`WFL REPL - Type .help for commands or .exit to
+  quit`, `wfl>` prompt, `...` continuation) instead of a made-up version banner
+  and `>`.
+- REPL commands are dot-prefixed: `.help`, `.history`, `.clear`, `.exit` — there
+  is no `exit`/`quit`/`clear`.
+- Replaced a fictional "Cannot add Number and Text" error example (WFL actually
+  coerces `5 plus "hello"` to `"5hello"`) with a real undefined-variable error.
+- Removed the stale "No history (yet)" limitation — `.history` and arrow-key
+  recall both exist.
+
+## Follow-ups (not done here)
+
+- Several tutorial examples elsewhere in `repl-guide.md` omit `call` before an
+  action name (`calculate area with 10 and 20`), which parses as concatenation,
+  not a call. That's a general action-call-syntax documentation issue, not a
+  REPL behavior issue, so it was left out of this change.

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -45,20 +45,30 @@ positives about the live session.
 
 All changes are in `src/repl.rs` (plus a tiny cleanup in `src/interpreter/mod.rs`).
 
-- **The interpreter is the source of truth.** The REPL no longer lets the
-  stateless analyzer/type-checker gate execution. Static analysis is kept only
-  for advisory **warnings** that are self-contained within one line (unreachable
-  code, shadowing, insecure RNG seeding, inconsistent returns). Analyzer
-  *errors* (undefined name, "not an action", already-defined) are context
-  dependent, so they are not reported here — the interpreter re-checks them
-  against the real session environment and reports genuine ones at run time with
-  the standard formatting. The type checker is skipped for the same reason. This
-  fixes causes #1 and #2 together: `store` stores, and later lines can use what
-  earlier lines defined.
-
-- **"Unused variable" warnings are suppressed in the REPL.** A stored binding is
-  available to the next line, so "unused" is always a false positive
-  interactively.
+- **The interpreter is the source of truth, and static analysis is filtered by
+  diagnostic code — not blanket-dropped.** The REPL no longer lets the stateless
+  analyzer/type-checker reject valid session code, but it still preserves the
+  diagnostics that are genuinely valid line-by-line:
+  - `ANALYZE-SEMANTIC` (context-dependent name resolution: undefined name, "not
+    an action", already-defined, undefined-inside-`try`) is dropped — a name
+    defined on an earlier line looks undefined to the per-line analyzer. The
+    interpreter re-checks these against the real environment and reports genuine
+    ones at run time. This fixes causes #1 and #2: `store` stores and later lines
+    can use what earlier lines defined.
+  - `ANALYZE-UNUSED` is dropped — a stored binding is available to the next line,
+    so "unused" is always a false positive interactively.
+  - **everything else is kept exactly as `wfl <file>` treats it.** Advisory
+    warnings (unreachable code, dead branch, shadowing, inconsistent returns) are
+    shown, and any self-contained **error** — notably the `ANALYZE-SECURITY` lint
+    that blocks seeding the RNG (`random_seed`) inside crypto/auth code — is shown
+    **and blocks execution**. These lints depend only on the current line's own
+    code, never on session state, so weakening them would be wrong. (An earlier
+    revision of this fix incorrectly filtered on `Severity::Warning`, which
+    silently discarded the fatal `ANALYZE-SECURITY` lint in the REPL; caught in
+    review and corrected to the code-based filter above.)
+  - The type checker is skipped: its diagnostics are the same context-dependent
+    name/type kind that would be noise on every line referring back to the
+    session.
 
 - **Robust multi-line detection.** `error_means_more_input_needed` replaces the
   fragile string match with two case-insensitive signals: the parser ran out of

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -129,7 +129,7 @@ Session-aware analysis (from the maintainer review):
 - `undefined_reference_inside_an_action_body_is_blocked_at_definition` — a typo
   inside a deferred action body is caught when defined, not at invocation.
 - `earlier_session_variable_is_usable_inside_a_definition`,
-  `self_recursive_action_is_accepted` — valid earlier-session and self references
+  `self_recursive_action_is_accepted` — valid earlier-session and self-references
   resolve.
 - `cross_line_type_mismatch_is_surfaced` — an incompatible assignment against an
   earlier-line variable is reported (advisory).

--- a/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
+++ b/Dev diary/2026-07-14-repl-errors-warnings-and-variable-storage.md
@@ -174,9 +174,26 @@ Session-level security gate (second maintainer review):
 - `fallback_path_still_blocks_insecure_seeding` — forcing the isolated fallback
   (tiny `max_session_analysis_bytes`) still blocks the combination, same-submission
   and cross-submission; the performance fallback is not a security mode switch.
+- `fallback_downgrades_earlier_session_reference_but_does_not_block` — in the same
+  forced fallback, a reference to an earlier-session variable is downgraded to
+  advisory (not blocked), so cross-line references keep working in the degraded path.
 - `rng_security_ingredients_reports_each_half_independently` (analyzer) — the
   ingredient scan reports seeding and security-builtin use independently and
   captures call sites.
+
+The isolated fallback (`static_check_isolated`) blocks per diagnostic rather than
+relaxing wholesale: **self-contained fatal errors still block**, while only
+**context-dependent name resolution** (an undefined variable/action/handler/list
+reference, which may name an earlier-session symbol we can't see when analysing
+the submission alone) is downgraded to advisory. Type checking is intentionally
+skipped in the fallback: its diagnostics are advisory (never block), and without
+the earlier-session symbols it would emit false-positive "undefined" type
+diagnostics for valid earlier-session references. Today the analyzer's only fatal
+semantic diagnostics are duplicate-definition (ignored interactively) and those
+name-resolution errors, so this changes no current behavior — it keeps the
+fallback correct-by-construction if a self-contained fatal semantic check is
+added later, and the insecure-RNG control is enforced regardless by the session
+gate above.
 
 `cargo test --lib`, `cargo fmt --all -- --check`, and
 `cargo clippy --all-targets --all-features -- -D warnings` are green.

--- a/Docs/02-getting-started/repl-guide.md
+++ b/Docs/02-getting-started/repl-guide.md
@@ -23,12 +23,13 @@ wfl
 
 **You'll see:**
 ```
-WFL REPL v26.1.17
-Type 'exit' or press Ctrl+C to quit
->
+WFL REPL - Type .help for commands or .exit to quit
+wfl>
 ```
 
-The `>` prompt means WFL is ready for your input.
+The `wfl>` prompt means WFL is ready for your input. While you are part-way
+through a multi-line block, the prompt changes to `...` to show WFL is waiting
+for the rest of the block.
 
 ## Basic Usage
 
@@ -249,44 +250,49 @@ no
 
 ## REPL Commands
 
+Commands that control the REPL itself all start with a dot, so they are never
+confused with WFL code. Type `.help` at any time to list them:
+
+| Command | What it does |
+|---------|--------------|
+| `.help` | Show the list of REPL commands |
+| `.history` | Show the commands you have entered this session |
+| `.clear` | Clear the screen |
+| `.exit` | Exit the REPL |
+
 ### Display Variables
 
-Just type the variable name:
+To see a value, just type the variable name (no dot — that's WFL code, not a
+REPL command):
 
 ```wfl
-> store x as 100
-> x
+wfl> store x as 100
+wfl> x
 100
 
-> store name as "Alice"
-> name
+wfl> store name as "Alice"
+wfl> name
 Alice
 ```
 
-### Clear Screen (if supported)
+### Clear the Screen
 
-Some terminals support:
 ```wfl
-> clear
+wfl> .clear
 ```
 
 ### Exit the REPL
 
-Multiple ways to exit:
+Any of these work:
 
-1. **Type `exit`:**
+1. **Type `.exit`:**
    ```wfl
-   > exit
+   wfl> .exit
    ```
 
-2. **Type `quit`:**
-   ```wfl
-   > quit
-   ```
+2. **Press Ctrl+C** (cancels a running command; press at the empty prompt to quit)
 
-3. **Press Ctrl+C**
-
-4. **Press Ctrl+D** (Linux/macOS)
+3. **Press Ctrl+D** (Linux/macOS)
 
 ## Tips and Tricks
 
@@ -337,16 +343,20 @@ List
 
 ### 4. Test Error Messages
 
-See how WFL reports errors:
+See how WFL reports errors. For example, referring to a variable you never
+defined points right at the problem:
 
 ```wfl
-> 5 plus "hello"
-ERROR: Cannot add Number and Text
-
-Type mismatch: expected Number, got Text
+wfl> display total
+error: Undefined variable 'total'
+  ┌─ repl:1:9
+  │
+1 │ display total
+  │         ^ Runtime error occurred here
 ```
 
-Error messages in the REPL help you understand what went wrong.
+Error messages in the REPL use the same clear, source-highlighting format as
+running a file, so they help you understand exactly what went wrong.
 
 ### 5. Prototype Functions
 
@@ -479,9 +489,12 @@ Hello, World!
 The REPL has some limitations:
 
 1. **No file saving** - Your session disappears when you exit
-2. **No history** (yet) - Can't scroll through previous commands
-3. **Limited editing** - Can't edit multi-line blocks easily
-4. **No undo** - Can't undo variable assignments
+2. **Limited editing** - Can't edit multi-line blocks after entering them
+3. **No undo** - Can't undo variable assignments (but you can re-`store` a
+   variable to overwrite it)
+
+You *can* review what you have typed this session with `.history`, and recall
+previous lines with the up/down arrow keys.
 
 **Solution:** Use the REPL for experiments, then move working code to `.wfl` files.
 

--- a/Docs/02-getting-started/repl-guide.md
+++ b/Docs/02-getting-started/repl-guide.md
@@ -261,7 +261,7 @@ confused with WFL code. Type `.help` at any time to list them:
 |---------|--------------|
 | `.help` | Show the list of REPL commands |
 | `.history` | List the WFL inputs you've run this session (dot-commands are not included) |
-| `.clear` | Clear the screen |
+| `.clear` | Clear the screen (via ANSI escape codes; see note below) |
 | `.exit` | Exit the REPL |
 
 ### Display Variables
@@ -284,6 +284,12 @@ Alice
 ```wfl
 > .clear
 ```
+
+`.clear` works by writing standard ANSI escape sequences. In most terminals it
+clears the screen and moves the cursor to the top; in a terminal or environment
+that does not interpret ANSI escapes (or when output is redirected), it may print
+the escape characters instead of clearing. Your session state is unaffected
+either way — `.clear` only touches the display.
 
 ### Exit the REPL
 

--- a/Docs/02-getting-started/repl-guide.md
+++ b/Docs/02-getting-started/repl-guide.md
@@ -31,6 +31,10 @@ The `wfl>` prompt means WFL is ready for your input. While you are part-way
 through a multi-line block, the prompt changes to `...` to show WFL is waiting
 for the rest of the block.
 
+> **Reading the examples:** to keep them short, the examples below use `>` as
+> shorthand for the `wfl>` prompt (and `...` for the multi-line continuation
+> prompt). Type only the code after the prompt.
+
 ## Basic Usage
 
 ### Simple Expressions
@@ -266,19 +270,19 @@ To see a value, just type the variable name (no dot — that's WFL code, not a
 REPL command):
 
 ```wfl
-wfl> store x as 100
-wfl> x
+> store x as 100
+> x
 100
 
-wfl> store name as "Alice"
-wfl> name
+> store name as "Alice"
+> name
 Alice
 ```
 
 ### Clear the Screen
 
 ```wfl
-wfl> .clear
+> .clear
 ```
 
 ### Exit the REPL
@@ -287,7 +291,7 @@ Any of these work:
 
 1. **Type `.exit`:**
    ```wfl
-   wfl> .exit
+   > .exit
    ```
 
 2. **Press Ctrl+C** (cancels a running command; press at the empty prompt to quit)
@@ -347,7 +351,7 @@ See how WFL reports errors. For example, referring to a variable you never
 defined points right at the problem:
 
 ```wfl
-wfl> display total
+> display total
 error: Undefined variable 'total'
   ┌─ repl:1:9
   │

--- a/Docs/02-getting-started/repl-guide.md
+++ b/Docs/02-getting-started/repl-guide.md
@@ -260,7 +260,7 @@ confused with WFL code. Type `.help` at any time to list them:
 | Command | What it does |
 |---------|--------------|
 | `.help` | Show the list of REPL commands |
-| `.history` | Show the commands you have entered this session |
+| `.history` | List the WFL inputs you've run this session (dot-commands are not included) |
 | `.clear` | Clear the screen |
 | `.exit` | Exit the REPL |
 
@@ -497,8 +497,9 @@ The REPL has some limitations:
 3. **No undo** - Can't undo variable assignments (but you can re-`store` a
    variable to overwrite it)
 
-You *can* review what you have typed this session with `.history`, and recall
-previous lines with the up/down arrow keys.
+You *can* review the WFL inputs you've run this session with `.history` (it does
+not list dot-commands like `.help`), and recall any previous line — including
+dot-commands — with the up/down arrow keys.
 
 **Solution:** Use the REPL for experiments, then move working code to `.wfl` files.
 

--- a/Docs/02-getting-started/repl-guide.md
+++ b/Docs/02-getting-started/repl-guide.md
@@ -352,15 +352,17 @@ defined points right at the problem:
 
 ```wfl
 > display total
-error: Undefined variable 'total'
+error: Variable 'total' is not defined
   ┌─ repl:1:9
   │
 1 │ display total
-  │         ^ Runtime error occurred here
+  │         ^ here
 ```
 
-Error messages in the REPL use the same clear, source-highlighting format as
-running a file, so they help you understand exactly what went wrong.
+Because the REPL analyses your input the same way `wfl <file>` does, an
+undefined name is caught up front by static analysis (the line is not run), and
+the error uses the same clear, source-highlighting format as running a file — so
+it points right at the problem and helps you understand exactly what went wrong.
 
 ### 5. Prototype Functions
 

--- a/src/analyzer/static_analyzer.rs
+++ b/src/analyzer/static_analyzer.rs
@@ -133,6 +133,55 @@ const SECURITY_SENSITIVE_BUILTINS: &[&str] = &[
     "wflmac256",
 ];
 
+/// The two ingredients of the insecure-RNG-seeding lint found in a single
+/// program: whether it seeds the RNG (`random_seed`) and whether it performs an
+/// authentication/session/cryptographic operation ([`SECURITY_SENSITIVE_BUILTINS`]),
+/// each with its first call site (1-based line, column).
+///
+/// [`Analyzer::check_insecure_rng_seeding`] flags a *file* that contains both at
+/// once. The REPL, however, receives one submission at a time, so the seed and
+/// the crypto operation can arrive on separate lines. It uses this to track the
+/// two ingredients across submissions — and independently of the capped
+/// combined-source analysis — so the insecure combination is still blocked no
+/// matter how it is split.
+pub struct RngSecurityIngredients {
+    /// Line/column of the first `random_seed` call, if any.
+    pub seed_site: Option<(usize, usize)>,
+    /// Line/column of the first security-sensitive builtin call, if any.
+    pub security_site: Option<(usize, usize)>,
+}
+
+impl RngSecurityIngredients {
+    /// The program seeds the RNG with `random_seed`.
+    pub fn seeds_rng(&self) -> bool {
+        self.seed_site.is_some()
+    }
+
+    /// The program calls an authentication/session/cryptographic builtin.
+    pub fn uses_security_builtin(&self) -> bool {
+        self.security_site.is_some()
+    }
+}
+
+/// Scan a single program for the two insecure-RNG-seeding ingredients (see
+/// [`RngSecurityIngredients`]). Recurses into action bodies, loops, and blocks
+/// exactly as [`Analyzer::check_insecure_rng_seeding`] does, since both use the
+/// same call collector.
+pub fn rng_security_ingredients(program: &Program) -> RngSecurityIngredients {
+    let mut calls = Vec::new();
+    collect_calls_in_statements(&program.statements, &mut calls);
+    RngSecurityIngredients {
+        seed_site: calls
+            .iter()
+            .find(|call| call.name == "random_seed")
+            .map(|call| (call.line, call.column)),
+        security_site: calls
+            .iter()
+            .find(|call| SECURITY_SENSITIVE_BUILTINS.contains(&call.name.as_str()))
+            .map(|call| (call.line, call.column)),
+    }
+}
+
 /// Record of a builtin call site discovered while walking the AST.
 struct CallSite {
     name: String,
@@ -2487,5 +2536,35 @@ mod tests {
 
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code, "ANALYZE-SECURITY");
+    }
+
+    #[test]
+    fn rng_security_ingredients_reports_each_half_independently() {
+        // The REPL blocks the seed+crypto combination across separate submissions
+        // by tracking each half on its own, so the ingredient scan must report the
+        // two independently (unlike the file lint, which only fires on both).
+        let seed_only = rng_security_ingredients(&parse_program("store s as random_seed of 42"));
+        assert!(seed_only.seeds_rng());
+        assert!(!seed_only.uses_security_builtin());
+
+        let crypto_only =
+            rng_security_ingredients(&parse_program("store t as secure_random_bytes of 16"));
+        assert!(!crypto_only.seeds_rng());
+        assert!(crypto_only.uses_security_builtin());
+
+        // General-purpose hashes are not "security-sensitive" (matching the lint's
+        // SECURITY_SENSITIVE_BUILTINS), so hashing + seeding is not an ingredient pair.
+        let checksum = rng_security_ingredients(&parse_program(
+            "store c as sha256 of \"data\"\nstore s as random_seed of 1",
+        ));
+        assert!(checksum.seeds_rng());
+        assert!(!checksum.uses_security_builtin());
+
+        // Call sites are captured (used to place the caret at the current line).
+        let both = rng_security_ingredients(&parse_program(
+            "store t as secure_random_bytes of 16\nstore s as random_seed of 1",
+        ));
+        assert!(both.seed_site.is_some());
+        assert!(both.security_site.is_some());
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -664,11 +664,17 @@ impl ReplState {
     /// blocking is decided per diagnostic, not relaxed wholesale:
     /// - **Self-contained fatal errors still block** (returns `true`). They are
     ///   present in the submission regardless of the earlier lines we can't see.
-    /// - **Context-dependent name resolution is downgraded** to advisory (does not
-    ///   block): without the earlier session lines a reference to an
-    ///   earlier-defined name looks "undefined", so it may be a false positive —
-    ///   the interpreter resolves it against the live session, and a genuine typo
-    ///   still errors at run time.
+    /// - **An undefined-name error is dropped only when the name is a live
+    ///   earlier-session binding.** Without the earlier lines a reference to an
+    ///   earlier-defined name looks "undefined"; the live interpreter environment
+    ///   is the source of truth for what the session actually holds, so if the
+    ///   name is bound there the diagnostic is a false positive — skip it. If the
+    ///   name is NOT in the session, it is a genuine undefined reference and stays
+    ///   fatal. This is what preserves definition-time checking for undefined
+    ///   references inside deferred bodies (a not-yet-called action/handler stores
+    ///   its body without evaluating it, so execution would not catch the typo);
+    ///   it also keeps the fallback consistent with the full-analysis path, which
+    ///   likewise treats a name absent from the session as a genuine error.
     ///
     /// The one self-contained fatal that does *not* rely on the analyzer here —
     /// insecure RNG seeding (`ANALYZE-SECURITY`) — is enforced ahead of this by
@@ -697,33 +703,55 @@ impl ReplState {
             if Self::is_repl_ignorable_semantic(diagnostic) {
                 continue;
             }
-            messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
-            if diagnostic.severity == Severity::Error
-                && !Self::is_context_dependent_name_resolution(diagnostic)
+            // Drop an undefined-name diagnostic only when that name is actually a
+            // live earlier-session binding (a false positive from losing the
+            // prefix): don't report noise, don't block. A name NOT in the session
+            // is a genuine undefined reference and falls through to fatal — which
+            // keeps a typo inside a not-yet-called action/handler body caught at
+            // definition time, since execution won't validate a stored-but-unrun
+            // body.
+            if let Some(name) = Self::undefined_name_of(diagnostic)
+                && self.interpreter.global_env().borrow().has(name)
             {
+                continue;
+            }
+            messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
+            if diagnostic.severity == Severity::Error {
                 fatal = true;
             }
         }
         fatal
     }
 
-    /// A semantic diagnostic whose validity depends on names defined earlier in
-    /// the session: an undefined variable/action/handler/list reference. When a
-    /// submission is analysed alone (the isolated fallback), such a name may be
-    /// defined on an earlier line we cannot see, so the "undefined" is potentially
-    /// a false positive and must not block. Every *other* semantic error is
-    /// self-contained — present regardless of the earlier lines — and stays fatal.
-    ///
-    /// In `static_check_submission` the earlier lines ARE in scope, so an
-    /// undefined name there is genuine and blocks; this downgrade is specific to
-    /// the isolated fallback.
-    fn is_context_dependent_name_resolution(diagnostic: &WflDiagnostic) -> bool {
-        diagnostic.code == "ANALYZE-SEMANTIC"
-            && ((diagnostic.message.starts_with("Variable '")
-                && diagnostic.message.ends_with("' is not defined"))
-                || diagnostic.message.starts_with("Undefined action '")
-                || diagnostic.message.starts_with("Undefined signal handler '")
-                || diagnostic.message.starts_with("Undefined list reference '"))
+    /// If `diagnostic` is a context-dependent undefined-name error (an undefined
+    /// variable/action/handler/list reference), return the referenced name;
+    /// otherwise `None`. The isolated fallback uses this to check the name against
+    /// the live session environment: a name the session actually holds is a false
+    /// positive (skip it), while any other name — or any non-name-resolution
+    /// error — stays fatal.
+    fn undefined_name_of(diagnostic: &WflDiagnostic) -> Option<&str> {
+        if diagnostic.code != "ANALYZE-SEMANTIC" {
+            return None;
+        }
+        let message = diagnostic.message.as_str();
+        message
+            .strip_prefix("Variable '")
+            .and_then(|rest| rest.strip_suffix("' is not defined"))
+            .or_else(|| {
+                message
+                    .strip_prefix("Undefined action '")
+                    .and_then(|rest| rest.strip_suffix('\''))
+            })
+            .or_else(|| {
+                message
+                    .strip_prefix("Undefined signal handler '")
+                    .and_then(|rest| rest.strip_suffix('\''))
+            })
+            .or_else(|| {
+                message
+                    .strip_prefix("Undefined list reference '")
+                    .and_then(|rest| rest.strip_suffix("' in pattern"))
+            })
     }
 
     /// A diagnostic belongs to the new submission when it sits on a line after
@@ -1172,25 +1200,73 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fallback_downgrades_earlier_session_reference_but_does_not_block() {
+    async fn fallback_does_not_block_reference_to_a_live_earlier_session_binding() {
         // In the isolated fallback we can't see earlier submissions, so a
-        // reference to an earlier-session variable looks "undefined". That is
-        // context-dependent, so it must be downgraded to advisory (not block) —
-        // the interpreter resolves it against the live session. This keeps
-        // cross-line references working even in the degraded fallback, while
-        // self-contained fatal errors (see the security tests) still block.
+        // reference to an earlier-session variable looks "undefined". But the name
+        // IS a live session binding, so the diagnostic is a false positive: it is
+        // dropped (no noise, no block) and cross-line references keep working even
+        // in the degraded fallback, while self-contained fatal errors (see the
+        // security tests) and genuine typos still block.
         let mut repl = ReplState::new();
         assert_eq!(
             repl.process_line("store greeting as \"hi\"").await.unwrap(),
             None
         );
         repl.max_session_analysis_bytes = 1; // force the isolated fallback
-        // Referencing the earlier-session variable must still execute (the
-        // name-resolution diagnostic is advisory, not a block).
-        let _ = repl.process_line("store echoed as greeting").await.unwrap();
+        // Referencing the earlier-session variable must run cleanly with no error.
+        assert_eq!(
+            repl.process_line("store echoed as greeting").await.unwrap(),
+            None,
+            "a live earlier-session reference must not error in the isolated fallback"
+        );
+        assert!(repl.interpreter.global_env().borrow().has("echoed"));
+    }
+
+    #[tokio::test]
+    async fn fallback_blocks_undefined_reference_inside_a_deferred_action_body() {
+        // Maintainer review (head 52c16b2): defining an action stores its body
+        // WITHOUT running it, so a genuine typo inside the body is not validated
+        // by execution. In the isolated fallback the undefined name must therefore
+        // still be fatal at definition time — the name is absent from the live
+        // session, so it is a real error, not a lost cross-line reference.
+        let mut repl = ReplState::new();
+        repl.max_session_analysis_bytes = 1; // force the isolated fallback
+        for line in ["define action called broken:", "display genuinely_missing"] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        let out =
+            repl.process_line("end action").await.unwrap().expect(
+                "an undefined reference in a deferred body must block, even in the fallback",
+            );
         assert!(
-            repl.interpreter.global_env().borrow().has("echoed"),
-            "an earlier-session reference must not block in the isolated fallback"
+            out.contains("genuinely_missing") && out.to_lowercase().contains("defined"),
+            "expected an undefined-name error, got: {out}"
+        );
+        // Blocked: the invalid definition was not accepted.
+        assert!(!repl.interpreter.global_env().borrow().has("broken"));
+    }
+
+    #[tokio::test]
+    async fn fallback_allows_action_referencing_a_valid_earlier_session_binding() {
+        // The companion to the previous test: an action body that references a
+        // name defined on an EARLIER line is valid — the live session holds it, so
+        // the fallback must accept the definition rather than block it.
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store greeting as \"hi\"").await.unwrap(),
+            None
+        );
+        repl.max_session_analysis_bytes = 1; // force the isolated fallback
+        for line in [
+            "define action called sayit:",
+            "display greeting",
+            "end action",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        assert!(
+            repl.interpreter.global_env().borrow().has("sayit"),
+            "an action referencing a live earlier-session binding must be accepted in the fallback"
         );
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -552,8 +552,17 @@ impl ReplState {
         // command. `join("\n")` over the prefix is `sum(len) + (count - 1)` bytes,
         // and the combined source adds a separator plus `input`, so its length is
         // exactly `sum(len_i + 1) + input.len()` when the session is non-empty.
+        //
+        // Also never lex a combined source larger than the user's configured
+        // `max_source_bytes`: that ceiling bounds how much source any one program
+        // may process, and the accumulated session IS the program being analysed
+        // here. The isolated fallback only sees this submission, which already
+        // passed the `max_source_bytes` check in `process_complete_input`.
+        let cap = self
+            .max_session_analysis_bytes
+            .min(self.interpreter.budget().max_source_bytes());
         let prefix_bytes: usize = self.session_inputs.iter().map(|s| s.len() + 1).sum();
-        if prefix_bytes + input.len() > self.max_session_analysis_bytes {
+        if prefix_bytes + input.len() > cap {
             return self.static_check_isolated(program, reporter, file_id, messages);
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -580,14 +580,23 @@ impl ReplState {
             )
         };
 
+        // The checked lexer only fails on a budget breach (deadline /
+        // cancellation / operation ceiling), never on a token error — so a lex
+        // failure here is fatal for the command, exactly as it is at entry in
+        // `process_complete_input`. Surface it instead of falling through to
+        // execute the submission with the budget already spent.
+        let tokens = match lex_wfl_with_positions_checked(&combined) {
+            Ok(tokens) => tokens,
+            Err(exceeded) => {
+                messages.push(format!("Error: {}", exceeded.message()));
+                return true;
+            }
+        };
         // Each prior submission parsed on its own, so the concatenation parses
         // too; if it somehow does not, fall back to analysing this submission
         // alone (no earlier-line context; its diagnostics are reported but
         // advisory — never blocking, so a dropped cross-line contract can't turn
         // into a false fatal).
-        let Ok(tokens) = lex_wfl_with_positions_checked(&combined) else {
-            return self.static_check_isolated(program, reporter, file_id, messages);
-        };
         let mut parser = Parser::new(&tokens);
         let Ok(combined_program) = parser.parse() else {
             return self.static_check_isolated(program, reporter, file_id, messages);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -208,15 +208,44 @@ impl ReplState {
             || (message.contains("expected 'end") && !message.contains("found"))
     }
 
+    /// Clamp a byte-offset span onto valid UTF-8 char boundaries within
+    /// `source`. Spans index the source `String`; a `start + 1` end (produced by
+    /// the `convert_*` helpers and the synthesized-label path alike) can land in
+    /// the middle of a multi-byte character, and codespan then slices a
+    /// non-char-boundary range and panics. This snaps `start` down and `end` up
+    /// to the enclosing character (widening never shrinking), covering the last
+    /// character when the offset was at EOF.
+    fn snap_span_to_char_boundaries(source: &str, span: Span) -> Span {
+        let len = source.len();
+        let mut start = span.start.min(len);
+        let mut end = span.end.min(len).max(start);
+        if start == end {
+            // Empty span: cover one character so the caret is visible. At EOF
+            // there is nothing to the right, so step back onto the last char.
+            if start == len && len > 0 {
+                start -= 1;
+            } else if end < len {
+                end += 1;
+            }
+        }
+        while start > 0 && !source.is_char_boundary(start) {
+            start -= 1;
+        }
+        while end < len && !source.is_char_boundary(end) {
+            end += 1;
+        }
+        Span { start, end }
+    }
+
     /// Render one WFL diagnostic to a coloured, Elm-style block (source
     /// snippet, caret, and note), returning the string the REPL prints.
     ///
-    /// Parse/type/runtime diagnostics already carry a labelled span, so they
-    /// render with a caret as-is. Analyzer diagnostics only carry a
-    /// line/column, so a one-character span is synthesized from it here — that
-    /// way *every* REPL diagnostic follows the same "point at the source"
-    /// convention (WFL Fundamental #4: clear, actionable errors) instead of
-    /// some showing a bare message with no location.
+    /// Parse/type/runtime diagnostics already carry a labelled span; analyzer
+    /// diagnostics only carry a line/column, so a span is synthesized from it —
+    /// that way *every* REPL diagnostic follows the same "point at the source"
+    /// convention (WFL Fundamental #4: clear, actionable errors). Every label
+    /// span (synthesized or pre-existing) is then snapped to UTF-8 char
+    /// boundaries so codespan never slices mid-codepoint on multi-byte source.
     fn render_diagnostic(
         reporter: &mut DiagnosticReporter,
         file_id: usize,
@@ -226,35 +255,26 @@ impl ReplState {
         if diag.labels.is_empty()
             && diag.line >= 1
             && let Some(offset) = reporter.line_col_to_offset(file_id, diag.line, diag.column)
-            && let Ok(file) = reporter.files.get(file_id)
         {
-            // Build a one-character span that stays on UTF-8 char boundaries.
-            // Spans are byte offsets into the source `String`; a `start + 1`
-            // (or an EOF clamp) can land in the middle of a multi-byte
-            // character, and codespan then slices a non-char-boundary range and
-            // panics. Snap `start` down and `end` up to the enclosing character
-            // so the caret always underlines a whole char.
+            diag.labels.push((
+                Span {
+                    start: offset,
+                    end: offset + 1,
+                },
+                "here".to_string(),
+            ));
+        }
+
+        // Normalize ALL label spans (synthesized or from `convert_*`) to valid
+        // char boundaries, then drop any that collapse to empty (e.g. an empty
+        // source) so they never render a zero-width caret.
+        if let Ok(file) = reporter.files.get(file_id) {
             let source = file.source();
-            let len = source.len();
-            let mut start = offset.min(len);
-            // `line_col_to_offset` may return an offset at EOF (one past the
-            // last byte). There is no character to the right there, so step back
-            // onto the last character so the caret still points at the source
-            // instead of vanishing.
-            if start == len && len > 0 {
-                start -= 1;
-            }
-            while start > 0 && !source.is_char_boundary(start) {
-                start -= 1;
-            }
-            let mut end = (start + 1).min(len);
-            while end < len && !source.is_char_boundary(end) {
-                end += 1;
-            }
-            if start < end {
-                diag.labels.push((Span { start, end }, "here".to_string()));
+            for (span, _) in diag.labels.iter_mut() {
+                *span = Self::snap_span_to_char_boundaries(source, *span);
             }
         }
+        diag.labels.retain(|(span, _)| span.start < span.end);
 
         let mut buffer = Buffer::ansi();
         let config = term::Config::default();
@@ -947,6 +967,25 @@ mod tests {
         assert!(
             rendered.contains("unreachable code") && rendered.contains("repl:1:"),
             "expected a caret-rendered diagnostic, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_diagnostic_snaps_preexisting_label_span_to_char_boundaries() {
+        // Parse/type/runtime diagnostics arrive with a span already attached
+        // (from the `convert_*` helpers, typically `start..start + 1`). If that
+        // end lands mid-codepoint on multi-byte source, codespan panics — so the
+        // normalization must apply to pre-existing labels too, not only
+        // synthesized ones. "café" is 5 bytes; a 3..4 span splits the 2-byte 'é'.
+        let mut reporter = DiagnosticReporter::new();
+        let file_id = reporter.add_file("repl", "café");
+        let diag =
+            WflDiagnostic::error("boom").with_primary_label(Span { start: 3, end: 4 }, "here");
+        // Must not panic and must still carry the message.
+        let rendered = ReplState::render_diagnostic(&mut reporter, file_id, &diag);
+        assert!(
+            rendered.contains("boom"),
+            "expected the message in the rendered diagnostic, got: {rendered}"
         );
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -6,6 +6,7 @@ use crate::interpreter::Interpreter;
 use crate::interpreter::value::Value;
 use crate::lexer::{lex_wfl_with_positions_checked, token::TokenWithPosition};
 use crate::parser::{Parser, ast::Statement};
+use crate::typechecker::{TypeCheckError, TypeChecker, TypeError};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::Buffer;
 use rustyline::error::ReadlineError;
@@ -25,6 +26,13 @@ pub struct ReplState {
     input_buffer: String,
     in_multiline: bool,
     history: Vec<String>,
+    /// Every submission that passed static analysis and was executed this
+    /// session, in order. Re-analysing `session_inputs + new submission` as one
+    /// program is what lets the (otherwise whole-program) analyzer and type
+    /// checker see names, actions, and their declared types from earlier lines,
+    /// so cross-line references resolve and cross-line type/security contracts
+    /// are still enforced — the interpreter alone cannot do the latter.
+    session_inputs: Vec<String>,
 }
 
 impl Default for ReplState {
@@ -57,6 +65,7 @@ impl ReplState {
             input_buffer: String::new(),
             in_multiline: false,
             history: Vec::new(),
+            session_inputs: Vec::new(),
         }
     }
 
@@ -310,57 +319,25 @@ impl ReplState {
         // Messages accumulated across the analysis and run phases.
         let mut messages: Vec<String> = Vec::new();
 
-        // --- Static analysis -------------------------------------------------
-        // The REPL keeps ONE persistent interpreter for the whole session, but
-        // the analyzer and type checker are whole-program tools that only ever
-        // see this single line. Some of their diagnostics are false positives
-        // against the live session; others are perfectly valid. So they are
-        // filtered by diagnostic code, not blanket-dropped:
-        //
-        //   * `ANALYZE-SEMANTIC` — context-dependent name resolution (undefined
-        //     name, "not an action", already-defined, undefined-inside-`try`).
-        //     A name defined on an earlier line looks undefined here, so these
-        //     are dropped: the interpreter, which owns the real environment,
-        //     re-checks them at run time and reports genuine ones (this is what
-        //     made `display x` after `store x as 5` wrongly fail).
-        //   * `ANALYZE-UNUSED` — a stored binding is available to the next line,
-        //     so "unused" is always a false positive interactively. Dropped.
-        //   * everything else is *self-contained* within the single line and is
-        //     kept exactly as `wfl <file>` treats it: advisory warnings
-        //     (unreachable code, dead branch, shadowing, inconsistent returns)
-        //     are shown, and any error — notably the `ANALYZE-SECURITY` lint for
-        //     seeding the RNG in crypto/auth code — is shown AND blocks
-        //     execution. Such lints depend only on this line's own code, never
-        //     on session state, so there is no reason to weaken them.
-        //
-        // The type checker is skipped because its diagnostics are the same
-        // context-dependent name/type kind that would be noise on every line
-        // referring back to the session.
-        let mut analyzer = Analyzer::new();
-        let mut has_fatal_error = false;
-        for diagnostic in &analyzer.analyze_static(&program, file_id) {
-            if matches!(
-                diagnostic.code.as_str(),
-                "ANALYZE-SEMANTIC" | "ANALYZE-UNUSED"
-            ) {
-                continue;
-            }
-            messages.push(Self::render_diagnostic(&mut reporter, file_id, diagnostic));
-            if diagnostic.severity == Severity::Error {
-                has_fatal_error = true;
-            }
-        }
-        // A self-contained fatal analysis error (e.g. a security-policy
-        // violation) must stop the command before it runs, just like the CLI.
-        if has_fatal_error {
+        // --- Session-aware static analysis -----------------------------------
+        // Run the SAME analyze -> type-check -> execute pipeline `wfl <file>`
+        // uses, but over `session_inputs + this submission` as one program, so
+        // names/actions/types defined on earlier lines are in scope. Only this
+        // submission's diagnostics are reported (see `static_check_submission`).
+        // A genuine semantic error (undefined name, insecure `random_seed`
+        // seeding, an undefined reference inside an action body) blocks
+        // execution just as it aborts a file; type diagnostics are advisory, as
+        // in the file pipeline.
+        if self.static_check_submission(input, &mut reporter, file_id, &mut messages) {
             return Ok(Some(messages.join("\n")));
         }
 
         // --- Execution -------------------------------------------------------
-        // Run the WHOLE program (so every statement's side effects happen), and
-        // echo the final value only when the last statement is a bare
-        // expression — `interpret` returns the value of the last executed
-        // statement. `store`/`change`/`display` statements produce no echo.
+        // Execute ONLY this submission — the earlier submissions already ran
+        // against the persistent interpreter, so re-running them would repeat
+        // their output and side effects. Echo the final value only when the last
+        // statement is a bare expression (`interpret` returns the value of the
+        // last executed statement); `store`/`change`/`display` produce no echo.
         let echo_value = matches!(
             program.statements.last(),
             Some(Statement::ExpressionStatement { .. })
@@ -388,11 +365,185 @@ impl ReplState {
             }
         }
 
+        // This submission passed static analysis and was executed, so it is now
+        // part of the session's static context for later submissions. (Kept even
+        // if execution hit a runtime error: the definitions it introduced were
+        // statically valid, and re-analysing them keeps later lines' references
+        // resolvable — a stray runtime failure still surfaces at run time.)
+        self.session_inputs.push(input.to_string());
+
         if messages.is_empty() {
             Ok(None)
         } else {
             Ok(Some(messages.join("\n")))
         }
+    }
+
+    /// Analyse `session_inputs + submission` as a single program and report only
+    /// the diagnostics that fall inside the new submission, translated back to
+    /// the submission's own line numbers. Returns `true` when a fatal error was
+    /// found (the submission must not run).
+    ///
+    /// This is what makes REPL static analysis session-aware: a variable/action
+    /// defined on an earlier line is in scope, so it is not a false "undefined";
+    /// and self-contained contracts the interpreter cannot enforce — the
+    /// insecure-RNG security lint, undefined references inside a not-yet-called
+    /// action body, cross-line type mismatches — are still checked. Semantic
+    /// errors are fatal (as they abort a file); type diagnostics are advisory
+    /// (as the file pipeline prints them and continues).
+    fn static_check_submission(
+        &self,
+        input: &str,
+        reporter: &mut DiagnosticReporter,
+        file_id: usize,
+        messages: &mut Vec<String>,
+    ) -> bool {
+        // Build the accumulated source and the line at which `input` begins in
+        // it (0 when this is the first submission).
+        let prefix = self.session_inputs.join("\n");
+        let (combined, base_line) = if prefix.is_empty() {
+            (input.to_string(), 0usize)
+        } else {
+            (
+                format!("{prefix}\n{input}"),
+                prefix.matches('\n').count() + 1,
+            )
+        };
+
+        // Each prior submission parsed on its own, so the concatenation parses
+        // too; if it somehow does not, fall back to analysing this submission
+        // alone (no earlier-line context, warnings only — never a false fatal).
+        let Ok(tokens) = lex_wfl_with_positions_checked(&combined) else {
+            return self.static_check_isolated(input, reporter, file_id, messages);
+        };
+        let mut parser = Parser::new(&tokens);
+        let Ok(combined_program) = parser.parse() else {
+            return self.static_check_isolated(input, reporter, file_id, messages);
+        };
+
+        // A scratch file over the combined source. Diagnostics reference it, but
+        // are rendered against the caller's submission `reporter`/`file_id`
+        // after their line numbers are shifted back by `base_line`.
+        let mut combined_reporter = DiagnosticReporter::new();
+        let combined_file = combined_reporter.add_file("repl", &combined);
+
+        let mut analyzer = Analyzer::new();
+        let mut fatal = false;
+        for diagnostic in &analyzer.analyze_static(&combined_program, combined_file) {
+            if !Self::belongs_to_submission(diagnostic.line, base_line)
+                || Self::is_repl_ignorable_semantic(diagnostic)
+            {
+                continue;
+            }
+            let mut adjusted = diagnostic.clone();
+            adjusted.line = adjusted.line.saturating_sub(base_line);
+            messages.push(Self::render_diagnostic(reporter, file_id, &adjusted));
+            if adjusted.severity == Severity::Error {
+                fatal = true;
+            }
+        }
+        // A fatal semantic error aborts before type checking, exactly as a file.
+        if fatal {
+            return true;
+        }
+
+        // Type checking is advisory in the file pipeline (`wfl <file>` prints
+        // type diagnostics and keeps going); mirror that here. A shared-budget
+        // breach is still fatal.
+        let mut type_checker = TypeChecker::with_analyzer(analyzer);
+        if let Err(failure) = type_checker.check_types(&combined_program) {
+            match failure {
+                TypeCheckError::Budget(exceeded) => {
+                    messages.push(format!("Error: {}", exceeded.message()));
+                    return true;
+                }
+                TypeCheckError::Types(errors) => {
+                    let action_params = type_checker.get_action_parameters().clone();
+                    for error in &errors {
+                        if !Self::belongs_to_submission(error.line, base_line)
+                            || Self::is_repl_ignorable_type_error(error, &action_params)
+                        {
+                            continue;
+                        }
+                        let mut adjusted = error.clone();
+                        adjusted.line = adjusted.line.saturating_sub(base_line);
+                        let diagnostic = reporter.convert_type_error(file_id, &adjusted);
+                        messages.push(Self::render_diagnostic(reporter, file_id, &diagnostic));
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Fallback used only if the accumulated source unexpectedly fails to parse:
+    /// analyse the submission alone. Without earlier-line context every
+    /// cross-line reference would look undefined, so this reports advisory
+    /// warnings only and never blocks — the interpreter still catches genuine
+    /// errors at run time. Returns `false` (never fatal).
+    fn static_check_isolated(
+        &self,
+        input: &str,
+        reporter: &mut DiagnosticReporter,
+        file_id: usize,
+        messages: &mut Vec<String>,
+    ) -> bool {
+        let Ok(tokens) = lex_wfl_with_positions_checked(input) else {
+            return false;
+        };
+        let mut parser = Parser::new(&tokens);
+        let Ok(program) = parser.parse() else {
+            return false;
+        };
+        let mut scratch = DiagnosticReporter::new();
+        let scratch_file = scratch.add_file("repl", input);
+        let mut analyzer = Analyzer::new();
+        for diagnostic in &analyzer.analyze_static(&program, scratch_file) {
+            if diagnostic.severity == Severity::Warning
+                && !Self::is_repl_ignorable_semantic(diagnostic)
+            {
+                messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
+            }
+        }
+        false
+    }
+
+    /// A diagnostic belongs to the new submission when it sits on a line after
+    /// the accumulated prefix. Position-less diagnostics (line 0) are kept so a
+    /// genuine but unlocated error is never silently dropped.
+    fn belongs_to_submission(line: usize, base_line: usize) -> bool {
+        line == 0 || line > base_line
+    }
+
+    /// Semantic diagnostics that are correct for a file but wrong to enforce in
+    /// an interactive session.
+    fn is_repl_ignorable_semantic(diagnostic: &WflDiagnostic) -> bool {
+        // "Unused" is a false positive interactively — a binding is available to
+        // a *future* submission. Re-`store`/re-defining a name is allowed in the
+        // REPL (the interpreter reassigns), so "already defined" must not block
+        // continuing the session.
+        diagnostic.code == "ANALYZE-UNUSED"
+            || diagnostic.message.contains("already been defined")
+            || diagnostic.message.contains("already defined")
+    }
+
+    /// Type diagnostics to drop in the REPL: the same action-parameter and
+    /// duplicate-symbol false positives `wfl <file>` filters, plus re-definition
+    /// (allowed interactively).
+    fn is_repl_ignorable_type_error(
+        error: &TypeError,
+        action_params: &std::collections::HashSet<String>,
+    ) -> bool {
+        if error.message.starts_with("Variable '") && error.message.ends_with("' is not defined") {
+            let name = error
+                .message
+                .trim_start_matches("Variable '")
+                .trim_end_matches("' is not defined");
+            if action_params.contains(name) {
+                return true;
+            }
+        }
+        error.message.contains("already been defined") || error.message.contains("already defined")
     }
 }
 
@@ -604,7 +755,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn undefined_variable_is_reported_as_a_runtime_error() {
+    async fn undefined_variable_is_reported() {
         let mut repl = ReplState::new();
         let out = repl
             .process_line("display genuinely_missing")
@@ -614,6 +765,137 @@ mod tests {
         assert!(
             out.contains("genuinely_missing") && out.to_lowercase().contains("defined"),
             "expected an undefined-variable error, got: {out}"
+        );
+    }
+
+    // --- Session-aware static analysis (maintainer review on PR #617) ------
+    // The REPL analyses `earlier submissions + this one` as one program, so the
+    // static checks the interpreter cannot do (security lint, definition-time
+    // reference checks, cross-line type contracts) still run, while genuine
+    // session definitions are not false "undefined".
+
+    #[tokio::test]
+    async fn insecure_rng_is_blocked_even_when_referencing_an_earlier_line_variable() {
+        // The security lint runs against the whole session, so referencing a
+        // variable defined on an earlier line no longer makes the analyzer bail
+        // before the lint (which was the reported gap).
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store note as \"session\"")
+                .await
+                .unwrap(),
+            None
+        );
+        for line in [
+            "define action called mk:",
+            "display note", // references the earlier-line variable
+            "random_seed of 1",
+            "give back secure_random_bytes of 16",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        let out = repl
+            .process_line("end action")
+            .await
+            .unwrap()
+            .expect("the security lint must still fire");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG error, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("mk"));
+    }
+
+    #[tokio::test]
+    async fn undefined_reference_inside_an_action_body_is_blocked_at_definition() {
+        // Defining an action stores its body without running it, so without
+        // definition-time validation a typo would only surface when the action
+        // is finally called. The analyzer must catch it now.
+        let mut repl = ReplState::new();
+        for line in [
+            "define action called broken:",
+            "display misspelled_variable",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        let out = repl
+            .process_line("end action")
+            .await
+            .unwrap()
+            .expect("an undefined reference in the body must be reported");
+        assert!(
+            out.contains("misspelled_variable") && out.to_lowercase().contains("defined"),
+            "expected an undefined-variable error, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("broken"));
+    }
+
+    #[tokio::test]
+    async fn earlier_session_variable_is_usable_inside_a_definition() {
+        // The converse of the previous test: a reference that *is* defined on an
+        // earlier line must resolve, so the definition is accepted and runs.
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store greeting as \"hello\"")
+                .await
+                .unwrap(),
+            None
+        );
+        for line in [
+            "define action called sayit:",
+            "display greeting",
+            "end action",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        assert!(repl.interpreter.global_env().borrow().has("sayit"));
+        // And calling it runs cleanly (no "not defined").
+        assert_eq!(repl.process_line("call sayit").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn self_recursive_action_is_accepted() {
+        // The action's own name is in scope inside its body (signature pass), so
+        // a self-reference is not a false "undefined" at definition time.
+        let mut repl = ReplState::new();
+        for line in [
+            "define action called countdown with n:",
+            "call countdown with n",
+            "end action",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        assert!(repl.interpreter.global_env().borrow().has("countdown"));
+    }
+
+    #[tokio::test]
+    async fn cross_line_type_mismatch_is_surfaced() {
+        // The type checker sees `n: Number` from the earlier line, so assigning
+        // text to it is reported — advisory, matching the `wfl <file>` pipeline,
+        // so the command still runs.
+        let mut repl = ReplState::new();
+        assert_eq!(repl.process_line("store n as 5").await.unwrap(), None);
+        let out = repl
+            .process_line("change n to \"hello\"")
+            .await
+            .unwrap()
+            .expect("a cross-line type mismatch must be surfaced");
+        assert!(
+            out.contains("incompatible") && out.contains("Number"),
+            "expected an incompatible-assignment type error, got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn re_storing_a_variable_is_allowed() {
+        // Re-defining a name is normal in a REPL (the interpreter reassigns), so
+        // the file-only "already defined" error must not block continuation.
+        let mut repl = ReplState::new();
+        assert_eq!(repl.process_line("store x as 5").await.unwrap(), None);
+        assert_eq!(repl.process_line("store x as 10").await.unwrap(), None);
+        assert_eq!(
+            repl.process_line("x").await.unwrap(),
+            Some("10".to_string())
         );
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1280,6 +1280,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fallback_blocks_undefined_action_call_inside_a_deferred_body() {
+        // The same guarantee for an undefined *action call* (not just a variable
+        // reference) inside a stored action body: the env check keys on the name,
+        // not on its syntactic role, so a call to a nonexistent action in a body
+        // is fatal at definition time even on the fallback path.
+        let mut repl = ReplState::new();
+        repl.max_session_analysis_bytes = 1; // force the isolated fallback
+        for line in ["define action called caller:", "call ghost_action"] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        let out = repl
+            .process_line("end action")
+            .await
+            .unwrap()
+            .expect("an undefined action call in a deferred body must block in the fallback");
+        assert!(
+            out.contains("ghost_action"),
+            "expected an undefined-action error, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("caller"));
+    }
+
+    #[tokio::test]
+    async fn fallback_allows_earlier_session_action_call_inside_a_deferred_body() {
+        // The valid companion: a body that CALLS an action defined on an earlier
+        // line is accepted in the fallback — the callee is a live session binding,
+        // so the "undefined action" false positive is dropped, not blocked.
+        let mut repl = ReplState::new();
+        for line in [
+            "define action called helper:",
+            "display \"hi\"",
+            "end action",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        assert!(repl.interpreter.global_env().borrow().has("helper"));
+        repl.max_session_analysis_bytes = 1; // force the isolated fallback
+        for line in ["define action called caller:", "call helper", "end action"] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        assert!(
+            repl.interpreter.global_env().borrow().has("caller"),
+            "a body calling a live earlier-session action must be accepted in the fallback"
+        );
+    }
+
+    #[tokio::test]
     async fn undefined_reference_inside_an_action_body_is_blocked_at_definition() {
         // Defining an action stores its body without running it, so without
         // definition-time validation a typo would only surface when the action

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -661,14 +661,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn multiline_if_block_runs_only_once_closed() {
+    async fn multiline_if_block_buffers_across_lines_and_runs_on_close() {
         let mut repl = ReplState::new();
+        // Opener and body are buffered — the REPL waits and runs nothing yet.
         assert_eq!(repl.process_line("check if yes:").await.unwrap(), None);
         assert!(repl.in_multiline, "REPL should be waiting for more input");
-        assert_eq!(repl.process_line("display \"inside\"").await.unwrap(), None);
+        assert_eq!(
+            repl.process_line("store inside_block as 7").await.unwrap(),
+            None
+        );
         assert!(repl.in_multiline);
-        // Closing the block completes the buffered input and clears multiline.
-        repl.process_line("end check").await.unwrap();
+        assert!(
+            !repl.interpreter.global_env().borrow().has("inside_block"),
+            "the buffered block must not run before it is closed"
+        );
+        // Closing the block completes the buffered input and runs it once,
+        // cleanly (no error → `Ok(None)`), which defines the block's variable.
+        assert_eq!(repl.process_line("end check").await.unwrap(), None);
         assert!(!repl.in_multiline, "block is closed, multiline should end");
+        assert!(
+            repl.interpreter.global_env().borrow().has("inside_block"),
+            "closing the block should execute its body exactly once"
+        );
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -365,11 +365,16 @@ impl ReplState {
             }
         }
 
-        // This submission passed static analysis and was executed, so it is now
-        // part of the session's static context for later submissions. (Kept even
-        // if execution hit a runtime error: the definitions it introduced were
-        // statically valid, and re-analysing them keeps later lines' references
-        // resolvable — a stray runtime failure still surfaces at run time.)
+        // This submission passed static analysis and was executed, so it joins
+        // the session's static context for later submissions. It is recorded on
+        // execution *attempt*, not only on success, on purpose: recording only
+        // fully-successful submissions would drop the bindings a partially-run
+        // construct DID establish in the interpreter, so a later reference to
+        // one would be wrongly reported as "undefined" — reintroducing exactly
+        // the false-positive blocking this change removes. The opposite drift (a
+        // fully-failed `store` whose binding never took effect is still "known"
+        // to later analysis) is benign: the reference simply raises a clear
+        // undefined error at run time rather than being blocked.
         self.session_inputs.push(input.to_string());
 
         if messages.is_empty() {
@@ -398,8 +403,10 @@ impl ReplState {
         file_id: usize,
         messages: &mut Vec<String>,
     ) -> bool {
-        // Build the accumulated source and the line at which `input` begins in
-        // it (0 when this is the first submission).
+        // Build the accumulated source. `base_line` is the number of lines in
+        // the prefix (0 for the first submission), so the new submission's first
+        // line sits at `base_line + 1` in the combined source — the offset used
+        // to keep only this submission's diagnostics and shift them back.
         let prefix = self.session_inputs.join("\n");
         let (combined, base_line) = if prefix.is_empty() {
             (input.to_string(), 0usize)
@@ -409,6 +416,16 @@ impl ReplState {
                 prefix.matches('\n').count() + 1,
             )
         };
+
+        // Re-analysing the whole session each command is O(n²) over its length.
+        // A per-command budget deadline already bounds the work, but cap the
+        // accumulated source at a generous size so a pathologically long session
+        // degrades to analysing just this submission (warnings only) instead of
+        // getting slow. Realistic interactive sessions never approach this.
+        const MAX_SESSION_ANALYSIS_BYTES: usize = 256 * 1024;
+        if combined.len() > MAX_SESSION_ANALYSIS_BYTES {
+            return self.static_check_isolated(input, reporter, file_id, messages);
+        }
 
         // Each prior submission parsed on its own, so the concatenation parses
         // too; if it somehow does not, fall back to analysing this submission

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -221,15 +221,20 @@ impl ReplState {
         {
             // Build a one-character span that stays on UTF-8 char boundaries.
             // Spans are byte offsets into the source `String`; a `start + 1`
-            // (or an EOF clamp of `len - 1`) can land in the middle of a
-            // multi-byte character, and codespan then slices a non-char-boundary
-            // range and panics. Snap `start` down and `end` up to the enclosing
-            // character so the caret always underlines a whole char. Also
-            // guards the EOF case, where `line_col_to_offset` may return an
-            // offset one past the last byte.
+            // (or an EOF clamp) can land in the middle of a multi-byte
+            // character, and codespan then slices a non-char-boundary range and
+            // panics. Snap `start` down and `end` up to the enclosing character
+            // so the caret always underlines a whole char.
             let source = file.source();
             let len = source.len();
             let mut start = offset.min(len);
+            // `line_col_to_offset` may return an offset at EOF (one past the
+            // last byte). There is no character to the right there, so step back
+            // onto the last character so the caret still points at the source
+            // instead of vanishing.
+            if start == len && len > 0 {
+                start -= 1;
+            }
             while start > 0 && !source.is_char_boundary(start) {
                 start -= 1;
             }
@@ -634,11 +639,38 @@ mod tests {
             4,
             None,
         );
-        // Must not panic, and must still carry the message.
+        // Must not panic, must carry the message, and must render the caret
+        // (the source-location header) rather than the caret-less fallback.
         let rendered = ReplState::render_diagnostic(&mut reporter, file_id, &diag);
         assert!(
-            rendered.contains("unreachable code"),
-            "expected the message in the rendered diagnostic, got: {rendered}"
+            rendered.contains("unreachable code") && rendered.contains("repl:1:"),
+            "expected a caret-rendered diagnostic, got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_diagnostic_points_at_source_even_at_eof() {
+        // A diagnostic whose column lands at EOF (one past the last byte) must
+        // still get a caret on the last character, not render caret-less.
+        let mut reporter = DiagnosticReporter::new();
+        let file_id = reporter.add_file("repl", "hi");
+        let diag = WflDiagnostic::new(
+            Severity::Warning,
+            "watch out",
+            None::<String>,
+            "ANALYZE-SHADOW",
+            file_id,
+            1,
+            3, // column past the last character of "hi"
+            None,
+        );
+        let rendered = ReplState::render_diagnostic(&mut reporter, file_id, &diag);
+        // A caret label makes codespan emit the source-location header
+        // (`repl:1:2`, pointing at the last character); without a label the
+        // message would render alone with no location.
+        assert!(
+            rendered.contains("repl:1:"),
+            "expected a caret pointing at the source at EOF, got: {rendered}"
         );
     }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,14 +1,11 @@
 use crate::analyzer::Analyzer;
 use crate::analyzer::static_analyzer::StaticAnalyzer;
-use crate::diagnostics::DiagnosticReporter;
+use crate::diagnostics::{DiagnosticReporter, Severity, Span, WflDiagnostic};
 use crate::exec::budget::ExecutionBudget;
 use crate::interpreter::Interpreter;
+use crate::interpreter::value::Value;
 use crate::lexer::{lex_wfl_with_positions_checked, token::TokenWithPosition};
-use crate::parser::{
-    Parser,
-    ast::{Program, Statement},
-};
-use crate::typechecker::{TypeCheckError, TypeChecker};
+use crate::parser::{Parser, ast::Statement};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::Buffer;
 use rustyline::error::ReadlineError;
@@ -174,11 +171,83 @@ impl ReplState {
 
         let mut parser = Parser::new(tokens);
         match parser.parse() {
-            Err(errors) => errors.iter().any(|e| {
-                e.message.contains("Unexpected end of input")
-                    || (e.message.contains("expected") && e.message.contains("end"))
-            }),
+            Err(errors) => errors.iter().any(Self::error_means_more_input_needed),
             Ok(_) => false, // Successfully parsed, input is complete
+        }
+    }
+
+    /// Decide whether a parse error means "keep reading — the user is
+    /// mid-construct" rather than "this is genuinely wrong".
+    ///
+    /// The parser has no single "unexpected EOF" error type; each construct
+    /// phrases running out of tokens in its own way ("Unexpected end of
+    /// input …", "…, found end of input", and — for action bodies — a bare
+    /// "Expected 'end' after action body" with no EOF marker at all). Matching
+    /// on those strings case-sensitively is what made `check if …:` and
+    /// `define action …:` blocks fail to continue onto the next line. Two
+    /// case-insensitive signals cover every block form:
+    ///   1. the parser explicitly ran out of tokens (`end of input`), or
+    ///   2. it is still waiting for a block terminator (`expected 'end`) and
+    ///      did **not** stop on a concrete token (no `found …`) — i.e. it hit
+    ///      EOF, so more lines can still complete the block.
+    ///
+    /// A real mid-stream mistake reports `… found <Token>` and is therefore
+    /// surfaced immediately instead of silently swallowed.
+    fn error_means_more_input_needed(error: &crate::parser::ast::ParseError) -> bool {
+        let message = error.message.to_lowercase();
+        message.contains("end of input")
+            || (message.contains("expected 'end") && !message.contains("found"))
+    }
+
+    /// Render one WFL diagnostic to a coloured, Elm-style block (source
+    /// snippet, caret, and note), returning the string the REPL prints.
+    ///
+    /// Parse/type/runtime diagnostics already carry a labelled span, so they
+    /// render with a caret as-is. Analyzer diagnostics only carry a
+    /// line/column, so a one-character span is synthesized from it here — that
+    /// way *every* REPL diagnostic follows the same "point at the source"
+    /// convention (WFL Fundamental #4: clear, actionable errors) instead of
+    /// some showing a bare message with no location.
+    fn render_diagnostic(
+        reporter: &mut DiagnosticReporter,
+        file_id: usize,
+        diagnostic: &WflDiagnostic,
+    ) -> String {
+        let mut diag = diagnostic.clone();
+        if diag.labels.is_empty()
+            && diag.line >= 1
+            && let Some(start) = reporter.line_col_to_offset(file_id, diag.line, diag.column)
+        {
+            diag.labels.push((
+                Span {
+                    start,
+                    end: start + 1,
+                },
+                "here".to_string(),
+            ));
+        }
+
+        let mut buffer = Buffer::ansi();
+        let config = term::Config::default();
+        match term::emit_to_write_style(
+            &mut buffer,
+            &config,
+            &reporter.files,
+            &diag.to_codespan_diagnostic(file_id),
+        ) {
+            Ok(()) => String::from_utf8_lossy(buffer.as_slice()).to_string(),
+            Err(_) => {
+                let severity = match diag.severity {
+                    Severity::Error => "error",
+                    Severity::Warning => "warning",
+                    Severity::Note => "note",
+                    Severity::Help => "help",
+                };
+                format!(
+                    "{severity}: {} (at line {}, column {})",
+                    diag.message, diag.line, diag.column
+                )
+            }
         }
     }
 
@@ -191,37 +260,26 @@ impl ReplState {
 
         let tokens = lex_wfl_with_positions_checked(input).map_err(|e| e.message())?;
 
+        let mut reporter = DiagnosticReporter::new();
+        let file_id = reporter.add_file("repl", input);
+
+        // --- Parse -----------------------------------------------------------
+        // A syntax error is genuinely fatal for this line: there is no AST to
+        // run. (Incomplete multiline input was already routed away by
+        // `is_input_incomplete`, so anything that reaches here is meant to be
+        // complete.)
         let mut parser = Parser::new(&tokens);
         let program = match parser.parse() {
             Ok(prog) => prog,
             Err(errors) => {
-                let mut error_messages = Vec::new();
-                let mut reporter = DiagnosticReporter::new();
-                let file_id = reporter.add_file("repl", input);
-
-                for error in &errors {
-                    let diagnostic = reporter.convert_parse_error(file_id, error);
-
-                    let mut buffer = Buffer::ansi();
-                    let config = term::Config::default();
-                    if let Err(_e) = term::emit_to_write_style(
-                        &mut buffer,
-                        &config,
-                        &reporter.files,
-                        &diagnostic.to_codespan_diagnostic(file_id),
-                    ) {
-                        error_messages.push(format!(
-                            "Parse error at line {}, column {}: {}",
-                            error.line, error.column, error.message
-                        ));
-                        continue;
-                    }
-
-                    let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                    error_messages.push(output);
-                }
-
-                return Ok(Some(error_messages.join("\n")));
+                let rendered: Vec<String> = errors
+                    .iter()
+                    .map(|error| {
+                        let diagnostic = reporter.convert_parse_error(file_id, error);
+                        Self::render_diagnostic(&mut reporter, file_id, &diagnostic)
+                    })
+                    .collect();
+                return Ok(Some(rendered.join("\n")));
             }
         };
 
@@ -229,171 +287,76 @@ impl ReplState {
             return Ok(None);
         }
 
+        // Messages accumulated across the analysis and run phases.
+        let mut messages: Vec<String> = Vec::new();
+
+        // --- Static analysis (advisory only) --------------------------------
+        // The REPL keeps ONE persistent interpreter for the whole session, but
+        // the analyzer and type checker are whole-program tools that only ever
+        // see this single line. A variable or action defined on an *earlier*
+        // line therefore looks "undefined" to them, and a bare `store x as 5`
+        // looks "unused" — both false positives against the live session. So
+        // the interpreter (which owns the real environment) is the source of
+        // truth for what is defined and what is an error, and static analysis
+        // is used here only for advisory WARNINGS that are self-contained
+        // within a single line (unreachable code, shadowing, insecure RNG
+        // seeding, inconsistent returns).
+        //
+        // Concretely: analyzer *errors* (undefined name, "not an action",
+        // already-defined, ...) are context-dependent and are re-checked by the
+        // interpreter at run time against the real environment — so they are
+        // NOT reported here (that is what made `display x` on the line after
+        // `store x as 5` wrongly fail). "Unused variable" warnings are likewise
+        // false positives in an interactive session and are suppressed. The
+        // type checker is skipped entirely for the same reason: its diagnostics
+        // are the same context-dependent kind and would be noise on every line
+        // that refers back to the session.
         let mut analyzer = Analyzer::new();
-        let mut reporter = DiagnosticReporter::new();
-        let file_id = reporter.add_file("repl", input);
-        let sema_diags = analyzer.analyze_static(&program, file_id);
-
-        if !sema_diags.is_empty() {
-            let mut error_messages = Vec::new();
-            for diagnostic in &sema_diags {
-                let mut buffer = Buffer::ansi();
-                let config = term::Config::default();
-                if let Err(_e) = term::emit_to_write_style(
-                    &mut buffer,
-                    &config,
-                    &reporter.files,
-                    &diagnostic.to_codespan_diagnostic(file_id),
-                ) {
-                    error_messages.push(format!("Semantic error: {}", diagnostic.message));
-                    continue;
-                }
-
-                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                error_messages.push(output);
+        for diagnostic in &analyzer.analyze_static(&program, file_id) {
+            let keep =
+                diagnostic.severity == Severity::Warning && diagnostic.code != "ANALYZE-UNUSED";
+            if keep {
+                messages.push(Self::render_diagnostic(&mut reporter, file_id, diagnostic));
             }
-
-            return Ok(Some(error_messages.join("\n")));
         }
 
-        let mut type_checker = TypeChecker::new();
-        if let Err(failure) = type_checker.check_types(&program) {
-            // A shared-budget breach (deadline/cancellation/resource) is fatal
-            // for this command and must not be rendered as an ordinary type
-            // diagnostic that the REPL might otherwise shrug off.
-            let errors = match failure {
-                TypeCheckError::Budget(exceeded) => {
-                    return Ok(Some(format!("Error: {}", exceeded.message())));
+        // --- Execution -------------------------------------------------------
+        // Run the WHOLE program (so every statement's side effects happen), and
+        // echo the final value only when the last statement is a bare
+        // expression — `interpret` returns the value of the last executed
+        // statement. `store`/`change`/`display` statements produce no echo.
+        let echo_value = matches!(
+            program.statements.last(),
+            Some(Statement::ExpressionStatement { .. })
+        );
+        match self.interpreter.interpret(&program).await {
+            Ok(value) => {
+                // Suppress the echo for void results (`nothing`/null) so a call
+                // to an action that only has side effects — e.g. `call greet
+                // with "World"` — does not print a stray `null` under its output.
+                //
+                // Echo with `Display`, not `Debug`, so the value reads the way
+                // WFL itself presents it (`yes`/`no` for booleans, unquoted
+                // text, `[1, 2, 3]` for lists) — consistent with `display` and
+                // WFL's natural-language principle, instead of Rust's `"..."`
+                // / `true` debug spelling.
+                if echo_value && !matches!(value, Value::Nothing | Value::Null) {
+                    messages.push(format!("{value}"));
                 }
-                TypeCheckError::Types(errors) => errors,
-            };
-            let mut error_messages = Vec::new();
-            for error in &errors {
-                let diagnostic = reporter.convert_type_error(file_id, error);
-
-                let mut buffer = Buffer::ansi();
-                let config = term::Config::default();
-                if let Err(_e) = term::emit_to_write_style(
-                    &mut buffer,
-                    &config,
-                    &reporter.files,
-                    &diagnostic.to_codespan_diagnostic(file_id),
-                ) {
-                    error_messages.push(format!("Type error: {error}"));
-                    continue;
-                }
-
-                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                error_messages.push(output);
             }
-
-            return Ok(Some(error_messages.join("\n")));
+            Err(errors) => {
+                for error in &errors {
+                    let diagnostic = reporter.convert_runtime_error(file_id, error);
+                    messages.push(Self::render_diagnostic(&mut reporter, file_id, &diagnostic));
+                }
+            }
         }
 
-        let mut result_output = None;
-
-        if let Some(last_stmt) = program.statements.last() {
-            match last_stmt {
-                Statement::ExpressionStatement { .. } => {
-                    let expr_program = Program {
-                        statements: vec![last_stmt.clone()],
-                    };
-
-                    match self.interpreter.interpret(&expr_program).await {
-                        Ok(value) => {
-                            result_output = Some(format!("{value:?}"));
-                        }
-                        Err(errors) => {
-                            let mut error_messages = Vec::new();
-                            let mut reporter = DiagnosticReporter::new();
-                            let file_id = reporter.add_file("repl", input);
-
-                            for error in &errors {
-                                let diagnostic = reporter.convert_runtime_error(file_id, error);
-
-                                let mut buffer = Buffer::ansi();
-                                let config = term::Config::default();
-                                if let Err(_e) = term::emit_to_write_style(
-                                    &mut buffer,
-                                    &config,
-                                    &reporter.files,
-                                    &diagnostic.to_codespan_diagnostic(file_id),
-                                ) {
-                                    error_messages.push(format!("Runtime error: {error}"));
-                                    continue;
-                                }
-
-                                let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                                error_messages.push(output);
-                            }
-
-                            result_output = Some(error_messages.join("\n"));
-                        }
-                    }
-                }
-                _ => match self.interpreter.interpret(&program).await {
-                    Ok(_) => {}
-                    Err(errors) => {
-                        let mut error_messages = Vec::new();
-                        let mut reporter = DiagnosticReporter::new();
-                        let file_id = reporter.add_file("repl", input);
-
-                        for error in &errors {
-                            let diagnostic = reporter.convert_runtime_error(file_id, error);
-
-                            let mut buffer = Buffer::ansi();
-                            let config = term::Config::default();
-                            if let Err(_e) = term::emit_to_write_style(
-                                &mut buffer,
-                                &config,
-                                &reporter.files,
-                                &diagnostic.to_codespan_diagnostic(file_id),
-                            ) {
-                                error_messages.push(format!("Runtime error: {error}"));
-                                continue;
-                            }
-
-                            let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                            error_messages.push(output);
-                        }
-
-                        result_output = Some(error_messages.join("\n"));
-                    }
-                },
-            }
+        if messages.is_empty() {
+            Ok(None)
         } else {
-            match self.interpreter.interpret(&program).await {
-                Ok(_) => {}
-                Err(errors) => {
-                    let mut error_messages = Vec::new();
-                    let mut reporter = DiagnosticReporter::new();
-                    let file_id = reporter.add_file("repl", input);
-
-                    for error in &errors {
-                        let diagnostic = reporter.convert_runtime_error(file_id, error);
-
-                        let mut buffer = Buffer::ansi();
-                        let config = term::Config::default();
-                        if let Err(_e) = term::emit_to_write_style(
-                            &mut buffer,
-                            &config,
-                            &reporter.files,
-                            &diagnostic.to_codespan_diagnostic(file_id),
-                        ) {
-                            error_messages.push(format!("Runtime error: {error}"));
-                            continue;
-                        }
-
-                        let output = String::from_utf8_lossy(buffer.as_slice()).to_string();
-                        error_messages.push(output);
-                    }
-
-                    result_output = Some(error_messages.join("\n"));
-                }
-            }
+            Ok(Some(messages.join("\n")))
         }
-
-        Ok(result_output)
     }
 }
 
@@ -520,5 +483,142 @@ mod tests {
         assert_eq!(result.unwrap(), CommandResult::ClearedScreen);
 
         unsafe { libc::dup2(_stdout_dup.as_raw_fd(), stdout_fd) };
+    }
+
+    /// Lex a snippet the way the REPL does before asking whether it is complete.
+    fn tokens_of(src: &str) -> Vec<TokenWithPosition> {
+        crate::lexer::lex_wfl_with_positions(src)
+    }
+
+    // --- The reported bug --------------------------------------------------
+    // Storing a variable used to print an "unused variable" warning and, worse,
+    // the warning made the REPL discard the whole command so the variable was
+    // never stored. A bare `store` must now produce no output *and* persist.
+
+    #[tokio::test]
+    async fn store_persists_and_prints_nothing() {
+        let mut repl = ReplState::new();
+        let out = repl.process_line("store x as 5").await.unwrap();
+        assert_eq!(out, None, "`store` must not print a warning or any echo");
+        assert!(
+            repl.interpreter.global_env().borrow().has("x"),
+            "the variable must actually be stored in the session"
+        );
+    }
+
+    #[tokio::test]
+    async fn variable_defined_on_an_earlier_line_is_usable_later() {
+        let mut repl = ReplState::new();
+        repl.process_line("store x as 5").await.unwrap();
+        // A bare reference echoes the value — proving the per-line analyzer no
+        // longer reports the session variable as "not defined".
+        let echo = repl.process_line("x").await.unwrap();
+        assert_eq!(echo, Some("5".to_string()));
+    }
+
+    #[tokio::test]
+    async fn action_defined_earlier_can_be_called_later_without_null_echo() {
+        let mut repl = ReplState::new();
+        for line in [
+            "define action called greet with name:",
+            "display \"Hello \" with name",
+            "end action",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        // The call resolves against the session (not "not an action") and its
+        // void return value is not echoed as a stray `null`.
+        let out = repl
+            .process_line("call greet with \"World\"")
+            .await
+            .unwrap();
+        assert_eq!(out, None);
+    }
+
+    // --- Error reporting still fires for genuine mistakes ------------------
+
+    #[tokio::test]
+    async fn undefined_variable_is_reported_as_a_runtime_error() {
+        let mut repl = ReplState::new();
+        let out = repl
+            .process_line("display genuinely_missing")
+            .await
+            .unwrap()
+            .expect("a genuine typo must still be reported");
+        assert!(
+            out.contains("genuinely_missing") && out.to_lowercase().contains("defined"),
+            "expected an undefined-variable error, got: {out}"
+        );
+    }
+
+    #[tokio::test]
+    async fn syntax_error_is_reported() {
+        let mut repl = ReplState::new();
+        let out = repl.process_line("store as 5").await.unwrap();
+        assert!(out.is_some(), "a syntax error must be surfaced");
+    }
+
+    // --- Expression echo uses WFL's own value spelling --------------------
+
+    #[tokio::test]
+    async fn expression_result_is_echoed() {
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("2 plus 3").await.unwrap(),
+            Some("5".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn boolean_echo_uses_yes_no_not_true_false() {
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("5 is greater than 3").await.unwrap(),
+            Some("yes".to_string())
+        );
+    }
+
+    // --- Multiline block detection ----------------------------------------
+    // Every `end`-terminated block must be recognised as "keep reading" so it
+    // can be typed across several lines (previously only some were).
+
+    #[test]
+    fn incomplete_blocks_request_more_input() {
+        let repl = ReplState::new();
+        for opener in [
+            "check if yes:",
+            "count from 1 to 3:",
+            "for each item in items:",
+            "repeat while yes:",
+            "define action called f with n:",
+        ] {
+            assert!(
+                repl.is_input_incomplete(&tokens_of(opener)),
+                "`{opener}` should be treated as incomplete (awaiting its `end`)"
+            );
+        }
+    }
+
+    #[test]
+    fn complete_statements_are_not_treated_as_incomplete() {
+        let repl = ReplState::new();
+        for complete in ["store x as 5", "display \"hi\"", "2 plus 3"] {
+            assert!(
+                !repl.is_input_incomplete(&tokens_of(complete)),
+                "`{complete}` is a complete statement and should run immediately"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn multiline_if_block_runs_only_once_closed() {
+        let mut repl = ReplState::new();
+        assert_eq!(repl.process_line("check if yes:").await.unwrap(), None);
+        assert!(repl.in_multiline, "REPL should be waiting for more input");
+        assert_eq!(repl.process_line("display \"inside\"").await.unwrap(), None);
+        assert!(repl.in_multiline);
+        // Closing the block completes the buffered input and clears multiline.
+        repl.process_line("end check").await.unwrap();
+        assert!(!repl.in_multiline, "block is closed, multiline should end");
     }
 }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -216,15 +216,22 @@ impl ReplState {
         let mut diag = diagnostic.clone();
         if diag.labels.is_empty()
             && diag.line >= 1
-            && let Some(start) = reporter.line_col_to_offset(file_id, diag.line, diag.column)
+            && let Some(offset) = reporter.line_col_to_offset(file_id, diag.line, diag.column)
         {
-            diag.labels.push((
-                Span {
-                    start,
-                    end: start + 1,
-                },
-                "here".to_string(),
-            ));
+            // `line_col_to_offset` may return an offset one past the last byte
+            // (a column at end-of-line / EOF). Clamp the one-character span into
+            // the source, because codespan fails to emit on an end offset past
+            // the file length — which would silently drop the caret.
+            let source_len = reporter
+                .files
+                .get(file_id)
+                .map(|file| file.source().len())
+                .unwrap_or(0);
+            let start = offset.min(source_len.saturating_sub(1));
+            let end = (start + 1).min(source_len);
+            if start < end {
+                diag.labels.push((Span { start, end }, "here".to_string()));
+            }
         }
 
         let mut buffer = Buffer::ansi();
@@ -290,34 +297,50 @@ impl ReplState {
         // Messages accumulated across the analysis and run phases.
         let mut messages: Vec<String> = Vec::new();
 
-        // --- Static analysis (advisory only) --------------------------------
+        // --- Static analysis -------------------------------------------------
         // The REPL keeps ONE persistent interpreter for the whole session, but
         // the analyzer and type checker are whole-program tools that only ever
-        // see this single line. A variable or action defined on an *earlier*
-        // line therefore looks "undefined" to them, and a bare `store x as 5`
-        // looks "unused" — both false positives against the live session. So
-        // the interpreter (which owns the real environment) is the source of
-        // truth for what is defined and what is an error, and static analysis
-        // is used here only for advisory WARNINGS that are self-contained
-        // within a single line (unreachable code, shadowing, insecure RNG
-        // seeding, inconsistent returns).
+        // see this single line. Some of their diagnostics are false positives
+        // against the live session; others are perfectly valid. So they are
+        // filtered by diagnostic code, not blanket-dropped:
         //
-        // Concretely: analyzer *errors* (undefined name, "not an action",
-        // already-defined, ...) are context-dependent and are re-checked by the
-        // interpreter at run time against the real environment — so they are
-        // NOT reported here (that is what made `display x` on the line after
-        // `store x as 5` wrongly fail). "Unused variable" warnings are likewise
-        // false positives in an interactive session and are suppressed. The
-        // type checker is skipped entirely for the same reason: its diagnostics
-        // are the same context-dependent kind and would be noise on every line
-        // that refers back to the session.
+        //   * `ANALYZE-SEMANTIC` — context-dependent name resolution (undefined
+        //     name, "not an action", already-defined, undefined-inside-`try`).
+        //     A name defined on an earlier line looks undefined here, so these
+        //     are dropped: the interpreter, which owns the real environment,
+        //     re-checks them at run time and reports genuine ones (this is what
+        //     made `display x` after `store x as 5` wrongly fail).
+        //   * `ANALYZE-UNUSED` — a stored binding is available to the next line,
+        //     so "unused" is always a false positive interactively. Dropped.
+        //   * everything else is *self-contained* within the single line and is
+        //     kept exactly as `wfl <file>` treats it: advisory warnings
+        //     (unreachable code, dead branch, shadowing, inconsistent returns)
+        //     are shown, and any error — notably the `ANALYZE-SECURITY` lint for
+        //     seeding the RNG in crypto/auth code — is shown AND blocks
+        //     execution. Such lints depend only on this line's own code, never
+        //     on session state, so there is no reason to weaken them.
+        //
+        // The type checker is skipped because its diagnostics are the same
+        // context-dependent name/type kind that would be noise on every line
+        // referring back to the session.
         let mut analyzer = Analyzer::new();
+        let mut has_fatal_error = false;
         for diagnostic in &analyzer.analyze_static(&program, file_id) {
-            let keep =
-                diagnostic.severity == Severity::Warning && diagnostic.code != "ANALYZE-UNUSED";
-            if keep {
-                messages.push(Self::render_diagnostic(&mut reporter, file_id, diagnostic));
+            if matches!(
+                diagnostic.code.as_str(),
+                "ANALYZE-SEMANTIC" | "ANALYZE-UNUSED"
+            ) {
+                continue;
             }
+            messages.push(Self::render_diagnostic(&mut reporter, file_id, diagnostic));
+            if diagnostic.severity == Severity::Error {
+                has_fatal_error = true;
+            }
+        }
+        // A self-contained fatal analysis error (e.g. a security-policy
+        // violation) must stop the command before it runs, just like the CLI.
+        if has_fatal_error {
+            return Ok(Some(messages.join("\n")));
         }
 
         // --- Execution -------------------------------------------------------
@@ -536,6 +559,33 @@ mod tests {
     }
 
     // --- Error reporting still fires for genuine mistakes ------------------
+
+    #[tokio::test]
+    async fn self_contained_security_lint_still_blocks() {
+        // Seeding the RNG inside crypto/auth code is a self-contained security
+        // violation (it does not depend on session state), so it must stay
+        // fatal in the REPL — not get filtered out with the context-dependent
+        // name-resolution diagnostics.
+        let mut repl = ReplState::new();
+        for line in [
+            "define action called make_token:",
+            "random_seed of 1",
+            "give back secure_random_bytes of 16",
+        ] {
+            assert_eq!(repl.process_line(line).await.unwrap(), None);
+        }
+        let out = repl
+            .process_line("end action")
+            .await
+            .unwrap()
+            .expect("the security lint must be reported");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG security error, got: {out}"
+        );
+        // Execution was blocked, so the action was never defined.
+        assert!(!repl.interpreter.global_env().borrow().has("make_token"));
+    }
 
     #[tokio::test]
     async fn undefined_variable_is_reported_as_a_runtime_error() {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -217,18 +217,26 @@ impl ReplState {
         if diag.labels.is_empty()
             && diag.line >= 1
             && let Some(offset) = reporter.line_col_to_offset(file_id, diag.line, diag.column)
+            && let Ok(file) = reporter.files.get(file_id)
         {
-            // `line_col_to_offset` may return an offset one past the last byte
-            // (a column at end-of-line / EOF). Clamp the one-character span into
-            // the source, because codespan fails to emit on an end offset past
-            // the file length — which would silently drop the caret.
-            let source_len = reporter
-                .files
-                .get(file_id)
-                .map(|file| file.source().len())
-                .unwrap_or(0);
-            let start = offset.min(source_len.saturating_sub(1));
-            let end = (start + 1).min(source_len);
+            // Build a one-character span that stays on UTF-8 char boundaries.
+            // Spans are byte offsets into the source `String`; a `start + 1`
+            // (or an EOF clamp of `len - 1`) can land in the middle of a
+            // multi-byte character, and codespan then slices a non-char-boundary
+            // range and panics. Snap `start` down and `end` up to the enclosing
+            // character so the caret always underlines a whole char. Also
+            // guards the EOF case, where `line_col_to_offset` may return an
+            // offset one past the last byte.
+            let source = file.source();
+            let len = source.len();
+            let mut start = offset.min(len);
+            while start > 0 && !source.is_char_boundary(start) {
+                start -= 1;
+            }
+            let mut end = (start + 1).min(len);
+            while end < len && !source.is_char_boundary(end) {
+                end += 1;
+            }
             if start < end {
                 diag.labels.push((Span { start, end }, "here".to_string()));
             }
@@ -606,6 +614,32 @@ mod tests {
         let mut repl = ReplState::new();
         let out = repl.process_line("store as 5").await.unwrap();
         assert!(out.is_some(), "a syntax error must be surfaced");
+    }
+
+    #[test]
+    fn render_diagnostic_snaps_span_to_char_boundaries() {
+        // A label-less diagnostic whose position falls on a multi-byte
+        // character must not make codespan slice a non-char-boundary range
+        // (which panics). "café" is 5 bytes; column 4 is the start of the 2-byte
+        // 'é', so a naive `start + 1` span would split it.
+        let mut reporter = DiagnosticReporter::new();
+        let file_id = reporter.add_file("repl", "café");
+        let diag = WflDiagnostic::new(
+            Severity::Warning,
+            "unreachable code",
+            None::<String>,
+            "ANALYZE-UNREACHABLE",
+            file_id,
+            1,
+            4,
+            None,
+        );
+        // Must not panic, and must still carry the message.
+        let rendered = ReplState::render_diagnostic(&mut reporter, file_id, &diag);
+        assert!(
+            rendered.contains("unreachable code"),
+            "expected the message in the rendered diagnostic, got: {rendered}"
+        );
     }
 
     // --- Expression echo uses WFL's own value spelling --------------------

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -521,9 +521,12 @@ mod tests {
         unsafe { libc::dup2(_stdout_dup.as_raw_fd(), stdout_fd) };
     }
 
-    /// Lex a snippet the way the REPL does before asking whether it is complete.
+    /// Lex a snippet through the same entry point the REPL uses before asking
+    /// whether the input is complete (`lex_wfl_with_positions_checked`). With no
+    /// budget scoped — as in these tests — the checked lexer skips its budget
+    /// checks and behaves like the plain lexer, so a small snippet never errors.
     fn tokens_of(src: &str) -> Vec<TokenWithPosition> {
-        crate::lexer::lex_wfl_with_positions(src)
+        lex_wfl_with_positions_checked(src).expect("test snippet should lex cleanly")
     }
 
     // --- The reported bug --------------------------------------------------

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -423,6 +423,23 @@ impl ReplState {
         file_id: usize,
         messages: &mut Vec<String>,
     ) -> bool {
+        // Re-analysing the whole session each command is O(n²) over its length.
+        // A per-command budget deadline already bounds the work, but cap the
+        // accumulated source at a generous size so a pathologically long session
+        // degrades to analysing just this submission (warnings only) instead of
+        // getting slow. Realistic interactive sessions never approach this.
+        //
+        // Size the cap check off `session_inputs` directly so a very long session
+        // falls back without first paying an O(n) `join`/`format!` copy every
+        // command. `join("\n")` over the prefix is `sum(len) + (count - 1)` bytes,
+        // and the combined source adds a separator plus `input`, so its length is
+        // exactly `sum(len_i + 1) + input.len()` when the session is non-empty.
+        const MAX_SESSION_ANALYSIS_BYTES: usize = 256 * 1024;
+        let prefix_bytes: usize = self.session_inputs.iter().map(|s| s.len() + 1).sum();
+        if prefix_bytes + input.len() > MAX_SESSION_ANALYSIS_BYTES {
+            return self.static_check_isolated(input, reporter, file_id, messages);
+        }
+
         // Build the accumulated source. `base_line` is the number of lines in
         // the prefix (0 for the first submission), so the new submission's first
         // line sits at `base_line + 1` in the combined source — the offset used
@@ -436,16 +453,6 @@ impl ReplState {
                 prefix.matches('\n').count() + 1,
             )
         };
-
-        // Re-analysing the whole session each command is O(n²) over its length.
-        // A per-command budget deadline already bounds the work, but cap the
-        // accumulated source at a generous size so a pathologically long session
-        // degrades to analysing just this submission (warnings only) instead of
-        // getting slow. Realistic interactive sessions never approach this.
-        const MAX_SESSION_ANALYSIS_BYTES: usize = 256 * 1024;
-        if combined.len() > MAX_SESSION_ANALYSIS_BYTES {
-            return self.static_check_isolated(input, reporter, file_id, messages);
-        }
 
         // Each prior submission parsed on its own, so the concatenation parses
         // too; if it somehow does not, fall back to analysing this submission

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -426,8 +426,9 @@ impl ReplState {
         // Re-analysing the whole session each command is O(n²) over its length.
         // A per-command budget deadline already bounds the work, but cap the
         // accumulated source at a generous size so a pathologically long session
-        // degrades to analysing just this submission (warnings only) instead of
-        // getting slow. Realistic interactive sessions never approach this.
+        // degrades to analysing just this submission (whose diagnostics are then
+        // advisory — reported but non-blocking) instead of getting slow.
+        // Realistic interactive sessions never approach this.
         //
         // Size the cap check off `session_inputs` directly so a very long session
         // falls back without first paying an O(n) `join`/`format!` copy every
@@ -456,7 +457,9 @@ impl ReplState {
 
         // Each prior submission parsed on its own, so the concatenation parses
         // too; if it somehow does not, fall back to analysing this submission
-        // alone (no earlier-line context, warnings only — never a false fatal).
+        // alone (no earlier-line context; its diagnostics are reported but
+        // advisory — never blocking, so a dropped cross-line contract can't turn
+        // into a false fatal).
         let Ok(tokens) = lex_wfl_with_positions_checked(&combined) else {
             return self.static_check_isolated(input, reporter, file_id, messages);
         };

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -38,11 +38,17 @@ pub struct ReplState {
     /// Session-level state for the insecure-RNG-seeding security control
     /// (`ANALYZE-SECURITY`). The file lint sees only one program, so it cannot
     /// catch a `random_seed` entered in one submission and a crypto/auth op in
-    /// another. These record whether *any* executed submission has seeded the
-    /// RNG (`rng_insecurely_seeded`) and whether any has used a security-sensitive
-    /// builtin (`security_builtin_used`), so the insecure combination is blocked
-    /// however it is split across submissions — and independently of the capped
+    /// another. These record whether any submission the REPL has *run* seeded the
+    /// RNG (`rng_insecurely_seeded`) or used a security-sensitive builtin
+    /// (`security_builtin_used`), so the insecure combination is blocked however
+    /// it is split across submissions — and independently of the capped
     /// combined-source analysis, which the performance fallback skips.
+    ///
+    /// "Run" means recorded on execution *attempt* (the same rule as
+    /// `session_inputs`), and detection is syntactic — so an ingredient counts
+    /// even if the submission later errored at run time. That is deliberately
+    /// conservative: it matches the file lint, which flags the *presence* of
+    /// `random_seed` in security-sensitive code, not its execution.
     rng_insecurely_seeded: bool,
     security_builtin_used: bool,
     /// Byte cap on the accumulated source that session-aware analysis will build
@@ -631,18 +637,30 @@ impl ReplState {
 
     /// Fallback used when the accumulated source exceeds
     /// `max_session_analysis_bytes` or unexpectedly fails to lex/parse: analyse
-    /// the submission alone. Without earlier-line context a cross-line reference
-    /// can look undefined, so this NEVER blocks on the *name-resolution* checks
-    /// (returns `false`) — the interpreter catches genuine name errors at run
-    /// time. It still *reports* every non-ignorable diagnostic (advisory, any
-    /// severity) rather than silently dropping errors.
+    /// this submission alone (the analyzer's semantic pass only — type checking is
+    /// discussed below). Every non-ignorable diagnostic is still *reported*.
     ///
-    /// This relaxation is limited to context-dependent name resolution — the one
-    /// self-contained fatal control, insecure RNG seeding (`ANALYZE-SECURITY`),
-    /// is enforced ahead of this by `insecure_seed_block`, which does not depend
-    /// on the combined source. So reaching this fallback is not a security mode
-    /// switch: a long or lex-failing session cannot execute a `random_seed` +
-    /// crypto combination it would have blocked at full length.
+    /// A performance/parse fallback must not become a correctness mode switch, so
+    /// blocking is decided per diagnostic, not relaxed wholesale:
+    /// - **Self-contained fatal errors still block** (returns `true`). They are
+    ///   present in the submission regardless of the earlier lines we can't see.
+    /// - **Context-dependent name resolution is downgraded** to advisory (does not
+    ///   block): without the earlier session lines a reference to an
+    ///   earlier-defined name looks "undefined", so it may be a false positive —
+    ///   the interpreter resolves it against the live session, and a genuine typo
+    ///   still errors at run time.
+    ///
+    /// The one self-contained fatal that does *not* rely on the analyzer here —
+    /// insecure RNG seeding (`ANALYZE-SECURITY`) — is enforced ahead of this by
+    /// `insecure_seed_block`, independent of the combined source; so a long or
+    /// lex-failing session cannot execute a `random_seed` + crypto combination it
+    /// would have blocked at full length.
+    ///
+    /// Type checking is intentionally *not* run here: its diagnostics are advisory
+    /// (they never block, so no safety is lost), and without the earlier session
+    /// symbols it would emit false-positive "undefined" type diagnostics for valid
+    /// earlier-session references — exactly the noise the session-aware path
+    /// avoids. The session-aware path (`static_check_submission`) runs it normally.
     fn static_check_isolated(
         &self,
         input: &str,
@@ -660,12 +678,38 @@ impl ReplState {
         let mut scratch = DiagnosticReporter::new();
         let scratch_file = scratch.add_file("repl", input);
         let mut analyzer = Analyzer::new();
+        let mut fatal = false;
         for diagnostic in &analyzer.analyze_static(&program, scratch_file) {
-            if !Self::is_repl_ignorable_semantic(diagnostic) {
-                messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
+            if Self::is_repl_ignorable_semantic(diagnostic) {
+                continue;
+            }
+            messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
+            if diagnostic.severity == Severity::Error
+                && !Self::is_context_dependent_name_resolution(diagnostic)
+            {
+                fatal = true;
             }
         }
-        false
+        fatal
+    }
+
+    /// A semantic diagnostic whose validity depends on names defined earlier in
+    /// the session: an undefined variable/action/handler/list reference. When a
+    /// submission is analysed alone (the isolated fallback), such a name may be
+    /// defined on an earlier line we cannot see, so the "undefined" is potentially
+    /// a false positive and must not block. Every *other* semantic error is
+    /// self-contained — present regardless of the earlier lines — and stays fatal.
+    ///
+    /// In `static_check_submission` the earlier lines ARE in scope, so an
+    /// undefined name there is genuine and blocks; this downgrade is specific to
+    /// the isolated fallback.
+    fn is_context_dependent_name_resolution(diagnostic: &WflDiagnostic) -> bool {
+        diagnostic.code == "ANALYZE-SEMANTIC"
+            && ((diagnostic.message.starts_with("Variable '")
+                && diagnostic.message.ends_with("' is not defined"))
+                || diagnostic.message.starts_with("Undefined action '")
+                || diagnostic.message.starts_with("Undefined signal handler '")
+                || diagnostic.message.starts_with("Undefined list reference '"))
     }
 
     /// A diagnostic belongs to the new submission when it sits on a line after
@@ -1111,6 +1155,29 @@ mod tests {
             "expected the insecure-RNG error on the fallback path, got: {out}"
         );
         assert!(!repl.interpreter.global_env().borrow().has("tok"));
+    }
+
+    #[tokio::test]
+    async fn fallback_downgrades_earlier_session_reference_but_does_not_block() {
+        // In the isolated fallback we can't see earlier submissions, so a
+        // reference to an earlier-session variable looks "undefined". That is
+        // context-dependent, so it must be downgraded to advisory (not block) —
+        // the interpreter resolves it against the live session. This keeps
+        // cross-line references working even in the degraded fallback, while
+        // self-contained fatal errors (see the security tests) still block.
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store greeting as \"hi\"").await.unwrap(),
+            None
+        );
+        repl.max_session_analysis_bytes = 1; // force the isolated fallback
+        // Referencing the earlier-session variable must still execute (the
+        // name-resolution diagnostic is advisory, not a block).
+        let _ = repl.process_line("store echoed as greeting").await.unwrap();
+        assert!(
+            repl.interpreter.global_env().borrow().has("echoed"),
+            "an earlier-session reference must not block in the isolated fallback"
+        );
     }
 
     #[tokio::test]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -494,10 +494,12 @@ impl ReplState {
     }
 
     /// Fallback used only if the accumulated source unexpectedly fails to parse:
-    /// analyse the submission alone. Without earlier-line context every
-    /// cross-line reference would look undefined, so this reports advisory
-    /// warnings only and never blocks — the interpreter still catches genuine
-    /// errors at run time. Returns `false` (never fatal).
+    /// analyse the submission alone. Without earlier-line context a cross-line
+    /// reference can look undefined, so this NEVER blocks (returns `false`) — the
+    /// interpreter catches genuine errors at run time. It still *reports* every
+    /// non-ignorable diagnostic (advisory, any severity) rather than silently
+    /// dropping errors; a stray false positive here is only reachable in the
+    /// near-impossible case where the concatenated session does not parse.
     fn static_check_isolated(
         &self,
         input: &str,
@@ -516,9 +518,7 @@ impl ReplState {
         let scratch_file = scratch.add_file("repl", input);
         let mut analyzer = Analyzer::new();
         for diagnostic in &analyzer.analyze_static(&program, scratch_file) {
-            if diagnostic.severity == Severity::Warning
-                && !Self::is_repl_ignorable_semantic(diagnostic)
-            {
+            if !Self::is_repl_ignorable_semantic(diagnostic) {
                 messages.push(Self::render_diagnostic(reporter, file_id, diagnostic));
             }
         }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -7,7 +7,10 @@ use crate::exec::budget::ExecutionBudget;
 use crate::interpreter::Interpreter;
 use crate::interpreter::value::Value;
 use crate::lexer::{lex_wfl_with_positions_checked, token::TokenWithPosition};
-use crate::parser::{Parser, ast::Statement};
+use crate::parser::{
+    Parser,
+    ast::{Program, Statement},
+};
 use crate::typechecker::{TypeCheckError, TypeChecker, TypeError};
 use codespan_reporting::term;
 use codespan_reporting::term::termcolor::Buffer;
@@ -396,7 +399,7 @@ impl ReplState {
         // seeding, an undefined reference inside an action body) blocks
         // execution just as it aborts a file; type diagnostics are advisory, as
         // in the file pipeline.
-        if self.static_check_submission(input, &mut reporter, file_id, &mut messages) {
+        if self.static_check_submission(input, &program, &mut reporter, file_id, &mut messages) {
             return Ok(Some(messages.join("\n")));
         }
 
@@ -529,6 +532,7 @@ impl ReplState {
     fn static_check_submission(
         &self,
         input: &str,
+        program: &Program,
         reporter: &mut DiagnosticReporter,
         file_id: usize,
         messages: &mut Vec<String>,
@@ -550,7 +554,7 @@ impl ReplState {
         // exactly `sum(len_i + 1) + input.len()` when the session is non-empty.
         let prefix_bytes: usize = self.session_inputs.iter().map(|s| s.len() + 1).sum();
         if prefix_bytes + input.len() > self.max_session_analysis_bytes {
-            return self.static_check_isolated(input, reporter, file_id, messages);
+            return self.static_check_isolated(program, reporter, file_id, messages);
         }
 
         // Build the accumulated source. `base_line` is the number of lines in
@@ -573,11 +577,11 @@ impl ReplState {
         // advisory — never blocking, so a dropped cross-line contract can't turn
         // into a false fatal).
         let Ok(tokens) = lex_wfl_with_positions_checked(&combined) else {
-            return self.static_check_isolated(input, reporter, file_id, messages);
+            return self.static_check_isolated(program, reporter, file_id, messages);
         };
         let mut parser = Parser::new(&tokens);
         let Ok(combined_program) = parser.parse() else {
-            return self.static_check_isolated(input, reporter, file_id, messages);
+            return self.static_check_isolated(program, reporter, file_id, messages);
         };
 
         // A scratch file over the combined source. Diagnostics reference it, but
@@ -640,6 +644,13 @@ impl ReplState {
     /// this submission alone (the analyzer's semantic pass only — type checking is
     /// discussed below). Every non-ignorable diagnostic is still *reported*.
     ///
+    /// It operates on the submission's already-parsed `program` (the same AST
+    /// `process_complete_input` produced and will execute) rather than re-lexing
+    /// the source: the input was lexed under the command budget once at entry —
+    /// where a `BudgetExceeded` is already surfaced fatally — so re-lexing here
+    /// would only duplicate work and risk *swallowing* a second budget breach by
+    /// treating it as an ordinary "couldn't analyse" skip.
+    ///
     /// A performance/parse fallback must not become a correctness mode switch, so
     /// blocking is decided per diagnostic, not relaxed wholesale:
     /// - **Self-contained fatal errors still block** (returns `true`). They are
@@ -663,23 +674,17 @@ impl ReplState {
     /// avoids. The session-aware path (`static_check_submission`) runs it normally.
     fn static_check_isolated(
         &self,
-        input: &str,
+        program: &Program,
         reporter: &mut DiagnosticReporter,
         file_id: usize,
         messages: &mut Vec<String>,
     ) -> bool {
-        let Ok(tokens) = lex_wfl_with_positions_checked(input) else {
-            return false;
-        };
-        let mut parser = Parser::new(&tokens);
-        let Ok(program) = parser.parse() else {
-            return false;
-        };
-        let mut scratch = DiagnosticReporter::new();
-        let scratch_file = scratch.add_file("repl", input);
+        // `file_id` already refers to this submission's source, so analyse
+        // against it directly — no scratch reporter, and diagnostics render with
+        // the submission's own line/column.
         let mut analyzer = Analyzer::new();
         let mut fatal = false;
-        for diagnostic in &analyzer.analyze_static(&program, scratch_file) {
+        for diagnostic in &analyzer.analyze_static(program, file_id) {
             if Self::is_repl_ignorable_semantic(diagnostic) {
                 continue;
             }

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,5 +1,7 @@
 use crate::analyzer::Analyzer;
-use crate::analyzer::static_analyzer::StaticAnalyzer;
+use crate::analyzer::static_analyzer::{
+    RngSecurityIngredients, StaticAnalyzer, rng_security_ingredients,
+};
 use crate::diagnostics::{DiagnosticReporter, Severity, Span, WflDiagnostic};
 use crate::exec::budget::ExecutionBudget;
 use crate::interpreter::Interpreter;
@@ -33,7 +35,27 @@ pub struct ReplState {
     /// so cross-line references resolve and cross-line type/security contracts
     /// are still enforced — the interpreter alone cannot do the latter.
     session_inputs: Vec<String>,
+    /// Session-level state for the insecure-RNG-seeding security control
+    /// (`ANALYZE-SECURITY`). The file lint sees only one program, so it cannot
+    /// catch a `random_seed` entered in one submission and a crypto/auth op in
+    /// another. These record whether *any* executed submission has seeded the
+    /// RNG (`rng_insecurely_seeded`) and whether any has used a security-sensitive
+    /// builtin (`security_builtin_used`), so the insecure combination is blocked
+    /// however it is split across submissions — and independently of the capped
+    /// combined-source analysis, which the performance fallback skips.
+    rng_insecurely_seeded: bool,
+    security_builtin_used: bool,
+    /// Byte cap on the accumulated source that session-aware analysis will build
+    /// before falling back to analysing this submission alone. A field (not a
+    /// hard-coded constant) so tests can force the fallback without constructing
+    /// a multi-hundred-kilobyte session; production always uses the default.
+    max_session_analysis_bytes: usize,
 }
+
+/// Default cap on the accumulated session source before analysis falls back to
+/// the current submission alone. Generous — realistic interactive sessions stay
+/// far below it.
+const DEFAULT_MAX_SESSION_ANALYSIS_BYTES: usize = 256 * 1024;
 
 impl Default for ReplState {
     fn default() -> Self {
@@ -66,6 +88,9 @@ impl ReplState {
             in_multiline: false,
             history: Vec::new(),
             session_inputs: Vec::new(),
+            rng_insecurely_seeded: false,
+            security_builtin_used: false,
+            max_session_analysis_bytes: DEFAULT_MAX_SESSION_ANALYSIS_BYTES,
         }
     }
 
@@ -339,6 +364,23 @@ impl ReplState {
         // Messages accumulated across the analysis and run phases.
         let mut messages: Vec<String> = Vec::new();
 
+        // --- Session-aware security gate -------------------------------------
+        // Owns the insecure-RNG-seeding control (`ANALYZE-SECURITY`) at the
+        // *session* level: a `random_seed` and a crypto/auth op can be entered as
+        // separate submissions, which neither the whole-program file lint nor the
+        // capped combined-source analysis below can see together. This runs on
+        // EVERY submission regardless of the analysis path, so the security
+        // control is never relaxed by the performance fallback. Blocking here is
+        // fatal and, like any fatal, does not record the submission — so the
+        // session never accumulates both ingredients, and a later innocent
+        // command is not blocked.
+        let security_ingredients = rng_security_ingredients(&program);
+        if let Some(rendered) =
+            self.insecure_seed_block(&security_ingredients, &mut reporter, file_id)
+        {
+            return Ok(Some(rendered));
+        }
+
         // --- Session-aware static analysis -----------------------------------
         // Run the SAME analyze -> type-check -> execute pipeline `wfl <file>`
         // uses, but over `session_inputs + this submission` as one program, so
@@ -395,6 +437,14 @@ impl ReplState {
         // fully-failed `store` whose binding never took effect is still "known"
         // to later analysis) is benign: the reference simply raises a clear
         // undefined error at run time rather than being blocked.
+        //
+        // Fold this submission's security ingredients into the session state
+        // (only reached when the security gate did NOT block) so a later
+        // submission supplying the missing half is blocked. Detection is
+        // syntactic, so it is recorded even if the submission errored at run
+        // time — matching `session_inputs`' record-on-attempt rule above.
+        self.rng_insecurely_seeded |= security_ingredients.seeds_rng();
+        self.security_builtin_used |= security_ingredients.uses_security_builtin();
         self.session_inputs.push(input.to_string());
 
         if messages.is_empty() {
@@ -402,6 +452,60 @@ impl ReplState {
         } else {
             Ok(Some(messages.join("\n")))
         }
+    }
+
+    /// The insecure-RNG-seeding security control, evaluated at the session level.
+    /// Returns a rendered fatal `ANALYZE-SECURITY` diagnostic when — combining
+    /// this submission's ingredients with the session state — the RNG has been
+    /// seeded with `random_seed` AND a security-sensitive builtin is used
+    /// somewhere in the session; otherwise `None`.
+    ///
+    /// This is the REPL's single owner of `ANALYZE-SECURITY`. The whole-program
+    /// file lint (`check_insecure_rng_seeding`) cannot see the two ingredients
+    /// when they are split across submissions, and the analysis fallback skips
+    /// the combined source entirely — so a source-driven check would let a long
+    /// or lex-failing session bypass the control. Running here, before and
+    /// independent of that analysis, keeps the control in force on every path.
+    ///
+    /// Because a completing submission is blocked (fatal) and therefore not
+    /// recorded, the session never holds both ingredients at once; so whenever
+    /// this fires, at least one site is in the *current* submission. The caret
+    /// points at the crypto op here if present (the operation just made
+    /// predictable), otherwise at the `random_seed` entered here against an
+    /// earlier crypto op.
+    fn insecure_seed_block(
+        &self,
+        ingredients: &RngSecurityIngredients,
+        reporter: &mut DiagnosticReporter,
+        file_id: usize,
+    ) -> Option<String> {
+        let seeded = self.rng_insecurely_seeded || ingredients.seeds_rng();
+        let uses_security = self.security_builtin_used || ingredients.uses_security_builtin();
+        if !(seeded && uses_security) {
+            return None;
+        }
+        let (line, column) = ingredients
+            .security_site
+            .or(ingredients.seed_site)
+            .unwrap_or((1, 1));
+        let diagnostic = WflDiagnostic::new(
+            Severity::Error,
+            "random_seed must not be used in authentication, session, or cryptographic code"
+                .to_string(),
+            Some(
+                "Seeding the random number generator makes its output predictable, which \
+                 undermines salts, session IDs, and tokens. Remove the random_seed call; \
+                 use secure_random_bytes for cryptographic randomness. Seeding is only for \
+                 reproducible non-security code such as simulations or tests."
+                    .to_string(),
+            ),
+            "ANALYZE-SECURITY".to_string(),
+            file_id,
+            line,
+            column,
+            None,
+        );
+        Some(Self::render_diagnostic(reporter, file_id, &diagnostic))
     }
 
     /// Analyse `session_inputs + submission` as a single program and report only
@@ -428,16 +532,18 @@ impl ReplState {
         // accumulated source at a generous size so a pathologically long session
         // degrades to analysing just this submission (whose diagnostics are then
         // advisory — reported but non-blocking) instead of getting slow.
-        // Realistic interactive sessions never approach this.
+        // Realistic interactive sessions never approach this. The self-contained
+        // security control is NOT relaxed by this fallback: it is enforced ahead
+        // of here by the session-level `insecure_seed_block`, which does not
+        // depend on the combined source.
         //
         // Size the cap check off `session_inputs` directly so a very long session
         // falls back without first paying an O(n) `join`/`format!` copy every
         // command. `join("\n")` over the prefix is `sum(len) + (count - 1)` bytes,
         // and the combined source adds a separator plus `input`, so its length is
         // exactly `sum(len_i + 1) + input.len()` when the session is non-empty.
-        const MAX_SESSION_ANALYSIS_BYTES: usize = 256 * 1024;
         let prefix_bytes: usize = self.session_inputs.iter().map(|s| s.len() + 1).sum();
-        if prefix_bytes + input.len() > MAX_SESSION_ANALYSIS_BYTES {
+        if prefix_bytes + input.len() > self.max_session_analysis_bytes {
             return self.static_check_isolated(input, reporter, file_id, messages);
         }
 
@@ -523,13 +629,20 @@ impl ReplState {
         false
     }
 
-    /// Fallback used only if the accumulated source unexpectedly fails to parse:
-    /// analyse the submission alone. Without earlier-line context a cross-line
-    /// reference can look undefined, so this NEVER blocks (returns `false`) — the
-    /// interpreter catches genuine errors at run time. It still *reports* every
-    /// non-ignorable diagnostic (advisory, any severity) rather than silently
-    /// dropping errors; a stray false positive here is only reachable in the
-    /// near-impossible case where the concatenated session does not parse.
+    /// Fallback used when the accumulated source exceeds
+    /// `max_session_analysis_bytes` or unexpectedly fails to lex/parse: analyse
+    /// the submission alone. Without earlier-line context a cross-line reference
+    /// can look undefined, so this NEVER blocks on the *name-resolution* checks
+    /// (returns `false`) — the interpreter catches genuine name errors at run
+    /// time. It still *reports* every non-ignorable diagnostic (advisory, any
+    /// severity) rather than silently dropping errors.
+    ///
+    /// This relaxation is limited to context-dependent name resolution — the one
+    /// self-contained fatal control, insecure RNG seeding (`ANALYZE-SECURITY`),
+    /// is enforced ahead of this by `insecure_seed_block`, which does not depend
+    /// on the combined source. So reaching this fallback is not a security mode
+    /// switch: a long or lex-failing session cannot execute a `random_seed` +
+    /// crypto combination it would have blocked at full length.
     fn static_check_isolated(
         &self,
         input: &str,
@@ -851,6 +964,153 @@ mod tests {
             "expected the insecure-RNG error, got: {out}"
         );
         assert!(!repl.interpreter.global_env().borrow().has("mk"));
+    }
+
+    // --- Cross-submission insecure-RNG-seeding gate (maintainer review) -----
+    // A `random_seed` and a crypto/auth op can be entered as SEPARATE
+    // submissions. The whole-program file lint cannot see the two together, so
+    // the REPL tracks them at the session level and blocks the combination
+    // however it is split — and independently of the analysis fallback.
+
+    #[tokio::test]
+    async fn insecure_seed_then_crypto_in_separate_submissions_is_blocked() {
+        let mut repl = ReplState::new();
+        // Seeding alone is legitimate (reproducible simulations) and executes.
+        assert_eq!(
+            repl.process_line("store s as random_seed of 1234")
+                .await
+                .unwrap(),
+            None
+        );
+        // A later, separate crypto op must be blocked: the RNG is now predictable.
+        let out = repl
+            .process_line("store token as secure_random_bytes of 32")
+            .await
+            .unwrap()
+            .expect("the later crypto op must be blocked once the RNG is seeded");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG security error, got: {out}"
+        );
+        // Blocked: it never executed nor joined the session context.
+        assert!(!repl.interpreter.global_env().borrow().has("token"));
+        assert!(
+            !repl
+                .session_inputs
+                .iter()
+                .any(|s| s.contains("secure_random_bytes"))
+        );
+    }
+
+    #[tokio::test]
+    async fn crypto_then_insecure_seed_in_separate_submissions_is_blocked() {
+        // The reverse split: a clean crypto op first, then a `random_seed` in a
+        // later submission. Seeding after security-sensitive code is in the
+        // session is equally insecure and must be blocked.
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store token as secure_random_bytes of 32")
+                .await
+                .unwrap(),
+            None
+        );
+        let out = repl
+            .process_line("store s as random_seed of 1234")
+            .await
+            .unwrap()
+            .expect("seeding after crypto is in the session must be blocked");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG security error, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("s"));
+    }
+
+    #[tokio::test]
+    async fn innocent_command_after_a_blocked_crypto_op_is_not_over_blocked() {
+        // The completing (blocked) submission is not recorded, so the session
+        // never holds both ingredients: a later innocent command must still run.
+        // The gate must not latch into "block everything".
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store s as random_seed of 1234")
+                .await
+                .unwrap(),
+            None
+        );
+        assert!(
+            repl.process_line("store token as secure_random_bytes of 32")
+                .await
+                .unwrap()
+                .expect("blocked")
+                .contains("random_seed must not be used")
+        );
+        // An unrelated command runs normally and joins the session.
+        assert_eq!(
+            repl.process_line("store greeting as \"hi\"").await.unwrap(),
+            None
+        );
+        assert!(repl.interpreter.global_env().borrow().has("greeting"));
+        assert_eq!(
+            repl.process_line("greeting").await.unwrap().as_deref(),
+            Some("hi")
+        );
+    }
+
+    #[tokio::test]
+    async fn insecure_seed_alone_is_still_allowed() {
+        // Seeding without any security-sensitive builtin is legitimate (e.g. a
+        // reproducible simulation) and must NOT be blocked.
+        let mut repl = ReplState::new();
+        assert_eq!(
+            repl.process_line("store s as random_seed of 42")
+                .await
+                .unwrap(),
+            None,
+            "seeding without crypto must be allowed"
+        );
+        assert!(repl.interpreter.global_env().borrow().has("s"));
+    }
+
+    #[tokio::test]
+    async fn fallback_path_still_blocks_insecure_seeding() {
+        // Reaching the isolated fallback (source over the cap, or a combined-source
+        // lex/parse failure) must not relax the security control. Force the
+        // fallback with a tiny cap and verify the seed+crypto combination — same
+        // submission AND split across submissions — is still fatal.
+        let mut repl = ReplState::new();
+        repl.max_session_analysis_bytes = 1; // any non-empty submission falls back
+
+        // Same-submission seed+crypto, taken down the isolated path.
+        let out = repl
+            .process_line("store t as secure_random_bytes of 16\nstore s as random_seed of 1")
+            .await
+            .unwrap()
+            .expect("the fallback must still block a self-contained security violation");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG error on the fallback path, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("t"));
+
+        // Cross-submission on the isolated path: seed first (clean, runs under the
+        // fallback), then a separate crypto op — still blocked by the session gate.
+        assert_eq!(
+            repl.process_line("store seed_val as random_seed of 7")
+                .await
+                .unwrap(),
+            None
+        );
+        let out = repl
+            .process_line("store tok as secure_random_bytes of 8")
+            .await
+            .unwrap()
+            .expect("cross-submission seeding must be blocked even on the fallback path");
+        assert!(
+            out.contains("random_seed must not be used"),
+            "expected the insecure-RNG error on the fallback path, got: {out}"
+        );
+        assert!(!repl.interpreter.global_env().borrow().has("tok"));
     }
 
     #[tokio::test]

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -593,15 +593,15 @@ impl ReplState {
             return self.static_check_isolated(program, reporter, file_id, messages);
         };
 
-        // A scratch file over the combined source. Diagnostics reference it, but
-        // are rendered against the caller's submission `reporter`/`file_id`
-        // after their line numbers are shifted back by `base_line`.
-        let mut combined_reporter = DiagnosticReporter::new();
-        let combined_file = combined_reporter.add_file("repl", &combined);
-
+        // `analyze_static` only needs a `file_id` to tag its diagnostics; it does
+        // not read source through a reporter. Diagnostics are rendered against the
+        // caller's submission `reporter`/`file_id` after their line numbers are
+        // shifted back by `base_line`, so pass the caller's `file_id` directly
+        // rather than cloning the whole combined source into a scratch reporter
+        // just for an id (an O(combined) copy on every submission).
         let mut analyzer = Analyzer::new();
         let mut fatal = false;
-        for diagnostic in &analyzer.analyze_static(&combined_program, combined_file) {
+        for diagnostic in &analyzer.analyze_static(&combined_program, file_id) {
             if !Self::belongs_to_submission(diagnostic.line, base_line)
                 || Self::is_repl_ignorable_semantic(diagnostic)
             {


### PR DESCRIPTION
## Summary

Fixes a bug where `store` statements in the REPL were discarded without persisting, and makes REPL error handling, multi-line block detection, and value echo align with WFL's error principles (Fundamental #4).

**Root cause:** the REPL keeps one persistent interpreter for the session but ran the analyzer/type-checker fresh on each single line. Those whole-program tools flagged earlier-line names as "undefined" and just-declared variables as "unused", and `process_complete_input` returned early on **any** diagnostic — so valid commands (including a bare `store`) were discarded before execution.

## Key changes

- **Session-aware static analysis.** The REPL runs the same `analyze → type-check → execute` pipeline as `wfl <file>`, but over `session_inputs + this submission` as one accumulated program, so names/actions/types defined on earlier lines are in scope. Only the new submission's diagnostics are reported (line numbers translated back), and only the new submission is executed against the persistent interpreter.
  - Cross-line references resolve (fixes the reported bug), while the checks the interpreter *can't* do still run: undefined references inside a not-yet-called action body (caught at definition time) and cross-line type mismatches.
  - Semantic **errors are fatal** (as they abort a file); **type diagnostics are advisory** (shown, non-blocking, as in the file pipeline). `ANALYZE-UNUSED` and "already defined" are suppressed so re-`store` and forward use work interactively.
  - The accumulated re-analysis is capped (256 KB) with a graceful fallback for pathologically long sessions. The fallback relaxes only context-dependent name resolution — it is **not** a security mode switch (see below).
- **Session-level insecure-RNG-seeding gate (`ANALYZE-SECURITY`).** The security control is owned at the session level, not derived from the capped combined-source analysis. `ReplState` tracks the two ingredients of the lint — an insecure `random_seed` and any security-sensitive builtin — across the whole session, and blocks the combination **however it is split across submissions** (either order), and **on every path** including the analysis fallback. The completing submission is fatal and therefore not recorded, so the session never accumulates both ingredients and a later innocent command is not over-blocked. Seeding without any security-sensitive builtin remains allowed. `rng_security_ingredients` reuses the analyzer's own call collector and builtin list, so the REPL and `wfl <file>` agree.
- **Fixed the "store doesn't store" bug** — a bare `store` now persists and produces no output (no spurious "unused" warning that discarded the command).
- **Robust multi-line block detection** — `error_means_more_input_needed` replaces fragile case-sensitive string matching; covers `check if`, `count`, `for each`, `repeat while/until`, and `define action`.
- **Every diagnostic gets a source caret** — `render_diagnostic` synthesizes a UTF-8-boundary-safe span (EOF-safe) from analyzer diagnostics' line/column, unifying the previously duplicated codespan rendering.
- **Cleaner value echo** — bare expressions echo with `Display` (`yes`/`no`, unquoted text, `[1, 2, 3]`); void results (`nothing`/null) are not echoed.

## Tests

Regression tests in `src/repl.rs` cover: the reported bug; cross-line references and calls; session-aware definition/type checks (undefined-in-body, earlier-session refs, self-recursion, cross-line type mismatch); the insecure-RNG-seeding gate (seed+crypto split across separate submissions in either order, no-over-block, seed-alone allowed, and a forced-fallback path that still blocks); re-`store`; multi-line detection; echo format; and diagnostic caret (UTF-8/EOF). `cargo test --lib`, `cargo fmt --all -- --check`, and `cargo clippy --all-targets --all-features -- -D warnings` are green.

## Documentation

Updated `Docs/02-getting-started/repl-guide.md` (real banner/prompt, dot-prefixed commands, real error example, accurate `.history` scope) and added a `Dev diary/` entry documenting the root cause, the session-aware design, and the session-level security gate.

## Design notes for reviewers

- Type diagnostics are **advisory** (matching `wfl <file>` and the No-Unlearning invariant), not blocking — can be made blocking if preferred.
- `session_inputs` records on execution *attempt* (not only success) so anything a submission tried to define stays referenceable (never falsely blocked); see the inline discussion.
- The insecure-RNG-seeding control is enforced across submissions and across the analysis fallback, so seeding in one command and doing crypto in a separate later command is now blocked (a fatal, so it is not recorded). The single-submission / file-equivalent case is also caught.

https://claude.ai/code/session_01T5Eov4S96MdgZbCd3NpQUK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - REPL sessions now retain variables and actions across submitted lines.
  - Added clearer error and warning messages with source locations and caret highlights.
  - Improved multiline input handling and continuation prompts.
  - Expression results use consistent formatting, while empty results remain hidden.
  - Security checks now account for activity across the entire REPL session.

- **Documentation**
  - Updated the REPL guide with current prompts, commands, navigation, limitations, and error examples.

- **Bug Fixes**
  - Fixed stored variables being lost after warnings.
  - Prevented false cross-line diagnostics and UTF-8 rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->