### PR TITLE
Stop echoing credential-bearing database URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+- Unsupported database URL errors no longer echo the full connection URL,
+  preventing embedded credentials from being disclosed in diagnostics.
 - **Subprocess policy is enforced on every process launch** (shell path and
   direct-exec / `with arguments` path). Previously, `shell_execution_mode` and
   related checks ran only when the engine believed a shell was required, so

--- a/src/interpreter/database.rs
+++ b/src/interpreter/database.rs
@@ -123,9 +123,10 @@ pub async fn connect(url: &str) -> Result<DbPool, String> {
             .map(DbPool::MySql)
             .map_err(|e| format!("Failed to connect to MariaDB/MySQL database: {e}"))
     } else {
-        Err(format!(
-            "Unsupported database URL '{url}'. Supported schemes: sqlite://, postgres://, postgresql://, mysql://, mariadb://"
-        ))
+        Err(
+            "Unsupported database URL scheme. Supported schemes: sqlite://, postgres://, postgresql://, mysql://, mariadb://"
+                .to_string(),
+        )
     }
 }
 
@@ -418,6 +419,21 @@ row_to_value!(mysql_row_to_value, MySqlRow, mysql_int);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn unsupported_database_url_does_not_echo_credentials() {
+        const SECRET: &str = "WFL_TEST_SECRET_unsupported_password_d5e0ec";
+        let url = format!("oracle://wfl:{SECRET}@database.example/app");
+
+        let error = match connect(&url).await {
+            Ok(_) => panic!("unsupported database URL unexpectedly connected"),
+            Err(error) => error,
+        };
+
+        assert!(error.contains("Unsupported database URL scheme"));
+        assert!(!error.contains(SECRET));
+        assert!(!error.contains(url.as_str()));
+    }
 
     #[test]
     fn whole_numbers_bind_as_integers() {


### PR DESCRIPTION
## Summary

- stop interpolating an unsupported database connection URL into the runtime error
- retain generic supported-scheme guidance without copying user info, host, path, or query data
- add a unique-secret regression and an Unreleased security changelog note

## Security impact

An unsupported URL such as `oracle://user:password@host/db` was copied verbatim into catchable runtime errors, console diagnostics, and default debug reports. Those diagnostics no longer disclose the supplied URL or embedded credentials.

## Validation

- `git diff --check` passed
- changed Rust code passed tree-sitter syntax parsing and the available formatter check
- native Cargo was unavailable locally; repository CI is the source-of-truth validation and passed on the final head
- all GitHub CI, config lint, and review checks passed on the final head

Part of the Rust-source production-readiness work tracked in #610.