### PR TITLE
fix(ci): raise nightly Windows build timeout 60→90 min (nightly timed out 2026-07-15)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,7 +123,7 @@ jobs:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.should_build == 'true'
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:


### PR DESCRIPTION
## What was broken
The scheduled **Nightly Build** on 2026-07-15 ([run 29392474402](https://github.com/WebFirstLanguage/wfl/actions/runs/29392474402)) did **not** publish a nightly release. The `Build WFL for Windows` job ran for **60m07s** (05:50:00Z → 06:50:07Z) and was **cancelled by its `timeout-minutes: 60` cap**; the `Create or Update Nightly Release` job was then skipped. So `main` @`56b5adb` has no nightly artifact.

## Root cause
Not a code or packaging fault — a **chronic thin-margin timeout**. The Windows build legitimately takes close to an hour and the durations of the last five successful nightlies sit right against the cap:

| Nightly | Build duration |
|---|---|
| 2026-07-10 | 51.0 min |
| 2026-07-11 | 58.7 min |
| 2026-07-12 | 54.7 min |
| 2026-07-13 | 57.5 min |
| 2026-07-14 | 56.1 min |
| **2026-07-15** | **60.1 min → cancelled (timeout)** |

With ~9 minutes of run-to-run variance and a 60-minute ceiling, any slightly slower runner (or incremental codebase growth) tips the job over. This exact margin was flagged as a watch item in prior maintenance passes ("59m22s, watch the margin"). Today it crossed the line.

## The fix
Raise `timeout-minutes` on the `Build WFL for Windows` job from **60 → 90**, restoring ~30 minutes of headroom over the typical ~57-minute build. One line, CI-only:

```diff
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
```

No build steps, dependencies, or product behavior are changed; the release job's own 15-minute timeout is untouched. This does not mask a hang — the job was making normal progress and finished each recent run in ~51–59 minutes; it simply needs a realistic ceiling. (A separate, larger effort to actually *shorten* the Windows build — e.g. caching/packaging tuning — would be worthwhile but is out of scope for restoring green tonight.)

## Verification
- Confirmed the cancellation was the 60-minute cap: the job's own runtime was exactly 60m07s and the release job shows `skipped`, not a step failure.
- `nightly.yml` parses cleanly (`yaml.safe_load`).
- The Windows-only nightly path cannot be reproduced on Linux (per the repo's CI failure map §F); the next scheduled nightly on `main` — or a manual `workflow_dispatch` from `main` after merge — will confirm the build now completes and publishes. I deliberately did **not** trigger a `workflow_dispatch` from this branch: the `release` job is gated only on `should_build`, not on `main`, so a branch run would tag and publish a nightly release from a non-`main` commit.

---
*Automated triage PR from the WFL repo warden — opened for a human to review and merge; the warden does not self-merge.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/618" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the Windows nightly build timeout to 90 minutes, reducing cancellations during longer-running builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->