### PR TITLE
Reject overflowing numeric literals safely

### DIFF
--- a/src/lexer/tests.rs
+++ b/src/lexer/tests.rs
@@ -158,6 +158,35 @@ fn test_keyword_case_sensitivity() {
     }
 }
 
+#[test]
+fn oversized_integer_literal_is_a_lex_error_instead_of_a_panic() {
+    use logos::Logos;
+
+    // One above i64::MAX. The old `parse::<i64>().unwrap()` callback panicked
+    // here, allowing an untrusted source file to abort CLI/LSP processing.
+    let mut lexer = Token::lexer("9223372036854775808");
+    assert!(matches!(lexer.next(), Some(Err(_))));
+    assert!(lexer.next().is_none());
+
+    // Exercise both public collection paths as regression protection: neither
+    // may unwind when the malformed literal appears inside an otherwise valid
+    // statement.
+    let source = "store value as 9223372036854775808\n";
+    assert!(std::panic::catch_unwind(|| lex_wfl(source)).is_ok());
+    assert!(std::panic::catch_unwind(|| lex_wfl_with_positions(source)).is_ok());
+}
+
+#[test]
+fn overflowing_float_literal_is_rejected_as_non_finite() {
+    use logos::Logos;
+
+    let source = format!("{}.0", "9".repeat(400));
+    let mut lexer = Token::lexer(&source);
+    assert!(matches!(lexer.next(), Some(Err(_))));
+    assert!(lexer.next().is_none());
+    assert!(std::panic::catch_unwind(|| lex_wfl_with_positions(&source)).is_ok());
+}
+
 // Escape sequence tests
 #[test]
 fn test_parse_string_newline_escape() {

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -460,10 +460,10 @@ pub enum Token {
     #[regex(r#""([^"\\]|\\.)*""#, |lex| parse_string(lex).ok())] // captures content inside quotes
     StringLiteral(String),
 
-    #[regex("[0-9]+\\.[0-9]+", |lex| lex.slice().parse::<f64>().unwrap())]
+    #[regex("[0-9]+\\.[0-9]+", parse_float_literal)]
     FloatLiteral(f64),
 
-    #[regex("[0-9]+", |lex| lex.slice().parse::<i64>().unwrap())]
+    #[regex("[0-9]+", parse_int_literal)]
     IntLiteral(i64),
 
     #[regex("[A-Za-z][A-Za-z0-9_]*", |lex| lex.slice().to_string())]
@@ -476,6 +476,23 @@ pub enum Token {
     RightParen,
 
     Error,
+}
+
+/// Parse a decimal integer without letting attacker-controlled source panic the
+/// lexer. Logos treats `None` as a normal lexing error, which the positioned
+/// lexer reports with the literal's span and the parser then rejects.
+fn parse_int_literal(lex: &mut logos::Lexer<Token>) -> Option<i64> {
+    lex.slice().parse::<i64>().ok()
+}
+
+/// WFL numbers must be finite. Rust accepts very large decimal floats as
+/// positive infinity, so reject both parse failures and non-finite results at
+/// the token boundary instead of injecting an infinity value into the runtime.
+fn parse_float_literal(lex: &mut logos::Lexer<Token>) -> Option<f64> {
+    lex.slice()
+        .parse::<f64>()
+        .ok()
+        .filter(|value| value.is_finite())
 }
 
 fn parse_string(lex: &mut logos::Lexer<Token>) -> Result<String, ()> {


### PR DESCRIPTION
## Summary

- replace panic-prone numeric lexer callbacks with fallible parsing
- reject integers outside WFL's `i64` representation
- reject non-finite decimal float literals
- add regressions for both public lexer collection paths

## Security impact

Previously, attacker-controlled WFL source containing an oversized integer reached `parse::<i64>().unwrap()` and could unwind CLI or LSP processing. Invalid numeric input now becomes a normal lexer error.

## Validation

- `git diff --check`
- added focused lexer regression tests, including `catch_unwind` coverage
- Rust tests were not run locally because this workspace has no Rust toolchain; repository CI passed on the final head
- all GitHub CI, config lint, and review checks passed on the final head

## Production readiness

- area: Security / Reliability / Testing
- advances the source-safety gate tracked in #610
- compatibility impact: out-of-range integers and non-finite float literals are now rejected instead of crashing or entering the runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or oversized integer literals are now reported as lexer errors instead of causing a crash.
  * Overflowing and non-finite floating-point literals are rejected safely as lexer errors.
  * Improved reliability when processing malformed numeric input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->