### PR TITLE
Bound pattern quantifier compilation

### DIFF
--- a/src/parser/stmt/patterns.rs
+++ b/src/parser/stmt/patterns.rs
@@ -27,6 +27,44 @@ fn token_to_char_class(token: &Token) -> Option<CharClass> {
     }
 }
 
+/// Convert a lexer integer to the representation used by pattern quantifiers
+/// without allowing signed or oversized values to wrap during conversion.
+fn checked_quantifier_count(
+    value: i64,
+    token: &TokenWithPosition,
+) -> Result<u32, ParseError> {
+    u32::try_from(value).map_err(|_| {
+        ParseError::from_token(
+            format!(
+                "Pattern quantifier count must be between 0 and {}",
+                u32::MAX
+            ),
+            token,
+        )
+    })
+}
+
+/// Validate a bounded quantifier before constructing its AST node. Keeping
+/// this invariant at the parser boundary prevents `max - min` underflow in
+/// downstream consumers, while the compiler repeats the check defensively for
+/// ASTs constructed through the public Rust API.
+fn checked_quantifier_range(
+    min: u32,
+    max: u32,
+    token: &TokenWithPosition,
+) -> Result<(u32, u32), ParseError> {
+    if min > max {
+        Err(ParseError::from_token(
+            format!(
+                "Pattern quantifier lower bound ({min}) cannot exceed upper bound ({max})"
+            ),
+            token,
+        ))
+    } else {
+        Ok((min, max))
+    }
+}
+
 pub(crate) trait PatternParser<'a>: ExprParser<'a> {
     fn parse_create_pattern_statement(&mut self) -> Result<Statement, ParseError>;
     fn parse_pattern_tokens(tokens: &[TokenWithPosition]) -> Result<PatternExpression, ParseError>;
@@ -451,6 +489,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                 *i += 1; // Skip "exactly"
                 if *i < tokens.len() {
                     if let Token::IntLiteral(n) = tokens[*i].token {
+                        let count = checked_quantifier_count(n, &tokens[*i])?;
                         *i += 1; // Skip the number
 
                         // Optionally consume "of" keyword
@@ -461,7 +500,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                         let base_element = Self::parse_pattern_element(tokens, i)?;
                         PatternExpression::Quantified {
                             pattern: Box::new(base_element),
-                            quantifier: Quantifier::Exactly(n as u32),
+                            quantifier: Quantifier::Exactly(count),
                         }
                     } else {
                         return Err(ParseError::from_token(
@@ -486,6 +525,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                             *i += 1; // Skip "least"
                             if *i < tokens.len() {
                                 if let Token::IntLiteral(n) = tokens[*i].token {
+                                    let count = checked_quantifier_count(n, &tokens[*i])?;
                                     *i += 1; // Skip the number
 
                                     // Optionally consume "of" keyword
@@ -496,7 +536,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                                     let base_element = Self::parse_pattern_element(tokens, i)?;
                                     PatternExpression::Quantified {
                                         pattern: Box::new(base_element),
-                                        quantifier: Quantifier::AtLeast(n as u32),
+                                        quantifier: Quantifier::AtLeast(count),
                                     }
                                 } else {
                                     return Err(ParseError::from_token(
@@ -515,6 +555,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                             *i += 1; // Skip "most"
                             if *i < tokens.len() {
                                 if let Token::IntLiteral(n) = tokens[*i].token {
+                                    let count = checked_quantifier_count(n, &tokens[*i])?;
                                     *i += 1; // Skip the number
 
                                     // Optionally consume "of" keyword
@@ -525,7 +566,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                                     let base_element = Self::parse_pattern_element(tokens, i)?;
                                     PatternExpression::Quantified {
                                         pattern: Box::new(base_element),
-                                        quantifier: Quantifier::AtMost(n as u32),
+                                        quantifier: Quantifier::AtMost(count),
                                     }
                                 } else {
                                     return Err(ParseError::from_token(
@@ -557,13 +598,22 @@ impl<'a> PatternParser<'a> for Parser<'a> {
 
             // Handle "N to M" syntax for numeric ranges
             Token::IntLiteral(min) => {
-                let min_val = *min as u32;
+                let min_value = *min;
+                let min_token_index = *i;
                 *i += 1; // Skip the number
 
                 // Check if this is a range pattern "N to M"
                 if *i + 1 < tokens.len() && tokens[*i].token == Token::KeywordTo {
+                    let min_val =
+                        checked_quantifier_count(min_value, &tokens[min_token_index])?;
                     *i += 1; // Skip "to"
                     if let Token::IntLiteral(max) = tokens[*i].token {
+                        let max_val = checked_quantifier_count(max, &tokens[*i])?;
+                        let (min_val, max_val) = checked_quantifier_range(
+                            min_val,
+                            max_val,
+                            &tokens[*i],
+                        )?;
                         *i += 1; // Skip the max number
 
                         // Optionally consume "of" keyword
@@ -574,7 +624,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                         let base_element = Self::parse_pattern_element(tokens, i)?;
                         PatternExpression::Quantified {
                             pattern: Box::new(base_element),
-                            quantifier: Quantifier::Between(min_val, max as u32),
+                            quantifier: Quantifier::Between(min_val, max_val),
                         }
                     } else {
                         return Err(ParseError::from_token(
@@ -584,7 +634,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                     }
                 } else {
                     // It's just a number literal, treat it as a literal pattern
-                    PatternExpression::Literal(min.to_string())
+                    PatternExpression::Literal(min_value.to_string())
                 }
             }
 
@@ -1112,10 +1162,11 @@ impl<'a> PatternParser<'a> for Parser<'a> {
             Token::KeywordExactly => {
                 if *i + 1 < tokens.len() {
                     if let Token::IntLiteral(n) = tokens[*i + 1].token {
+                        let count = checked_quantifier_count(n, &tokens[*i + 1])?;
                         *i += 2;
                         Ok(PatternExpression::Quantified {
                             pattern: Box::new(base_pattern),
-                            quantifier: Quantifier::Exactly(n as u32),
+                            quantifier: Quantifier::Exactly(count),
                         })
                     } else {
                         Ok(base_pattern)
@@ -1129,10 +1180,14 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                     if let (Token::IntLiteral(min), Token::IntLiteral(max)) =
                         (&tokens[*i + 1].token, &tokens[*i + 3].token)
                     {
+                        let min = checked_quantifier_count(*min, &tokens[*i + 1])?;
+                        let max = checked_quantifier_count(*max, &tokens[*i + 3])?;
+                        let (min, max) =
+                            checked_quantifier_range(min, max, &tokens[*i + 3])?;
                         *i += 4;
                         Ok(PatternExpression::Quantified {
                             pattern: Box::new(base_pattern),
-                            quantifier: Quantifier::Between(*min as u32, *max as u32),
+                            quantifier: Quantifier::Between(min, max),
                         })
                     } else {
                         Ok(base_pattern)
@@ -1142,6 +1197,21 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                 }
             }
             _ => Ok(base_pattern),
+        }
+    }
+}
+
+#[cfg(test)]
+mod quantifier_validation_tests {
+    use super::*;
+
+    #[test]
+    fn checked_quantifier_count_rejects_negative_and_out_of_range_values() {
+        for value in [-1, i64::from(u32::MAX) + 1, i64::MAX] {
+            let token = TokenWithPosition::new(Token::IntLiteral(value), 1, 1, 1);
+            let error = checked_quantifier_count(value, &token)
+                .expect_err("invalid quantifier count must be rejected");
+            assert!(error.message.contains("between 0 and"));
         }
     }
 }

--- a/src/parser/stmt/patterns.rs
+++ b/src/parser/stmt/patterns.rs
@@ -29,10 +29,7 @@ fn token_to_char_class(token: &Token) -> Option<CharClass> {
 
 /// Convert a lexer integer to the representation used by pattern quantifiers
 /// without allowing signed or oversized values to wrap during conversion.
-fn checked_quantifier_count(
-    value: i64,
-    token: &TokenWithPosition,
-) -> Result<u32, ParseError> {
+fn checked_quantifier_count(value: i64, token: &TokenWithPosition) -> Result<u32, ParseError> {
     u32::try_from(value).map_err(|_| {
         ParseError::from_token(
             format!(
@@ -55,9 +52,7 @@ fn checked_quantifier_range(
 ) -> Result<(u32, u32), ParseError> {
     if min > max {
         Err(ParseError::from_token(
-            format!(
-                "Pattern quantifier lower bound ({min}) cannot exceed upper bound ({max})"
-            ),
+            format!("Pattern quantifier lower bound ({min}) cannot exceed upper bound ({max})"),
             token,
         ))
     } else {
@@ -604,16 +599,12 @@ impl<'a> PatternParser<'a> for Parser<'a> {
 
                 // Check if this is a range pattern "N to M"
                 if *i + 1 < tokens.len() && tokens[*i].token == Token::KeywordTo {
-                    let min_val =
-                        checked_quantifier_count(min_value, &tokens[min_token_index])?;
+                    let min_val = checked_quantifier_count(min_value, &tokens[min_token_index])?;
                     *i += 1; // Skip "to"
                     if let Token::IntLiteral(max) = tokens[*i].token {
                         let max_val = checked_quantifier_count(max, &tokens[*i])?;
-                        let (min_val, max_val) = checked_quantifier_range(
-                            min_val,
-                            max_val,
-                            &tokens[*i],
-                        )?;
+                        let (min_val, max_val) =
+                            checked_quantifier_range(min_val, max_val, &tokens[*i])?;
                         *i += 1; // Skip the max number
 
                         // Optionally consume "of" keyword
@@ -1182,8 +1173,7 @@ impl<'a> PatternParser<'a> for Parser<'a> {
                     {
                         let min = checked_quantifier_count(*min, &tokens[*i + 1])?;
                         let max = checked_quantifier_count(*max, &tokens[*i + 3])?;
-                        let (min, max) =
-                            checked_quantifier_range(min, max, &tokens[*i + 3])?;
+                        let (min, max) = checked_quantifier_range(min, max, &tokens[*i + 3])?;
                         *i += 4;
                         Ok(PatternExpression::Quantified {
                             pattern: Box::new(base_pattern),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2225,3 +2225,69 @@ fn try_statement_parses_finally_and_named_error_binding() {
         other => panic!("expected a try statement, got {other:?}"),
     }
 }
+
+#[test]
+fn pattern_quantifier_rejects_descending_numeric_range() {
+    let input = "create pattern bounded:\n    10 to 1 digit\nend pattern";
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let error = parser
+        .parse_statement()
+        .expect_err("a descending pattern range must be rejected");
+
+    assert!(
+        error.message.contains("lower bound") && error.message.contains("upper bound"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn pattern_quantifier_rejects_counts_outside_u32_range() {
+    for body in [
+        "exactly 4294967296 digit",
+        "exactly 9223372036854775807 digit",
+        "1 to 4294967296 digit",
+        "digit exactly 4294967296",
+        "digit between 1 and 4294967296",
+    ] {
+        let input = format!("create pattern bounded:\n    {body}\nend pattern");
+        let tokens = lex_wfl_with_positions(&input);
+        let mut parser = Parser::new(&tokens);
+
+        let error = parser
+            .parse_statement()
+            .expect_err("out-of-range quantifier must be rejected");
+        assert!(
+            error.message.contains("between 0 and"),
+            "unexpected error for `{body}`: {error}"
+        );
+    }
+}
+
+#[test]
+fn normal_pattern_quantifier_counts_remain_compatible() {
+    let cases = [
+        ("exactly 3 digit", Quantifier::Exactly(3)),
+        ("2 to 6 digit", Quantifier::Between(2, 6)),
+        ("digit exactly 4", Quantifier::Exactly(4)),
+        ("digit between 1 and 5", Quantifier::Between(1, 5)),
+    ];
+
+    for (body, expected_quantifier) in cases {
+        let input = format!("create pattern bounded:\n    {body}\nend pattern");
+        let tokens = lex_wfl_with_positions(&input);
+        let mut parser = Parser::new(&tokens);
+        let statement = parser
+            .parse_statement()
+            .unwrap_or_else(|error| panic!("expected `{body}` to parse: {error}"));
+
+        let Statement::PatternDefinition { pattern, .. } = statement else {
+            panic!("expected a pattern definition for `{body}`");
+        };
+        let PatternExpression::Quantified { quantifier, .. } = pattern else {
+            panic!("expected a quantified pattern for `{body}`, got {pattern:?}");
+        };
+        assert_eq!(quantifier, expected_quantifier, "body: `{body}`");
+    }
+}

--- a/src/pattern/compiler.rs
+++ b/src/pattern/compiler.rs
@@ -6,10 +6,19 @@
 
 use super::PatternError;
 use super::instruction::{CharClassType, Instruction, Program};
+use crate::exec::ExecutionBudget;
 use crate::interpreter::environment::Environment;
 use crate::interpreter::value::Value;
 use crate::parser::ast::{Anchor, CharClass, PatternExpression, Quantifier};
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A second line of defense beyond the VM's transition budget. Bytecode
+/// compilation expands bounded quantifiers, so it must have a substantially
+/// smaller ceiling of its own to keep hostile source from allocating millions
+/// of instructions before the VM starts.
+const MAX_COMPILED_PATTERN_INSTRUCTIONS: usize = 100_000;
 
 /// Compiler that converts PatternExpression AST into executable bytecode.
 ///
@@ -62,6 +71,12 @@ pub struct PatternCompiler {
     capture_map: HashMap<String, usize>,
     /// Counter for save slots (currently unused but preserved for future use)
     save_counter: usize,
+    /// Maximum number of instructions this compilation may emit. This is
+    /// capped by both the hard compilation ceiling and the active run budget.
+    max_instructions: usize,
+    /// Instructions emitted across the root program and embedded lookbehind
+    /// programs. Lookbehind compilers share this counter with their parent.
+    emitted_instructions: Arc<AtomicUsize>,
 }
 
 impl PatternCompiler {
@@ -70,12 +85,64 @@ impl PatternCompiler {
     /// The compiler starts with an empty program and no capture groups.
     /// Each compiler instance should only be used to compile a single pattern.
     pub fn new() -> Self {
+        let max_instructions = ExecutionBudget::current_or_default()
+            .pattern_step_limit()
+            .min(MAX_COMPILED_PATTERN_INSTRUCTIONS);
+        Self::with_instruction_limit(max_instructions)
+    }
+
+    fn with_instruction_limit(max_instructions: usize) -> Self {
+        Self::with_shared_instruction_limit(max_instructions, Arc::new(AtomicUsize::new(0)))
+    }
+
+    fn with_shared_instruction_limit(
+        max_instructions: usize,
+        emitted_instructions: Arc<AtomicUsize>,
+    ) -> Self {
         Self {
             program: Program::new(),
             capture_names: Vec::new(),
             capture_map: HashMap::new(),
             save_counter: 0,
+            max_instructions,
+            emitted_instructions,
         }
+    }
+
+    fn instruction_limit_error(&self) -> PatternError {
+        PatternError::CompileError(format!(
+            "Pattern bytecode exceeds the compilation instruction limit ({})",
+            self.max_instructions
+        ))
+    }
+
+    fn checked_instruction_add(&self, left: usize, right: usize) -> Result<usize, PatternError> {
+        left.checked_add(right)
+            .filter(|total| *total <= self.max_instructions)
+            .ok_or_else(|| self.instruction_limit_error())
+    }
+
+    fn checked_instruction_mul(&self, left: usize, right: usize) -> Result<usize, PatternError> {
+        left.checked_mul(right)
+            .filter(|total| *total <= self.max_instructions)
+            .ok_or_else(|| self.instruction_limit_error())
+    }
+
+    fn ensure_instruction_capacity(&self, additional: usize) -> Result<(), PatternError> {
+        self.emitted_instructions
+            .load(Ordering::Relaxed)
+            .checked_add(additional)
+            .filter(|total| *total <= self.max_instructions)
+            .map(|_| ())
+            .ok_or_else(|| self.instruction_limit_error())
+    }
+
+    fn emit_instruction(&mut self, instruction: Instruction) -> Result<(), PatternError> {
+        self.ensure_instruction_capacity(1)?;
+        self.program.push(instruction);
+        let previous = self.emitted_instructions.fetch_add(1, Ordering::Relaxed);
+        debug_assert!(previous < self.max_instructions);
+        Ok(())
     }
 
     /// Compile a PatternExpression AST into executable bytecode.
@@ -110,8 +177,9 @@ impl PatternCompiler {
     /// # }
     /// ```
     pub fn compile(&mut self, pattern: &PatternExpression) -> Result<Program, PatternError> {
+        self.ensure_pattern_fits(pattern)?;
         self.compile_expression(pattern)?;
-        self.program.push(Instruction::Match);
+        self.emit_instruction(Instruction::Match)?;
 
         // Set metadata
         self.program.set_num_captures(self.capture_names.len());
@@ -152,8 +220,10 @@ impl PatternCompiler {
         pattern: &PatternExpression,
         env: &Environment,
     ) -> Result<Program, PatternError> {
-        self.compile_expression_with_env(pattern, env)?;
-        self.program.push(Instruction::Match);
+        let resolved_pattern = self.resolve_list_references(pattern, env)?;
+        self.ensure_pattern_fits(&resolved_pattern)?;
+        self.compile_expression(&resolved_pattern)?;
+        self.emit_instruction(Instruction::Match)?;
 
         // Set metadata
         self.program.set_num_captures(self.capture_names.len());
@@ -171,6 +241,105 @@ impl PatternCompiler {
     /// * `Vec<String>` - Names of all capture groups found during compilation
     pub fn capture_names(&self) -> Vec<String> {
         self.capture_names.clone()
+    }
+
+    /// Preflight bytecode growth before entering any quantifier loop. All
+    /// arithmetic is checked, so even multiply-nested `u32::MAX` counts become
+    /// a normal compile error rather than wrapping or iterating to exhaustion.
+    fn ensure_pattern_fits(&self, pattern: &PatternExpression) -> Result<(), PatternError> {
+        let body_instructions = self.estimate_pattern_instructions(pattern)?;
+        let total_instructions = self.checked_instruction_add(body_instructions, 1)?; // Match
+        self.ensure_instruction_capacity(total_instructions)
+    }
+
+    fn estimate_pattern_instructions(
+        &self,
+        pattern: &PatternExpression,
+    ) -> Result<usize, PatternError> {
+        match pattern {
+            PatternExpression::Literal(text) => Ok(if text.is_empty() { 0 } else { 1 }),
+            PatternExpression::CharacterClass(_)
+            | PatternExpression::Backreference(_)
+            | PatternExpression::Anchor(_) => Ok(1),
+            PatternExpression::ListReference(_) => Ok(0),
+            PatternExpression::Sequence(patterns) => {
+                let mut total = 0;
+                for pattern in patterns {
+                    total = self.checked_instruction_add(
+                        total,
+                        self.estimate_pattern_instructions(pattern)?,
+                    )?;
+                }
+                Ok(total)
+            }
+            PatternExpression::Alternative(patterns) => {
+                let mut total = 0;
+                for pattern in patterns {
+                    total = self.checked_instruction_add(
+                        total,
+                        self.estimate_pattern_instructions(pattern)?,
+                    )?;
+                }
+                let branch_instructions =
+                    self.checked_instruction_mul(patterns.len().saturating_sub(1), 2)?;
+                self.checked_instruction_add(total, branch_instructions)
+            }
+            PatternExpression::Quantified {
+                pattern,
+                quantifier,
+            } => {
+                if let Quantifier::Between(min, max) = quantifier
+                    && min > max
+                {
+                    return Err(Self::invalid_range_error(*min, *max));
+                }
+                let inner = self.estimate_pattern_instructions(pattern)?;
+                // Repeating an empty expression still performs one compiler
+                // iteration per count, so charge at least one expansion unit.
+                let expansion_unit = inner.max(1);
+                match quantifier {
+                    Quantifier::Optional => self.checked_instruction_add(inner, 1),
+                    Quantifier::ZeroOrMore => self.checked_instruction_add(inner, 2),
+                    Quantifier::OneOrMore => {
+                        let repeated = self.checked_instruction_mul(inner, 2)?;
+                        self.checked_instruction_add(repeated, 2)
+                    }
+                    Quantifier::Exactly(count) => {
+                        self.checked_instruction_mul(expansion_unit, *count as usize)
+                    }
+                    Quantifier::Between(min, max) => {
+                        let repeated =
+                            self.checked_instruction_mul(expansion_unit, *max as usize)?;
+                        self.checked_instruction_add(repeated, (*max - *min) as usize)
+                    }
+                    Quantifier::AtLeast(count) => {
+                        let repetitions = (*count as usize)
+                            .checked_add(1)
+                            .ok_or_else(|| self.instruction_limit_error())?;
+                        let repeated = self.checked_instruction_mul(expansion_unit, repetitions)?;
+                        self.checked_instruction_add(repeated, 2)
+                    }
+                    Quantifier::AtMost(count) => {
+                        let one_optional = self.checked_instruction_add(inner, 1)?;
+                        self.checked_instruction_mul(one_optional, *count as usize)
+                    }
+                }
+            }
+            PatternExpression::Capture { pattern, .. }
+            | PatternExpression::Lookahead(pattern)
+            | PatternExpression::NegativeLookahead(pattern)
+            | PatternExpression::Lookbehind(pattern)
+            | PatternExpression::NegativeLookbehind(pattern) => {
+                let inner = self.estimate_pattern_instructions(pattern)?;
+                self.checked_instruction_add(inner, 2)
+            }
+        }
+    }
+
+    fn invalid_range_error(min: u32, max: u32) -> PatternError {
+        PatternError::CompileError(format!(
+            "Pattern quantifier lower bound ({min}) cannot exceed upper bound ({max})"
+        ))
     }
 
     /// Compile a single pattern expression node recursively.
@@ -241,38 +410,6 @@ impl PatternCompiler {
                 return Err(PatternError::CompileError(
                     "List references require environment context for compilation. Use compile_with_env() instead.".to_string(),
                 ));
-            }
-        }
-        Ok(())
-    }
-
-    /// Compile a single pattern expression node recursively with environment access.
-    ///
-    /// This is similar to `compile_expression` but allows resolving list references
-    /// from the provided environment. List references are resolved at compile time
-    /// and converted to alternative patterns.
-    ///
-    /// # Arguments
-    /// * `pattern` - The AST node to compile
-    /// * `env` - Environment containing variable definitions
-    ///
-    /// # Returns
-    /// * `Ok(())` - Node compiled successfully
-    /// * `Err(PatternError)` - Compilation failed or list not found
-    fn compile_expression_with_env(
-        &mut self,
-        pattern: &PatternExpression,
-        env: &Environment,
-    ) -> Result<(), PatternError> {
-        match pattern {
-            PatternExpression::ListReference(name) => {
-                self.compile_list_reference(name, env)?;
-            }
-
-            // For all other patterns, recursively handle any nested list references
-            _ => {
-                let resolved_pattern = self.resolve_list_references(pattern, env)?;
-                self.compile_expression(&resolved_pattern)?;
             }
         }
         Ok(())
@@ -393,17 +530,6 @@ impl PatternCompiler {
         }
     }
 
-    /// Compile a list reference by resolving it from the environment.
-    fn compile_list_reference(
-        &mut self,
-        name: &str,
-        env: &Environment,
-    ) -> Result<(), PatternError> {
-        let resolved =
-            self.resolve_list_references(&PatternExpression::ListReference(name.to_string()), env)?;
-        self.compile_expression(&resolved)
-    }
-
     /// Compile a literal string into matching instructions.
     ///
     /// Optimizes single characters to use `Char` instruction for efficiency.
@@ -419,10 +545,10 @@ impl PatternCompiler {
         if text.len() == 1 {
             // Single character - use Char instruction
             let ch = text.chars().next().unwrap();
-            self.program.push(Instruction::Char(ch));
+            self.emit_instruction(Instruction::Char(ch))?;
         } else {
             // Multi-character string - use Literal instruction
-            self.program.push(Instruction::Literal(text.to_string()));
+            self.emit_instruction(Instruction::Literal(text.to_string()))?;
         }
         Ok(())
     }
@@ -449,7 +575,7 @@ impl PatternCompiler {
                 CharClassType::UnicodeProperty(property.clone())
             }
         };
-        self.program.push(Instruction::CharClass(class_type));
+        self.emit_instruction(Instruction::CharClass(class_type))?;
         Ok(())
     }
 
@@ -498,13 +624,13 @@ impl PatternCompiler {
             } else {
                 // Not the last - emit split and compile pattern
                 let split_addr = self.program.len();
-                self.program.push(Instruction::Split(0, 0)); // Will be patched
+                self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                 self.compile_expression(pattern)?;
 
                 // Jump to end after this alternative succeeds
                 let jump_addr = self.program.len();
-                self.program.push(Instruction::Jump(0)); // Will be patched
+                self.emit_instruction(Instruction::Jump(0))?; // Will be patched
                 jump_to_end.push(jump_addr);
 
                 // Patch the split to point to the next alternative
@@ -543,7 +669,7 @@ impl PatternCompiler {
                 // L2: (continue)
 
                 let split_addr = self.program.len();
-                self.program.push(Instruction::Split(0, 0)); // Will be patched
+                self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                 self.compile_expression(pattern)?;
 
@@ -566,12 +692,12 @@ impl PatternCompiler {
                 // L3: (continue)
 
                 let loop_start = self.program.len();
-                self.program.push(Instruction::Split(0, 0)); // Will be patched
+                self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                 self.compile_expression(pattern)?;
 
                 // Jump back to loop start
-                self.program.push(Instruction::Jump(loop_start));
+                self.emit_instruction(Instruction::Jump(loop_start))?;
 
                 let end_addr = self.program.len();
 
@@ -595,12 +721,12 @@ impl PatternCompiler {
                 self.compile_expression(pattern)?;
 
                 let loop_start = self.program.len();
-                self.program.push(Instruction::Split(0, 0)); // Will be patched
+                self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                 self.compile_expression(pattern)?;
 
                 // Jump back to loop start
-                self.program.push(Instruction::Jump(loop_start));
+                self.emit_instruction(Instruction::Jump(loop_start))?;
 
                 let end_addr = self.program.len();
 
@@ -623,16 +749,20 @@ impl PatternCompiler {
             Quantifier::Between(min, max) => {
                 // Between min and max: first min required, then up to (max-min) optional
 
+                if min > max {
+                    return Err(Self::invalid_range_error(*min, *max));
+                }
+
                 // Required repetitions
                 for _ in 0..*min {
                     self.compile_expression(pattern)?;
                 }
 
                 // Optional repetitions
-                let optional_count = max - min;
+                let optional_count = *max - *min;
                 for _ in 0..optional_count {
                     let split_addr = self.program.len();
-                    self.program.push(Instruction::Split(0, 0)); // Will be patched
+                    self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                     self.compile_expression(pattern)?;
 
@@ -658,12 +788,12 @@ impl PatternCompiler {
 
                 // Then zero or more (same as ZeroOrMore logic)
                 let loop_start = self.program.len();
-                self.program.push(Instruction::Split(0, 0)); // Will be patched
+                self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                 self.compile_expression(pattern)?;
 
                 // Jump back to loop start
-                self.program.push(Instruction::Jump(loop_start));
+                self.emit_instruction(Instruction::Jump(loop_start))?;
 
                 let end_addr = self.program.len();
 
@@ -681,7 +811,7 @@ impl PatternCompiler {
 
                 for _ in 0..*n {
                     let split_addr = self.program.len();
-                    self.program.push(Instruction::Split(0, 0)); // Will be patched
+                    self.emit_instruction(Instruction::Split(0, 0))?; // Will be patched
 
                     self.compile_expression(pattern)?;
 
@@ -718,13 +848,13 @@ impl PatternCompiler {
         };
 
         // Start capture
-        self.program.push(Instruction::StartCapture(capture_index));
+        self.emit_instruction(Instruction::StartCapture(capture_index))?;
 
         // Compile the pattern
         self.compile_expression(pattern)?;
 
         // End capture
-        self.program.push(Instruction::EndCapture(capture_index));
+        self.emit_instruction(Instruction::EndCapture(capture_index))?;
 
         Ok(())
     }
@@ -733,7 +863,7 @@ impl PatternCompiler {
     fn compile_backreference(&mut self, name: &str) -> Result<(), PatternError> {
         // Look up the capture index by name
         if let Some(&capture_index) = self.capture_map.get(name) {
-            self.program.push(Instruction::Backreference(capture_index));
+            self.emit_instruction(Instruction::Backreference(capture_index))?;
             Ok(())
         } else {
             Err(PatternError::CompileError(format!(
@@ -746,10 +876,10 @@ impl PatternCompiler {
     fn compile_anchor(&mut self, anchor: &Anchor) -> Result<(), PatternError> {
         match anchor {
             Anchor::StartOfText => {
-                self.program.push(Instruction::StartAnchor);
+                self.emit_instruction(Instruction::StartAnchor)?;
             }
             Anchor::EndOfText => {
-                self.program.push(Instruction::EndAnchor);
+                self.emit_instruction(Instruction::EndAnchor)?;
             }
         }
         Ok(())
@@ -761,9 +891,9 @@ impl PatternCompiler {
         // 1. Begin lookahead (saves position)
         // 2. Compile the pattern to check
         // 3. End lookahead (restores position if pattern matched)
-        self.program.push(Instruction::BeginLookahead);
+        self.emit_instruction(Instruction::BeginLookahead)?;
         self.compile_expression(pattern)?;
-        self.program.push(Instruction::EndLookahead);
+        self.emit_instruction(Instruction::EndLookahead)?;
         Ok(())
     }
 
@@ -776,23 +906,26 @@ impl PatternCompiler {
         // 1. Begin negative lookahead (saves position)
         // 2. Compile the pattern to check
         // 3. End negative lookahead (restores position if pattern didn't match)
-        self.program.push(Instruction::BeginNegativeLookahead);
+        self.emit_instruction(Instruction::BeginNegativeLookahead)?;
         self.compile_expression(pattern)?;
-        self.program.push(Instruction::EndNegativeLookahead);
+        self.emit_instruction(Instruction::EndNegativeLookahead)?;
         Ok(())
     }
 
     /// Compile a positive lookbehind
     fn compile_lookbehind(&mut self, pattern: &PatternExpression) -> Result<(), PatternError> {
         // Create a separate program for the lookbehind pattern
-        let mut lookbehind_compiler = PatternCompiler::new();
+        let mut lookbehind_compiler = PatternCompiler::with_shared_instruction_limit(
+            self.max_instructions,
+            Arc::clone(&self.emitted_instructions),
+        );
         lookbehind_compiler.compile_expression(pattern)?;
-        lookbehind_compiler.program.push(Instruction::Match);
+        lookbehind_compiler.emit_instruction(Instruction::Match)?;
 
         // Embed the lookbehind program in the instruction
-        self.program.push(Instruction::CheckLookbehind(Box::new(
+        self.emit_instruction(Instruction::CheckLookbehind(Box::new(
             lookbehind_compiler.program,
-        )));
+        )))?;
 
         Ok(())
     }
@@ -803,15 +936,17 @@ impl PatternCompiler {
         pattern: &PatternExpression,
     ) -> Result<(), PatternError> {
         // Create a separate program for the negative lookbehind pattern
-        let mut lookbehind_compiler = PatternCompiler::new();
+        let mut lookbehind_compiler = PatternCompiler::with_shared_instruction_limit(
+            self.max_instructions,
+            Arc::clone(&self.emitted_instructions),
+        );
         lookbehind_compiler.compile_expression(pattern)?;
-        lookbehind_compiler.program.push(Instruction::Match);
+        lookbehind_compiler.emit_instruction(Instruction::Match)?;
 
         // Embed the lookbehind program in the instruction
-        self.program
-            .push(Instruction::CheckNegativeLookbehind(Box::new(
-                lookbehind_compiler.program,
-            )));
+        self.emit_instruction(Instruction::CheckNegativeLookbehind(Box::new(
+            lookbehind_compiler.program,
+        )))?;
 
         Ok(())
     }
@@ -845,6 +980,7 @@ impl Default for PatternCompiler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exec::BudgetLimits;
     use crate::parser::ast::{CharClass, PatternExpression, Quantifier};
 
     #[test]
@@ -957,5 +1093,123 @@ mod tests {
         }
         assert_eq!(program.instructions[2], Instruction::EndCapture(0));
         assert_eq!(program.instructions[3], Instruction::Match);
+    }
+
+    fn quantified(pattern: PatternExpression, quantifier: Quantifier) -> PatternExpression {
+        PatternExpression::Quantified {
+            pattern: Box::new(pattern),
+            quantifier,
+        }
+    }
+
+    fn assert_compile_error_without_panic(pattern: PatternExpression, expected: &str) {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut compiler = PatternCompiler::with_instruction_limit(64);
+            compiler.compile(&pattern)
+        }));
+        let compile_result = result.expect("invalid quantifier must not panic");
+        let error = compile_result.expect_err("invalid quantifier must not compile");
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn descending_between_quantifier_returns_compile_error_without_panicking() {
+        assert_compile_error_without_panic(
+            quantified(
+                PatternExpression::CharacterClass(CharClass::Digit),
+                Quantifier::Between(10, 1),
+            ),
+            "lower bound",
+        );
+    }
+
+    #[test]
+    fn huge_quantifiers_hit_compile_limit_before_expansion() {
+        for quantifier in [
+            Quantifier::Exactly(u32::MAX),
+            Quantifier::Between(u32::MAX - 1, u32::MAX),
+            Quantifier::AtLeast(u32::MAX),
+            Quantifier::AtMost(u32::MAX),
+        ] {
+            assert_compile_error_without_panic(
+                quantified(
+                    PatternExpression::CharacterClass(CharClass::Digit),
+                    quantifier,
+                ),
+                "instruction limit",
+            );
+        }
+
+        assert_compile_error_without_panic(
+            quantified(
+                PatternExpression::Literal(String::new()),
+                Quantifier::Exactly(u32::MAX),
+            ),
+            "instruction limit",
+        );
+    }
+
+    #[test]
+    fn quantifier_instruction_estimate_overflow_is_a_compile_error() {
+        let repeated = quantified(
+            quantified(
+                quantified(
+                    PatternExpression::CharacterClass(CharClass::Digit),
+                    Quantifier::Exactly(u32::MAX),
+                ),
+                Quantifier::Exactly(u32::MAX),
+            ),
+            Quantifier::Exactly(u32::MAX),
+        );
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut compiler = PatternCompiler::with_instruction_limit(usize::MAX);
+            compiler.compile(&repeated)
+        }));
+        let compile_result = result.expect("instruction estimate overflow must not panic");
+        let error = compile_result.expect_err("overflowing instruction estimate must be rejected");
+        assert!(error.to_string().contains("instruction limit"));
+    }
+
+    #[test]
+    fn normal_exact_and_range_quantifiers_keep_their_bytecode_shape() {
+        let mut exact_compiler = PatternCompiler::with_instruction_limit(64);
+        let exact = exact_compiler
+            .compile(&quantified(
+                PatternExpression::CharacterClass(CharClass::Digit),
+                Quantifier::Exactly(3),
+            ))
+            .unwrap();
+        assert_eq!(exact.instructions.len(), 4); // Three classes + Match.
+
+        let mut range_compiler = PatternCompiler::with_instruction_limit(64);
+        let range = range_compiler
+            .compile(&quantified(
+                PatternExpression::CharacterClass(CharClass::Digit),
+                Quantifier::Between(2, 4),
+            ))
+            .unwrap();
+        assert_eq!(range.instructions.len(), 7); // Two required, two optional, Match.
+    }
+
+    #[test]
+    fn compiler_ceiling_honors_the_active_pattern_step_budget() {
+        let mut limits = BudgetLimits::default();
+        limits.max_pattern_steps = 3;
+        let _budget_guard =
+            ExecutionBudget::enter(std::sync::Arc::new(ExecutionBudget::new(limits)));
+
+        let mut compiler = PatternCompiler::new();
+        let error = compiler
+            .compile(&quantified(
+                PatternExpression::CharacterClass(CharClass::Digit),
+                Quantifier::Exactly(3),
+            ))
+            .expect_err("three classes plus Match exceed a three-step budget");
+
+        assert!(error.to_string().contains("instruction limit (3)"));
     }
 }

--- a/src/pattern/compiler.rs
+++ b/src/pattern/compiler.rs
@@ -6,7 +6,6 @@
 
 use super::PatternError;
 use super::instruction::{CharClassType, Instruction, Program};
-use crate::exec::ExecutionBudget;
 use crate::interpreter::environment::Environment;
 use crate::interpreter::value::Value;
 use crate::parser::ast::{Anchor, CharClass, PatternExpression, Quantifier};
@@ -71,8 +70,7 @@ pub struct PatternCompiler {
     capture_map: HashMap<String, usize>,
     /// Counter for save slots (currently unused but preserved for future use)
     save_counter: usize,
-    /// Maximum number of instructions this compilation may emit. This is
-    /// capped by both the hard compilation ceiling and the active run budget.
+    /// Maximum number of instructions this compilation may emit.
     max_instructions: usize,
     /// Instructions emitted across the root program and embedded lookbehind
     /// programs. Lookbehind compilers share this counter with their parent.
@@ -85,10 +83,7 @@ impl PatternCompiler {
     /// The compiler starts with an empty program and no capture groups.
     /// Each compiler instance should only be used to compile a single pattern.
     pub fn new() -> Self {
-        let max_instructions = ExecutionBudget::current_or_default()
-            .pattern_step_limit()
-            .min(MAX_COMPILED_PATTERN_INSTRUCTIONS);
-        Self::with_instruction_limit(max_instructions)
+        Self::with_instruction_limit(MAX_COMPILED_PATTERN_INSTRUCTIONS)
     }
 
     fn with_instruction_limit(max_instructions: usize) -> Self {
@@ -980,7 +975,6 @@ impl Default for PatternCompiler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::exec::BudgetLimits;
     use crate::parser::ast::{CharClass, PatternExpression, Quantifier};
 
     #[test]
@@ -1193,23 +1187,5 @@ mod tests {
             ))
             .unwrap();
         assert_eq!(range.instructions.len(), 7); // Two required, two optional, Match.
-    }
-
-    #[test]
-    fn compiler_ceiling_honors_the_active_pattern_step_budget() {
-        let mut limits = BudgetLimits::default();
-        limits.max_pattern_steps = 3;
-        let _budget_guard =
-            ExecutionBudget::enter(std::sync::Arc::new(ExecutionBudget::new(limits)));
-
-        let mut compiler = PatternCompiler::new();
-        let error = compiler
-            .compile(&quantified(
-                PatternExpression::CharacterClass(CharClass::Digit),
-                Quantifier::Exactly(3),
-            ))
-            .expect_err("three classes plus Match exceed a three-step budget");
-
-        assert!(error.to_string().contains("instruction limit (3)"));
     }
 }


### PR DESCRIPTION
## Summary

- validate pattern quantifier counts before signed-to-unsigned conversion
- reject descending bounded ranges at the parser and compiler boundaries
- preflight bytecode expansion with checked arithmetic before entering repetition loops
- cap compiled pattern bytecode at 100,000 instructions
- share instruction accounting with embedded lookbehind programs
- add adversarial overflow/range regressions and compatibility checks for ordinary quantifiers

## Security impact

Attacker-controlled quantifier counts could wrap during conversion, underflow descending ranges, or make the compiler expand billions of repetitions before the pattern VM's runtime budget existed. Invalid and oversized patterns now fail with normal compile errors before expansion.

## Validation

- `git diff --check`
- Rust tree-sitter syntax scan
- focused parser/compiler regressions cover descending ranges, out-of-`u32` values, huge exact/range/at-least/at-most counts, empty repeated patterns, nested arithmetic overflow, and ordinary bytecode shapes
- repository CI caught and prompted a fix for coupling the compile ceiling to deliberately tiny runtime-step test budgets; the replacement run passed
- all GitHub CI, config lint, and review checks passed on the final head

## Production readiness

- area: Security / Reliability / Testing
- advances the pattern/ReDoS gate tracked in #610
- compatibility impact: patterns whose compiled form exceeds 100,000 instructions now return a compile error instead of consuming unbounded CPU or memory