### PR TITLE
fix(ci): raise Build/Test/Clippy timeout from 15 to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,14 @@ jobs:
     name: Build, Test, Clippy
     runs-on: ubuntu-latest
     needs: fmt
-    timeout-minutes: 15
+    # This job compiles the workspace three times (debug, release, and a third
+    # release build for the panic=abort assert), runs the full workspace test
+    # suite, builds the LSP binary, and runs Clippy. That real work now lands
+    # right at ~15 minutes even with a warm cache, so a 15-minute limit was
+    # firing mid-Clippy / during the cache-save step and marking the whole job
+    # `cancelled` (which also skips bump-version). 30 minutes gives headroom for
+    # cold-cache builds without letting a genuinely hung job run unbounded.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The `clippy-and-test` job compiles the workspace three times (debug,
release, and a third release build for the panic=abort assert), runs the
full workspace test suite, builds the LSP binary, and runs Clippy. That
real work now lands right at ~15 minutes even with a warm cache.

As a result, the last two pushes to main both failed CI: the 15-minute
`timeout-minutes` fired mid-Clippy (run 1a9705a) or during the cache-save
Post step (run 6c9888c), marking the whole job `cancelled` even though
every real step passed. A cancelled job also skips `bump-version`, so
post-merge version bumps stopped happening.

Raise the limit to 30 minutes to give headroom for cold-cache builds
while still bounding a genuinely hung job.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015fZVmhdQkqK15wvKjzeRYS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the CI validation time limit to better support slower, cold-cache builds.
  * Added explanatory notes about timeout behavior and version update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->