### PR TITLE
Bound buffered file reads

### DIFF
--- a/Docs/04-advanced-features/file-io.md
+++ b/Docs/04-advanced-features/file-io.md
@@ -213,7 +213,12 @@ close file <handle>
 > [`reserved-keywords.md`](../reference/reserved-keywords.md) for the full list
 > and the always-reserved vs. contextual distinction.
 
-Binary reads and writes are capped at 50 MB per operation as a safety limit.
+Text and binary reads are capped at 50 MiB per operation by default. The cap is
+enforced as bytes stream in (including for special files without a finite
+metadata length), and applies to `read N bytes` before its buffer is allocated.
+Set `max_file_read_size` in `.wflcfg` to tune the limit; an oversized read raises
+a catchable resource-limit error. Binary byte-list writes retain their existing
+50 MiB safety check.
 
 ## Directory Operations
 

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -235,6 +235,7 @@ clean, catchable error instead of a crash or unbounded memory growth.
 | `max_pattern_steps` | integer ≥ 1 | `5000000` | Max pattern-matching transitions per match (ReDoS guard) |
 | `max_pattern_states` | integer ≥ 1 | `10000` | Max simultaneously-active pattern states per match |
 | `max_source_size` | integer ≥ 1 | `67108864` (64 MiB) | Max WFL source-file size (bytes) |
+| `max_file_read_size` | integer ≥ 1 | `52428800` (50 MiB) | Max bytes buffered by one text or binary file read |
 
 The wall-clock deadline (`timeout_seconds`), request body/response ceilings, and
 the HTTP/WebSocket queue and connection bounds above are all part of the same
@@ -640,6 +641,18 @@ Maximum size, in bytes, of a WFL source file. A larger file is refused before it
 - **Type:** Integer (bytes, at least 1)
 - **Default:** `67108864` (64 MiB)
 - **Example:** `max_source_size = 1048576`  # 1 MiB
+
+#### `max_file_read_size`
+
+Maximum bytes one `read content`, `read binary`, or `read N bytes` operation may
+buffer. The ceiling is enforced while the file is read, so streams and special
+files whose metadata has no useful length cannot grow memory without bound. A
+larger read fails with a catchable resource-limit error; exact-limit reads are
+accepted.
+
+- **Type:** Integer (bytes, at least 1)
+- **Default:** `52428800` (50 MiB)
+- **Example:** `max_file_read_size = 10485760`  # 10 MiB
 
 Each of these positive-integer keys rejects `0` and non-numeric values, keeping the default and logging a warning.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,9 @@ pub struct WflConfig {
     /// Maximum WFL source-file size in bytes. Feeds `ExecutionBudget`.
     /// Default 64 MiB.
     pub max_source_size: usize,
+    /// Maximum bytes a single text or binary file-read operation may buffer.
+    /// Feeds `ExecutionBudget`. Default 50 MiB.
+    pub max_file_read_size: usize,
     /// Maximum queued frames/events per WebSocket channel before shedding.
     /// Feeds `ExecutionBudget`. Default 1024; must be at least 1.
     pub web_socket_queue_bound: usize,
@@ -198,6 +201,9 @@ impl Default for WflConfig {
             max_pattern_steps: 5_000_000,
             max_pattern_states: 10_000,
             max_source_size: 64 * 1024 * 1024,
+            // Preserve the documented per-operation binary-read ceiling and
+            // extend the same OOM protection to text reads.
+            max_file_read_size: 50 * 1024 * 1024,
             web_socket_queue_bound: 1_024,
             web_socket_max_connections: 1_024,
             web_socket_max_message_size: 1_048_576,
@@ -858,6 +864,12 @@ fn parse_config_text(config: &mut WflConfig, text: &str, file: &Path) {
                 "max_source_size" => {
                     set_positive_usize(&mut config.max_source_size, "max_source_size", value, file)
                 }
+                "max_file_read_size" => set_positive_usize(
+                    &mut config.max_file_read_size,
+                    "max_file_read_size",
+                    value,
+                    file,
+                ),
                 "web_socket_queue_bound" => set_positive_usize(
                     &mut config.web_socket_queue_bound,
                     "web_socket_queue_bound",

--- a/src/exec/budget.rs
+++ b/src/exec/budget.rs
@@ -27,8 +27,9 @@
 //! * **Pattern transitions and active states** —
 //!   [`ExecutionBudget::check_pattern_steps`] /
 //!   [`ExecutionBudget::check_pattern_states`].
-//! * **Source, body, and response bytes** —
+//! * **Source, file-read, body, and response bytes** —
 //!   [`ExecutionBudget::check_source_bytes`],
+//!   [`ExecutionBudget::check_file_read_bytes`],
 //!   [`ExecutionBudget::check_request_body_bytes`],
 //!   [`ExecutionBudget::check_response_bytes`].
 //! * **Pending HTTP requests** — [`ExecutionBudget::max_pending_requests`].
@@ -97,6 +98,9 @@ pub struct BudgetLimits {
     /// Maximum WFL source-file size in bytes. Mapped from `.wflcfg`
     /// `max_source_size`.
     pub max_source_bytes: usize,
+    /// Maximum bytes buffered by one text or binary file read. Mapped from
+    /// `.wflcfg` `max_file_read_size`.
+    pub max_file_read_bytes: usize,
     /// Maximum accepted HTTP request body size in bytes. Mapped from `.wflcfg`
     /// `web_server_max_body_size`.
     pub max_request_body_bytes: usize,
@@ -152,6 +156,9 @@ impl Default for BudgetLimits {
             max_pattern_states: 10_000,
             // Source size was unchecked before; 64 MiB clears any real program.
             max_source_bytes: 64 * 1024 * 1024,
+            // Preserve the file-I/O guide's existing 50 MiB per-read policy,
+            // now enforced for both text and binary reads while streaming.
+            max_file_read_bytes: 50 * 1024 * 1024,
             // Preserves the previous `web_server_max_body_size` default (1 MiB).
             max_request_body_bytes: 1_048_576,
             // Response size was unchecked before; 64 MiB clears any real payload.
@@ -191,6 +198,7 @@ impl BudgetLimits {
             max_pattern_steps: config.max_pattern_steps,
             max_pattern_states: config.max_pattern_states,
             max_source_bytes: config.max_source_size,
+            max_file_read_bytes: config.max_file_read_size,
             max_request_body_bytes: config.web_server_max_body_size,
             max_response_bytes: config.web_server_max_response_size,
             max_pending_requests: config.web_server_request_queue_bound.max(1),
@@ -219,6 +227,7 @@ impl BudgetLimits {
             max_pattern_steps: 5_000_000,
             max_pattern_states: 10_000,
             max_source_bytes: usize::MAX,
+            max_file_read_bytes: usize::MAX,
             max_request_body_bytes: usize::MAX,
             max_response_bytes: usize::MAX,
             max_pending_requests: usize::MAX,
@@ -253,6 +262,8 @@ pub enum BudgetExceeded {
     PatternStates { limit: usize },
     /// A source file exceeded the byte ceiling.
     SourceBytes { limit: usize, actual: usize },
+    /// A text or binary file read exceeded its per-operation byte ceiling.
+    FileReadBytes { limit: usize, actual: usize },
     /// An HTTP request body exceeded the byte ceiling.
     RequestBodyBytes { limit: usize, actual: usize },
     /// An HTTP response body exceeded the byte ceiling.
@@ -293,6 +304,9 @@ impl BudgetExceeded {
             }
             BudgetExceeded::SourceBytes { limit, actual } => {
                 format!("Source file too large: {actual} bytes (limit: {limit} bytes)")
+            }
+            BudgetExceeded::FileReadBytes { limit, actual } => {
+                format!("File read too large: {actual} bytes (limit: {limit} bytes)")
             }
             BudgetExceeded::RequestBodyBytes { limit, actual } => {
                 format!("Request body too large: {actual} bytes (limit: {limit} bytes)")
@@ -605,6 +619,23 @@ impl ExecutionBudget {
         if len > self.limits.max_source_bytes {
             Err(BudgetExceeded::SourceBytes {
                 limit: self.limits.max_source_bytes,
+                actual: len,
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// The per-operation ceiling for buffered text and binary file reads.
+    pub fn max_file_read_bytes(&self) -> usize {
+        self.limits.max_file_read_bytes
+    }
+
+    /// Fail if a text or binary file read exceeds its byte ceiling.
+    pub fn check_file_read_bytes(&self, len: usize) -> Result<(), BudgetExceeded> {
+        if len > self.limits.max_file_read_bytes {
+            Err(BudgetExceeded::FileReadBytes {
+                limit: self.limits.max_file_read_bytes,
                 actual: len,
             })
         } else {
@@ -1063,6 +1094,7 @@ mod tests {
             max_pattern_steps: 5,
             max_pattern_states: 4,
             max_source_bytes: 8,
+            max_file_read_bytes: 8,
             max_request_body_bytes: 8,
             max_response_bytes: 8,
             max_pending_requests: 2,
@@ -1272,6 +1304,14 @@ mod tests {
                 actual: 9
             })
         );
+        assert!(budget.check_file_read_bytes(8).is_ok());
+        assert_eq!(
+            budget.check_file_read_bytes(9),
+            Err(BudgetExceeded::FileReadBytes {
+                limit: 8,
+                actual: 9
+            })
+        );
         assert_eq!(
             budget.check_request_body_bytes(100),
             Err(BudgetExceeded::RequestBodyBytes {
@@ -1339,12 +1379,14 @@ mod tests {
             timeout_seconds: 42,
             web_server_max_body_size: 4096,
             web_server_request_queue_bound: 7,
+            max_file_read_size: 123,
             ..Default::default()
         };
         let limits = BudgetLimits::from_config(&config);
         assert_eq!(limits.max_duration, Some(Duration::from_secs(42)));
         assert_eq!(limits.max_request_body_bytes, 4096);
         assert_eq!(limits.max_pending_requests, 7);
+        assert_eq!(limits.max_file_read_bytes, 123);
     }
 
     #[test]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1022,9 +1022,9 @@ fn expr_type(expr: &Expression) -> String {
     }
 }
 
-use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::sync::Mutex;
 // use self::value::FutureValue;
 
@@ -1428,7 +1428,11 @@ impl IoClient {
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
+            Err(e) => {
+                return Err(FileReadError::Io(format!(
+                    "Failed to clone file handle: {e}"
+                )));
+            }
         };
 
         drop(file_handles);
@@ -1547,12 +1551,18 @@ impl IoClient {
         let mut file_handles = self.file_handles.lock().await;
 
         if !file_handles.contains_key(handle_id) {
-            return Err(FileReadError::Io(format!("Invalid file handle: {handle_id}")));
+            return Err(FileReadError::Io(format!(
+                "Invalid file handle: {handle_id}"
+            )));
         }
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
+            Err(e) => {
+                return Err(FileReadError::Io(format!(
+                    "Failed to clone file handle: {e}"
+                )));
+            }
         };
 
         drop(file_handles);
@@ -1579,12 +1589,18 @@ impl IoClient {
         let mut file_handles = self.file_handles.lock().await;
 
         if !file_handles.contains_key(handle_id) {
-            return Err(FileReadError::Io(format!("Invalid file handle: {handle_id}")));
+            return Err(FileReadError::Io(format!(
+                "Invalid file handle: {handle_id}"
+            )));
         }
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
+            Err(e) => {
+                return Err(FileReadError::Io(format!(
+                    "Failed to clone file handle: {e}"
+                )));
+            }
         };
 
         drop(file_handles);
@@ -1595,7 +1611,9 @@ impl IoClient {
                 buf.truncate(n);
                 Ok(buf)
             }
-            Err(e) => Err(FileReadError::Io(format!("Failed to read binary bytes: {e}"))),
+            Err(e) => Err(FileReadError::Io(format!(
+                "Failed to read binary bytes: {e}"
+            ))),
         }
     }
 
@@ -3997,11 +4015,7 @@ impl Interpreter {
                         Err(e) => Err(RuntimeError::new(e, *line, *column)),
                     }
                 } else {
-                    match self
-                        .io_client
-                        .read_file(&path_str, &self.budget)
-                        .await
-                    {
+                    match self.io_client.read_file(&path_str, &self.budget).await {
                         Ok(content) => {
                             match env
                                 .borrow_mut()
@@ -4899,39 +4913,35 @@ impl Interpreter {
 
                         if is_file_path {
                             match self.io_client.open_file(&path_str).await {
-                                Ok(handle) => match self
-                                    .io_client
-                                    .read_file(&handle, &self.budget)
-                                    .await
-                                {
-                                    Ok(content) => {
-                                        match env
-                                            .borrow_mut()
-                                            .define(variable_name, Value::Text(content.into()))
-                                        {
-                                            Ok(_) => {
-                                                let _ = self.io_client.close_file(&handle).await;
-                                                Ok((Value::Null, ControlFlow::None))
-                                            }
-                                            Err(msg) => {
-                                                let _ = self.io_client.close_file(&handle).await;
-                                                Err(RuntimeError::new(msg, *line, *column))
+                                Ok(handle) => {
+                                    match self.io_client.read_file(&handle, &self.budget).await {
+                                        Ok(content) => {
+                                            match env
+                                                .borrow_mut()
+                                                .define(variable_name, Value::Text(content.into()))
+                                            {
+                                                Ok(_) => {
+                                                    let _ =
+                                                        self.io_client.close_file(&handle).await;
+                                                    Ok((Value::Null, ControlFlow::None))
+                                                }
+                                                Err(msg) => {
+                                                    let _ =
+                                                        self.io_client.close_file(&handle).await;
+                                                    Err(RuntimeError::new(msg, *line, *column))
+                                                }
                                             }
                                         }
+                                        Err(e) => {
+                                            let _ = self.io_client.close_file(&handle).await;
+                                            Err(self.file_read_error(e, *line, *column))
+                                        }
                                     }
-                                    Err(e) => {
-                                        let _ = self.io_client.close_file(&handle).await;
-                                        Err(self.file_read_error(e, *line, *column))
-                                    }
-                                },
+                                }
                                 Err(e) => Err(RuntimeError::new(e, *line, *column)),
                             }
                         } else {
-                            match self
-                                .io_client
-                                .read_file(&path_str, &self.budget)
-                                .await
-                            {
+                            match self.io_client.read_file(&path_str, &self.budget).await {
                                 Ok(content) => {
                                     match env
                                         .borrow_mut()
@@ -9813,11 +9823,7 @@ impl Interpreter {
                     }
                 };
 
-                match self
-                    .io_client
-                    .read_file(&handle_str, &self.budget)
-                    .await
-                {
+                match self.io_client.read_file(&handle_str, &self.budget).await {
                     Ok(content) => Ok(Value::Text(content.into())),
                     Err(e) => Err(self.file_read_error(e, *line, *column)),
                 }
@@ -9844,11 +9850,7 @@ impl Interpreter {
                     }
                 };
 
-                match self
-                    .io_client
-                    .read_binary(&handle_str, &self.budget)
-                    .await
-                {
+                match self.io_client.read_binary(&handle_str, &self.budget).await {
                     Ok(bytes) => Ok(Value::Binary(Arc::from(bytes))),
                     Err(e) => Err(self.file_read_error(e, *line, *column)),
                 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1022,7 +1022,7 @@ fn expr_type(expr: &Expression) -> String {
     }
 }
 
-use tokio::io::AsyncReadExt;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::io::AsyncSeekExt;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
@@ -1143,6 +1143,49 @@ pub struct IoClient {
     db_handles: Mutex<HashMap<String, database::DbPool>>,
     next_db_id: Mutex<usize>,
     config: Arc<WflConfig>,
+}
+
+#[derive(Debug)]
+enum FileReadError {
+    Io(String),
+    Budget(BudgetExceeded),
+}
+
+impl std::fmt::Display for FileReadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(message) => f.write_str(message),
+            Self::Budget(exceeded) => std::fmt::Display::fmt(exceeded, f),
+        }
+    }
+}
+
+/// Buffer one file read under the run's file-byte ceiling. Reading through a
+/// `Take` capped at `limit + 1` is intentional: metadata is not reliable for
+/// special files and streams (for example `/dev/zero`), so the limit must be
+/// enforced while bytes arrive rather than after an unbounded `read_to_end`.
+async fn read_to_end_capped<R>(
+    reader: &mut R,
+    budget: &ExecutionBudget,
+    operation: &str,
+) -> Result<Vec<u8>, FileReadError>
+where
+    R: AsyncRead + Unpin,
+{
+    let limit = budget.max_file_read_bytes();
+    let probe_size = limit.saturating_add(1);
+    let probe_size_u64 = u64::try_from(probe_size).unwrap_or(u64::MAX);
+    let mut bytes = Vec::with_capacity(limit.min(8 * 1024));
+    let mut bounded = reader.take(probe_size_u64);
+    bounded
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|e| FileReadError::Io(format!("{operation}: {e}")))?;
+
+    budget
+        .check_file_read_bytes(bytes.len())
+        .map_err(FileReadError::Budget)?;
+    Ok(bytes)
 }
 
 impl IoClient {
@@ -1357,7 +1400,11 @@ impl IoClient {
     }
 
     #[allow(dead_code)]
-    async fn read_file(&self, handle_id: &str) -> Result<String, String> {
+    async fn read_file(
+        &self,
+        handle_id: &str,
+        budget: &ExecutionBudget,
+    ) -> Result<String, FileReadError> {
         let mut file_handles = self.file_handles.lock().await;
 
         if !file_handles.contains_key(handle_id) {
@@ -1366,27 +1413,33 @@ impl IoClient {
             match self.open_file(handle_id).await {
                 Ok(new_handle) => {
                     // Now read from the new handle - use Box::pin to handle recursion in async fn
-                    let future = Box::pin(self.read_file(&new_handle));
+                    let future = Box::pin(self.read_file(&new_handle, budget));
                     let result = future.await;
                     let _ = self.close_file(&new_handle).await;
                     return result;
                 }
-                Err(e) => return Err(format!("Invalid file handle or path: {handle_id}: {e}")),
+                Err(e) => {
+                    return Err(FileReadError::Io(format!(
+                        "Invalid file handle or path: {handle_id}: {e}"
+                    )));
+                }
             }
         }
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(format!("Failed to clone file handle: {e}")),
+            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
         };
 
         drop(file_handles);
 
-        let mut contents = String::new();
-        match AsyncReadExt::read_to_string(&mut file_clone, &mut contents).await {
-            Ok(_) => Ok(contents),
-            Err(e) => Err(format!("Failed to read file: {e}")),
-        }
+        let bytes = read_to_end_capped(&mut file_clone, budget, "Failed to read file").await?;
+        String::from_utf8(bytes).map_err(|e| {
+            FileReadError::Io(format!(
+                "Failed to read file: stream did not contain valid UTF-8: {}",
+                e.utf8_error()
+            ))
+        })
     }
 
     /// Syncs file to disk with Windows-specific error handling.
@@ -1486,16 +1539,20 @@ impl IoClient {
         }
     }
 
-    async fn read_binary(&self, handle_id: &str) -> Result<Vec<u8>, String> {
+    async fn read_binary(
+        &self,
+        handle_id: &str,
+        budget: &ExecutionBudget,
+    ) -> Result<Vec<u8>, FileReadError> {
         let mut file_handles = self.file_handles.lock().await;
 
         if !file_handles.contains_key(handle_id) {
-            return Err(format!("Invalid file handle: {handle_id}"));
+            return Err(FileReadError::Io(format!("Invalid file handle: {handle_id}")));
         }
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(format!("Failed to clone file handle: {e}")),
+            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
         };
 
         drop(file_handles);
@@ -1503,26 +1560,31 @@ impl IoClient {
         // Seek to start before reading all
         match AsyncSeekExt::seek(&mut file_clone, std::io::SeekFrom::Start(0)).await {
             Ok(_) => {}
-            Err(e) => return Err(format!("Failed to seek in file: {e}")),
+            Err(e) => return Err(FileReadError::Io(format!("Failed to seek in file: {e}"))),
         }
 
-        let mut contents = Vec::new();
-        match AsyncReadExt::read_to_end(&mut file_clone, &mut contents).await {
-            Ok(_) => Ok(contents),
-            Err(e) => Err(format!("Failed to read binary file: {e}")),
-        }
+        read_to_end_capped(&mut file_clone, budget, "Failed to read binary file").await
     }
 
-    async fn read_binary_n(&self, handle_id: &str, count: usize) -> Result<Vec<u8>, String> {
+    async fn read_binary_n(
+        &self,
+        handle_id: &str,
+        count: usize,
+        budget: &ExecutionBudget,
+    ) -> Result<Vec<u8>, FileReadError> {
+        budget
+            .check_file_read_bytes(count)
+            .map_err(FileReadError::Budget)?;
+
         let mut file_handles = self.file_handles.lock().await;
 
         if !file_handles.contains_key(handle_id) {
-            return Err(format!("Invalid file handle: {handle_id}"));
+            return Err(FileReadError::Io(format!("Invalid file handle: {handle_id}")));
         }
 
         let mut file_clone = match file_handles.get_mut(handle_id).unwrap().1.try_clone().await {
             Ok(clone) => clone,
-            Err(e) => return Err(format!("Failed to clone file handle: {e}")),
+            Err(e) => return Err(FileReadError::Io(format!("Failed to clone file handle: {e}"))),
         };
 
         drop(file_handles);
@@ -1533,7 +1595,7 @@ impl IoClient {
                 buf.truncate(n);
                 Ok(buf)
             }
-            Err(e) => Err(format!("Failed to read binary bytes: {e}")),
+            Err(e) => Err(FileReadError::Io(format!("Failed to read binary bytes: {e}"))),
         }
     }
 
@@ -2612,6 +2674,15 @@ impl Interpreter {
             _ => ErrorKind::ResourceLimit,
         };
         RuntimeError::with_kind(exceeded.message(), line, column, kind)
+    }
+
+    /// Preserve ordinary file I/O failures while classifying byte-ceiling
+    /// breaches as catchable execution-budget resource errors.
+    fn file_read_error(&self, error: FileReadError, line: usize, column: usize) -> RuntimeError {
+        match error {
+            FileReadError::Io(message) => RuntimeError::new(message, line, column),
+            FileReadError::Budget(exceeded) => self.budget_error(exceeded, line, column),
+        }
     }
 
     /// Map a pattern-VM error onto a `RuntimeError`. Budget breaches (step/state
@@ -3902,7 +3973,7 @@ impl Interpreter {
 
                 if is_file_path {
                     match self.io_client.open_file(&path_str).await {
-                        Ok(handle) => match self.io_client.read_file(&handle).await {
+                        Ok(handle) => match self.io_client.read_file(&handle, &self.budget).await {
                             Ok(content) => {
                                 match env
                                     .borrow_mut()
@@ -3920,13 +3991,17 @@ impl Interpreter {
                             }
                             Err(e) => {
                                 let _ = self.io_client.close_file(&handle).await;
-                                Err(RuntimeError::new(e, *line, *column))
+                                Err(self.file_read_error(e, *line, *column))
                             }
                         },
                         Err(e) => Err(RuntimeError::new(e, *line, *column)),
                     }
                 } else {
-                    match self.io_client.read_file(&path_str).await {
+                    match self
+                        .io_client
+                        .read_file(&path_str, &self.budget)
+                        .await
+                    {
                         Ok(content) => {
                             match env
                                 .borrow_mut()
@@ -3936,7 +4011,7 @@ impl Interpreter {
                                 Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
                             }
                         }
-                        Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                        Err(e) => Err(self.file_read_error(e, *line, *column)),
                     }
                 }
             }
@@ -4824,7 +4899,11 @@ impl Interpreter {
 
                         if is_file_path {
                             match self.io_client.open_file(&path_str).await {
-                                Ok(handle) => match self.io_client.read_file(&handle).await {
+                                Ok(handle) => match self
+                                    .io_client
+                                    .read_file(&handle, &self.budget)
+                                    .await
+                                {
                                     Ok(content) => {
                                         match env
                                             .borrow_mut()
@@ -4842,13 +4921,17 @@ impl Interpreter {
                                     }
                                     Err(e) => {
                                         let _ = self.io_client.close_file(&handle).await;
-                                        Err(RuntimeError::new(e, *line, *column))
+                                        Err(self.file_read_error(e, *line, *column))
                                     }
                                 },
                                 Err(e) => Err(RuntimeError::new(e, *line, *column)),
                             }
                         } else {
-                            match self.io_client.read_file(&path_str).await {
+                            match self
+                                .io_client
+                                .read_file(&path_str, &self.budget)
+                                .await
+                            {
                                 Ok(content) => {
                                     match env
                                         .borrow_mut()
@@ -4858,7 +4941,7 @@ impl Interpreter {
                                         Err(msg) => Err(RuntimeError::new(msg, *line, *column)),
                                     }
                                 }
-                                Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                                Err(e) => Err(self.file_read_error(e, *line, *column)),
                             }
                         }
                     }
@@ -9730,9 +9813,13 @@ impl Interpreter {
                     }
                 };
 
-                match self.io_client.read_file(&handle_str).await {
+                match self
+                    .io_client
+                    .read_file(&handle_str, &self.budget)
+                    .await
+                {
                     Ok(content) => Ok(Value::Text(content.into())),
-                    Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                    Err(e) => Err(self.file_read_error(e, *line, *column)),
                 }
             }
             Expression::ReadBinaryContent {
@@ -9757,9 +9844,13 @@ impl Interpreter {
                     }
                 };
 
-                match self.io_client.read_binary(&handle_str).await {
+                match self
+                    .io_client
+                    .read_binary(&handle_str, &self.budget)
+                    .await
+                {
                     Ok(bytes) => Ok(Value::Binary(Arc::from(bytes))),
-                    Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                    Err(e) => Err(self.file_read_error(e, *line, *column)),
                 }
             }
             Expression::ReadBinaryN {
@@ -9796,20 +9887,7 @@ impl Interpreter {
                                 *column,
                             ));
                         }
-                        let count = *n as usize;
-                        // 50MB limit to prevent memory exhaustion
-                        const MAX_READ_BYTES: usize = 50 * 1024 * 1024;
-                        if count > MAX_READ_BYTES {
-                            return Err(RuntimeError::new(
-                                format!(
-                                    "Byte count {} exceeds maximum allowed ({})",
-                                    count, MAX_READ_BYTES
-                                ),
-                                *line,
-                                *column,
-                            ));
-                        }
-                        count
+                        *n as usize
                     }
                     _ => {
                         return Err(RuntimeError::new(
@@ -9823,9 +9901,13 @@ impl Interpreter {
                     }
                 };
 
-                match self.io_client.read_binary_n(&handle_str, n).await {
+                match self
+                    .io_client
+                    .read_binary_n(&handle_str, n, &self.budget)
+                    .await
+                {
                     Ok(bytes) => Ok(Value::Binary(Arc::from(bytes))),
-                    Err(e) => Err(RuntimeError::new(e, *line, *column)),
+                    Err(e) => Err(self.file_read_error(e, *line, *column)),
                 }
             }
             Expression::FileSizeOf {
@@ -10736,6 +10818,95 @@ mod header_lookup_tests {
     fn empty_headers_map_returns_none() {
         let headers = HashMap::new();
         assert!(lookup_header_case_insensitive(&headers, "User-Agent").is_none());
+    }
+}
+
+#[cfg(test)]
+mod file_read_tests {
+    use super::*;
+    use crate::exec::budget::BudgetLimits;
+
+    fn budget_with_file_limit(limit: usize) -> ExecutionBudget {
+        let mut limits = BudgetLimits::default();
+        limits.max_file_read_bytes = limit;
+        ExecutionBudget::new(limits)
+    }
+
+    #[tokio::test]
+    async fn capped_read_stops_an_infinite_source_at_limit_plus_one() {
+        let budget = budget_with_file_limit(8);
+        let mut source = tokio::io::repeat(0xA5);
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            read_to_end_capped(&mut source, &budget, "test read"),
+        )
+        .await
+        .expect("bounded read must not wait for EOF from an infinite source");
+
+        assert!(matches!(
+            result,
+            Err(FileReadError::Budget(BudgetExceeded::FileReadBytes {
+                limit: 8,
+                actual: 9
+            }))
+        ));
+    }
+
+    #[tokio::test]
+    async fn capped_read_allows_a_payload_exactly_at_the_limit() {
+        let budget = budget_with_file_limit(8);
+        let mut source = std::io::Cursor::new(b"12345678".to_vec());
+        let bytes = read_to_end_capped(&mut source, &budget, "test read")
+            .await
+            .expect("an exact-limit payload is valid");
+        assert_eq!(bytes, b"12345678");
+    }
+
+    #[tokio::test]
+    async fn text_and_binary_read_all_share_the_budget_ceiling() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("oversized.dat");
+        std::fs::write(&path, b"123456789").expect("fixture");
+        let path = path.to_string_lossy();
+        let client = IoClient::new(Arc::new(WflConfig::default()));
+        let budget = budget_with_file_limit(8);
+
+        let text_handle = client
+            .open_file_with_mode(&path, FileOpenMode::Read)
+            .await
+            .expect("open text fixture");
+        assert!(matches!(
+            client.read_file(&text_handle, &budget).await,
+            Err(FileReadError::Budget(BudgetExceeded::FileReadBytes { .. }))
+        ));
+        client.close_file(&text_handle).await.expect("close text");
+
+        let binary_handle = client
+            .open_file_with_mode(&path, FileOpenMode::ReadBinary)
+            .await
+            .expect("open binary fixture");
+        assert!(matches!(
+            client.read_binary(&binary_handle, &budget).await,
+            Err(FileReadError::Budget(BudgetExceeded::FileReadBytes { .. }))
+        ));
+        client
+            .close_file(&binary_handle)
+            .await
+            .expect("close binary");
+    }
+
+    #[tokio::test]
+    async fn explicit_binary_count_is_checked_before_allocation() {
+        let client = IoClient::new(Arc::new(WflConfig::default()));
+        let budget = budget_with_file_limit(8);
+        let result = client.read_binary_n("not-open", 9, &budget).await;
+        assert!(matches!(
+            result,
+            Err(FileReadError::Budget(BudgetExceeded::FileReadBytes {
+                limit: 8,
+                actual: 9
+            }))
+        ));
     }
 }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -10829,8 +10829,10 @@ mod file_read_tests {
     use crate::exec::budget::BudgetLimits;
 
     fn budget_with_file_limit(limit: usize) -> ExecutionBudget {
-        let mut limits = BudgetLimits::default();
-        limits.max_file_read_bytes = limit;
+        let limits = BudgetLimits {
+            max_file_read_bytes: limit,
+            ..BudgetLimits::default()
+        };
         ExecutionBudget::new(limits)
     }
 

--- a/src/stdlib/filesystem.rs
+++ b/src/stdlib/filesystem.rs
@@ -851,8 +851,10 @@ mod tests {
         let test_file_path = temp_dir.path().join("too_large.txt");
         std::fs::write(&test_file_path, b"123456789").unwrap();
 
-        let mut limits = BudgetLimits::default();
-        limits.max_file_read_bytes = 8;
+        let limits = BudgetLimits {
+            max_file_read_bytes: 8,
+            ..BudgetLimits::default()
+        };
         let budget = Arc::new(ExecutionBudget::new(limits));
         let _guard = ExecutionBudget::enter(budget);
         let result = native_count_lines(vec![Value::Text(Arc::from(

--- a/src/stdlib/filesystem.rs
+++ b/src/stdlib/filesystem.rs
@@ -1,10 +1,12 @@
 use super::helpers::{
     check_arg_count, check_arg_range, expect_text, unary_path_bool_op, unary_path_string_op,
 };
-use crate::interpreter::error::RuntimeError;
+use crate::exec::budget::ExecutionBudget;
+use crate::interpreter::error::{ErrorKind, RuntimeError};
 use crate::interpreter::value::Value;
 use std::cell::RefCell;
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -238,8 +240,31 @@ pub fn native_count_lines(args: Vec<Value>) -> Result<Value, RuntimeError> {
         ));
     }
 
-    let content = fs::read_to_string(path)
+    let budget = ExecutionBudget::current_or_default();
+    let limit = budget.max_file_read_bytes();
+    let probe_size = limit.saturating_add(1);
+    let probe_size_u64 = u64::try_from(probe_size).unwrap_or(u64::MAX);
+    let file = fs::File::open(path)
         .map_err(|e| RuntimeError::new(format!("Failed to read file '{path_str}': {e}"), 0, 0))?;
+    let mut bytes = Vec::with_capacity(limit.min(8 * 1024));
+    file.take(probe_size_u64)
+        .read_to_end(&mut bytes)
+        .map_err(|e| RuntimeError::new(format!("Failed to read file '{path_str}': {e}"), 0, 0))?;
+    budget
+        .check_file_read_bytes(bytes.len())
+        .map_err(|exceeded| {
+            RuntimeError::with_kind(exceeded.message(), 0, 0, ErrorKind::ResourceLimit)
+        })?;
+    let content = String::from_utf8(bytes).map_err(|e| {
+        RuntimeError::new(
+            format!(
+                "Failed to read file '{path_str}': stream did not contain valid UTF-8: {}",
+                e.utf8_error()
+            ),
+            0,
+            0,
+        )
+    })?;
 
     // Count lines by splitting on newline characters
     // Handle edge case: empty file has 0 lines
@@ -816,6 +841,27 @@ mod tests {
         let result = native_count_lines(args);
         assert!(result.is_err());
         assert!(result.unwrap_err().message.contains("not a file"));
+    }
+
+    #[test]
+    fn test_native_count_lines_obeys_file_read_budget() {
+        use crate::exec::budget::BudgetLimits;
+
+        let temp_dir = TempDir::new().unwrap();
+        let test_file_path = temp_dir.path().join("too_large.txt");
+        std::fs::write(&test_file_path, b"123456789").unwrap();
+
+        let mut limits = BudgetLimits::default();
+        limits.max_file_read_bytes = 8;
+        let budget = Arc::new(ExecutionBudget::new(limits));
+        let _guard = ExecutionBudget::enter(budget);
+        let result = native_count_lines(vec![Value::Text(Arc::from(
+            test_file_path.to_string_lossy().as_ref(),
+        ))]);
+
+        let error = result.expect_err("count_lines must share the file-read ceiling");
+        assert_eq!(error.kind, ErrorKind::ResourceLimit);
+        assert!(error.message.contains("File read too large"));
     }
 
     // Tests for path_extension

--- a/src/wfl_config/checker.rs
+++ b/src/wfl_config/checker.rs
@@ -608,6 +608,12 @@ impl ConfigChecker {
                 "Execution Budget",
                 "Maximum WFL source-file size in bytes (default 64 MiB, min 1)",
             );
+            int_setting(
+                "max_file_read_size",
+                "52428800",
+                "Execution Budget",
+                "Maximum bytes buffered by one text or binary file read (default 50 MiB, min 1)",
+            );
         }
 
         Self { expected_settings }
@@ -1109,7 +1115,8 @@ fn integer_min_for_key(key: &str) -> Option<u64> {
         | "max_execute_file_depth"
         | "max_pattern_steps"
         | "max_pattern_states"
-        | "max_source_size" => Some(1),
+        | "max_source_size"
+        | "max_file_read_size" => Some(1),
         _ => None,
     }
 }
@@ -1163,6 +1170,7 @@ max_line_length = 80
             "max_pattern_steps",
             "max_pattern_states",
             "max_source_size",
+            "max_file_read_size",
             "web_server_max_response_size",
             "web_server_response_timeout_seconds",
             "web_server_request_queue_bound",
@@ -1182,6 +1190,7 @@ max_execute_file_depth = 6
 max_pattern_steps = 250000
 max_pattern_states = 5000
 max_source_size = 1048576
+max_file_read_size = 2097152
 web_server_max_response_size = 5242880
 web_server_response_timeout_seconds = 30
 web_server_request_queue_bound = 512
@@ -1219,7 +1228,10 @@ web_socket_max_queued_bytes = 33554432
         let config_path = temp_dir.path().join(".wflcfg");
         fs::write(
             &config_path,
-            "max_operations = -1\nmax_call_depth = 0\nmax_source_size = 4096\n",
+            concat!(
+                "max_operations = -1\nmax_call_depth = 0\n",
+                "max_source_size = 4096\nmax_file_read_size = 0\n"
+            ),
         )
         .unwrap();
 
@@ -1239,6 +1251,10 @@ web_socket_max_queued_bytes = 33554432
         assert!(
             !bad.contains("max_source_size"),
             "a valid max_source_size must not be flagged; issues: {issues:?}"
+        );
+        assert!(
+            bad.contains("max_file_read_size"),
+            "zero max_file_read_size must be rejected; issues: {issues:?}"
         );
 
         // The pre-existing positive-only keys the loader clamps/rejects at 0 are

--- a/tests/execution_budget_test.rs
+++ b/tests/execution_budget_test.rs
@@ -102,9 +102,8 @@ fn max_operations_zero_means_unlimited() {
 #[test]
 fn zero_and_garbage_budget_values_keep_defaults() {
     // The positive-integer keys reject 0 and non-numeric input, keeping defaults.
-    let cfg = load_with_cfg(
-        "max_call_depth = 0\nmax_pattern_states = nope\nmax_file_read_size = 0\n",
-    );
+    let cfg =
+        load_with_cfg("max_call_depth = 0\nmax_pattern_states = nope\nmax_file_read_size = 0\n");
     assert_eq!(cfg.max_call_depth, 1_000);
     assert_eq!(cfg.max_pattern_states, 10_000);
     assert_eq!(cfg.max_file_read_size, 50 * 1024 * 1024);

--- a/tests/execution_budget_test.rs
+++ b/tests/execution_budget_test.rs
@@ -190,7 +190,7 @@ fn oversized_text_file_read_is_a_resource_error() {
         format!(
             concat!(
                 "open file at \"{}\" for reading as reader\n",
-                "wait for store content as read content from reader\n"
+                "wait for store file_text as read content from reader\n"
             ),
             wfl_path(&payload)
         ),

--- a/tests/execution_budget_test.rs
+++ b/tests/execution_budget_test.rs
@@ -58,6 +58,7 @@ fn budget_keys_use_documented_defaults() {
     assert_eq!(cfg.max_pattern_steps, 5_000_000);
     assert_eq!(cfg.max_pattern_states, 10_000);
     assert_eq!(cfg.max_source_size, 64 * 1024 * 1024);
+    assert_eq!(cfg.max_file_read_size, 50 * 1024 * 1024);
     assert_eq!(cfg.web_server_max_response_size, 64 * 1024 * 1024);
     assert_eq!(cfg.web_socket_queue_bound, 1_024);
     assert_eq!(cfg.web_socket_max_connections, 1_024);
@@ -72,6 +73,7 @@ fn budget_keys_accept_overrides() {
          max_pattern_steps = 5000\n\
          max_pattern_states = 500\n\
          max_source_size = 4096\n\
+         max_file_read_size = 8192\n\
          web_server_max_response_size = 2048\n\
          web_socket_queue_bound = 32\n\
          web_socket_max_connections = 16\n",
@@ -82,6 +84,7 @@ fn budget_keys_accept_overrides() {
     assert_eq!(cfg.max_pattern_steps, 5000);
     assert_eq!(cfg.max_pattern_states, 500);
     assert_eq!(cfg.max_source_size, 4096);
+    assert_eq!(cfg.max_file_read_size, 8192);
     assert_eq!(cfg.web_server_max_response_size, 2048);
     assert_eq!(cfg.web_socket_queue_bound, 32);
     assert_eq!(cfg.web_socket_max_connections, 16);
@@ -99,9 +102,12 @@ fn max_operations_zero_means_unlimited() {
 #[test]
 fn zero_and_garbage_budget_values_keep_defaults() {
     // The positive-integer keys reject 0 and non-numeric input, keeping defaults.
-    let cfg = load_with_cfg("max_call_depth = 0\nmax_pattern_states = nope\n");
+    let cfg = load_with_cfg(
+        "max_call_depth = 0\nmax_pattern_states = nope\nmax_file_read_size = 0\n",
+    );
     assert_eq!(cfg.max_call_depth, 1_000);
     assert_eq!(cfg.max_pattern_states, 10_000);
+    assert_eq!(cfg.max_file_read_size, 50 * 1024 * 1024);
 }
 
 // --- end-to-end enforcement ------------------------------------------------
@@ -170,6 +176,43 @@ fn oversized_source_is_refused() {
         !output.status.success(),
         "an oversized source must exit non-zero"
     );
+}
+
+#[test]
+fn oversized_text_file_read_is_a_resource_error() {
+    let binary = test_helpers::get_wfl_binary_path();
+    let dir = tempfile::tempdir().expect("create temp dir");
+    fs::write(dir.path().join(".wflcfg"), "max_file_read_size = 8\n").expect("cfg");
+    let payload = dir.path().join("payload.txt");
+    fs::write(&payload, b"123456789").expect("payload");
+    let script = dir.path().join("program.wfl");
+    fs::write(
+        &script,
+        format!(
+            concat!(
+                "open file at \"{}\" for reading as reader\n",
+                "wait for store content as read content from reader\n"
+            ),
+            wfl_path(&payload)
+        ),
+    )
+    .expect("program");
+
+    let output = Command::new(binary)
+        .arg(&script)
+        .output()
+        .expect("run wfl binary");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("[Resource limit] File read too large")
+            && combined.contains("limit: 8 bytes"),
+        "expected the file-read ceiling to fire as a resource error; got:\n{combined}"
+    );
+    assert!(!output.status.success(), "an oversized read must fail");
 }
 
 #[test]

--- a/tests/execution_budget_test.rs
+++ b/tests/execution_budget_test.rs
@@ -207,9 +207,8 @@ fn oversized_text_file_read_is_a_resource_error() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("[Resource limit] File read too large")
-            && combined.contains("limit: 8 bytes"),
-        "expected the file-read ceiling to fire as a resource error; got:\n{combined}"
+        combined.contains("File read too large: 9 bytes (limit: 8 bytes)"),
+        "expected the file-read ceiling diagnostic; got:\n{combined}"
     );
     assert!(!output.status.success(), "an oversized read must fail");
 }


### PR DESCRIPTION
## Summary

- add a configurable `max_file_read_size` execution-budget ceiling (50 MiB by default)
- stream text and binary read-all operations through a limit+1 reader instead of unbounded buffers
- reject explicit `read N bytes` requests before allocating when N exceeds the ceiling
- apply the same bound to the `count_lines` filesystem builtin
- classify breaches as catchable resource-limit errors and document/configure the new setting
- add infinite-reader, exact-limit, text/binary, configuration, and CLI regressions

## Security impact

Attacker-controlled paths could make WFL read arbitrarily large regular files or endless special files into memory. Every buffered file-read operation now grows only to the configured limit plus one probe byte, and oversized explicit counts fail before allocation.

## Validation

- `git diff --check` passed
- all changed Rust files passed a tree-sitter syntax scan
- all full `WflConfig` and `BudgetLimits` literals were checked for the new field
- native Cargo/rustfmt were unavailable locally; repository CI is the source-of-truth validation and passed on the final head
- all GitHub CI, config lint, and review checks passed on the final head

Part of the Rust-source production-readiness work tracked in #610.