### PR TITLE
Confine package filesystem operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+- Package filesystem operations now enforce the manifest's package-name rules,
+  reject symlinked cache/install roots and targets, verify canonical directory
+  containment before recursive deletion, and prevent archive extraction through
+  pre-existing symlink ancestors.
 - **Subprocess policy is enforced on every process launch** (shell path and
   direct-exec / `with arguments` path). Previously, `shell_execution_mode` and
   related checks ran only when the engine believed a shell was required, so

--- a/crates/wflpkg/src/archive.rs
+++ b/crates/wflpkg/src/archive.rs
@@ -122,14 +122,15 @@ pub fn extract_archive(archive_path: &Path, dest_dir: &Path) -> Result<(), Packa
             )));
         }
 
-        // Create parent directories as needed
-        if let Some(parent) = target.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        entry.unpack(&target).map_err(|e| {
+        let unpacked = entry.unpack_in(&dest_canonical).map_err(|e| {
             PackageError::General(format!("Failed to extract {}: {}", entry_path.display(), e))
         })?;
+        if !unpacked {
+            return Err(PackageError::General(format!(
+                "Archive entry escapes destination: {}",
+                entry_path.display()
+            )));
+        }
     }
 
     Ok(())

--- a/crates/wflpkg/src/cache/mod.rs
+++ b/crates/wflpkg/src/cache/mod.rs
@@ -1,7 +1,102 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use crate::error::PackageError;
+use crate::manifest::parser::validate_package_name;
 use crate::manifest::version::Version;
+
+fn verify_directory(path: &Path, description: &str) -> Result<PathBuf, PackageError> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() {
+        return Err(PackageError::General(format!(
+            "Refusing to use {} \"{}\": symbolic links are not allowed.",
+            description,
+            path.display()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to use {} \"{}\": it is not a directory.",
+            description,
+            path.display()
+        )));
+    }
+    path.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify {} \"{}\": {}",
+            description,
+            path.display(),
+            error
+        ))
+    })
+}
+
+fn existing_child_directory(
+    parent: &Path,
+    child: &Path,
+    description: &str,
+) -> Result<Option<PathBuf>, PackageError> {
+    let metadata = match std::fs::symlink_metadata(child) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(PackageError::General(format!(
+            "Refusing to use {} \"{}\": symbolic links are not allowed.",
+            description,
+            child.display()
+        )));
+    }
+    if !metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to use {} \"{}\": it is not a directory.",
+            description,
+            child.display()
+        )));
+    }
+
+    let canonical_child = child.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify {} \"{}\": {}",
+            description,
+            child.display(),
+            error
+        ))
+    })?;
+    if canonical_child.parent() != Some(parent) {
+        return Err(PackageError::General(format!(
+            "Refusing to use {} \"{}\": it escapes its expected parent directory.",
+            description,
+            child.display()
+        )));
+    }
+
+    Ok(Some(canonical_child))
+}
+
+fn ensure_child_directory(
+    parent: &Path,
+    child: &Path,
+    description: &str,
+) -> Result<PathBuf, PackageError> {
+    if let Some(existing) = existing_child_directory(parent, child, description)? {
+        return Ok(existing);
+    }
+
+    match std::fs::create_dir(child) {
+        Ok(()) => {}
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+        Err(error) => return Err(error.into()),
+    }
+    existing_child_directory(parent, child, description)?.ok_or_else(|| {
+        PackageError::General(format!(
+            "Could not create {} \"{}\".",
+            description,
+            child.display()
+        ))
+    })
+}
 
 /// Manages the global package cache at `~/.wfl/packages/`.
 pub struct PackageCache {
@@ -13,33 +108,81 @@ impl PackageCache {
     pub fn new() -> Result<Self, PackageError> {
         let home = dirs_home()?;
         let cache_dir = home.join(".wfl").join("packages");
-        std::fs::create_dir_all(&cache_dir)?;
-        Ok(Self { cache_dir })
+        Self::with_dir(cache_dir)
     }
 
     /// Create a cache manager with a custom directory (for testing).
     pub fn with_dir(cache_dir: PathBuf) -> Result<Self, PackageError> {
-        std::fs::create_dir_all(&cache_dir)?;
-        Ok(Self { cache_dir })
+        match std::fs::symlink_metadata(&cache_dir) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(PackageError::General(format!(
+                    "Refusing to use package cache \"{}\": symbolic links are not allowed.",
+                    cache_dir.display()
+                )));
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(PackageError::General(format!(
+                    "Refusing to use package cache \"{}\": it is not a directory.",
+                    cache_dir.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                std::fs::create_dir_all(&cache_dir)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+
+        Ok(Self {
+            cache_dir: verify_directory(&cache_dir, "package cache")?,
+        })
     }
 
     /// Get the path for a specific package version in the cache.
     pub fn package_path(&self, name: &str, version: &Version) -> PathBuf {
+        if validate_package_name(name).is_err() {
+            return self
+                .cache_dir
+                .join(".invalid-package-name")
+                .join(version.to_string());
+        }
         self.cache_dir.join(name).join(version.to_string())
     }
 
     /// Check if a package version is cached.
     pub fn is_cached(&self, name: &str, version: &Version) -> bool {
-        self.package_path(name, version).exists()
+        if validate_package_name(name).is_err() {
+            return false;
+        }
+        self.cached_package_directory(name, version)
+            .ok()
+            .flatten()
+            .is_some()
     }
 
     /// Store a package in the cache by copying from a source directory.
     pub fn store(&self, name: &str, version: &Version, source: &Path) -> Result<(), PackageError> {
-        let dest = self.package_path(name, version);
-        if dest.exists() {
-            std::fs::remove_dir_all(&dest)?;
+        validate_package_name(name)?;
+        let source = verify_directory(source, "package source")?;
+        let cache_root = self.verified_cache_root()?;
+        let package_root = ensure_child_directory(
+            &cache_root,
+            &cache_root.join(name),
+            "package cache directory",
+        )?;
+        let dest = package_root.join(version.to_string());
+        if let Some(existing) =
+            existing_child_directory(&package_root, &dest, "cached package version")?
+        {
+            if existing == source {
+                return Err(PackageError::General(
+                    "Refusing to replace a cached package with itself.".to_string(),
+                ));
+            }
+            std::fs::remove_dir_all(existing)?;
         }
-        copy_dir_recursive(source, &dest)?;
+
+        copy_dir_recursive(&source, &dest)?;
         Ok(())
     }
 
@@ -50,34 +193,57 @@ impl PackageCache {
         version: &Version,
         project_dir: &Path,
     ) -> Result<(), PackageError> {
-        let cache_path = self.package_path(name, version);
-        if !cache_path.exists() {
-            return Err(PackageError::General(format!(
-                "Package {} {} is not in the cache.",
-                name, version
-            )));
-        }
+        validate_package_name(name)?;
+        let cache_path = self
+            .cached_package_directory(name, version)?
+            .ok_or_else(|| {
+                PackageError::General(format!("Package {} {} is not in the cache.", name, version))
+            })?;
 
-        let dest = project_dir.join("packages").join(name);
-        if dest.exists() {
-            std::fs::remove_dir_all(&dest)?;
+        let project_root = project_dir.canonicalize().map_err(|error| {
+            PackageError::General(format!(
+                "Could not verify project directory \"{}\": {}",
+                project_dir.display(),
+                error
+            ))
+        })?;
+        let packages_path = project_root.join("packages");
+        let packages_root =
+            ensure_child_directory(&project_root, &packages_path, "project packages directory")?;
+        let dest = packages_root.join(name);
+        if let Some(existing) =
+            existing_child_directory(&packages_root, &dest, "installed package directory")?
+        {
+            std::fs::remove_dir_all(existing)?;
         }
-        std::fs::create_dir_all(&dest)?;
         copy_dir_recursive(&cache_path, &dest)?;
         Ok(())
     }
 
     /// List all cached versions of a package.
     pub fn list_versions(&self, name: &str) -> Result<Vec<Version>, PackageError> {
-        let pkg_dir = self.cache_dir.join(name);
-        if !pkg_dir.exists() {
-            return Ok(Vec::new());
-        }
+        validate_package_name(name)?;
+        let cache_root = self.verified_cache_root()?;
+        let pkg_dir = match existing_child_directory(
+            &cache_root,
+            &cache_root.join(name),
+            "package cache directory",
+        )? {
+            Some(path) => path,
+            None => return Ok(Vec::new()),
+        };
 
         let mut versions = Vec::new();
         for entry in std::fs::read_dir(&pkg_dir)? {
             let entry = entry?;
-            if entry.path().is_dir()
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                return Err(PackageError::General(format!(
+                    "Refusing to inspect cached package version \"{}\": symbolic links are not allowed.",
+                    entry.path().display()
+                )));
+            }
+            if file_type.is_dir()
                 && let Ok(v) = Version::parse(&entry.file_name().to_string_lossy())
             {
                 versions.push(v);
@@ -90,6 +256,38 @@ impl PackageCache {
     /// Get the cache directory path.
     pub fn cache_dir(&self) -> &Path {
         &self.cache_dir
+    }
+
+    fn verified_cache_root(&self) -> Result<PathBuf, PackageError> {
+        let canonical = verify_directory(&self.cache_dir, "package cache")?;
+        if canonical != self.cache_dir {
+            return Err(PackageError::General(format!(
+                "Refusing to use package cache \"{}\": its filesystem location changed.",
+                self.cache_dir.display()
+            )));
+        }
+        Ok(canonical)
+    }
+
+    fn cached_package_directory(
+        &self,
+        name: &str,
+        version: &Version,
+    ) -> Result<Option<PathBuf>, PackageError> {
+        let cache_root = self.verified_cache_root()?;
+        let package_root = match existing_child_directory(
+            &cache_root,
+            &cache_root.join(name),
+            "package cache directory",
+        )? {
+            Some(path) => path,
+            None => return Ok(None),
+        };
+        existing_child_directory(
+            &package_root,
+            &package_root.join(version.to_string()),
+            "cached package version",
+        )
     }
 }
 
@@ -112,8 +310,13 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<(), PackageError> {
 
         if metadata.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
+        } else if metadata.is_file() {
             std::fs::copy(&src_path, &dst_path)?;
+        } else {
+            return Err(PackageError::General(format!(
+                "Unsupported filesystem entry found in package: {}",
+                src_path.display()
+            )));
         }
     }
     Ok(())

--- a/crates/wflpkg/src/commands/remove.rs
+++ b/crates/wflpkg/src/commands/remove.rs
@@ -1,20 +1,129 @@
-use std::path::Path;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
 
 use crate::error::PackageError;
 use crate::manifest::ProjectManifest;
+use crate::manifest::parser::validate_package_name;
+
+fn directory_to_remove(
+    name: &str,
+    canonical_project: &Path,
+) -> Result<Option<PathBuf>, PackageError> {
+    let packages_dir = canonical_project.join("packages");
+    let packages_metadata = match std::fs::symlink_metadata(&packages_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+
+    if packages_metadata.file_type().is_symlink() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": the packages directory \"{}\" is a symbolic link.",
+            name,
+            packages_dir.display()
+        )));
+    }
+    if !packages_metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": \"{}\" is not a directory.",
+            name,
+            packages_dir.display()
+        )));
+    }
+
+    let canonical_packages = packages_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify packages directory \"{}\": {}",
+            packages_dir.display(),
+            error
+        ))
+    })?;
+    if canonical_packages.parent() != Some(canonical_project) {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": packages directory escapes the project.",
+            name
+        )));
+    }
+
+    let package_dir = packages_dir.join(name);
+    let package_metadata = match std::fs::symlink_metadata(&package_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+
+    if package_metadata.file_type().is_symlink() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": package directory \"{}\" is a symbolic link.",
+            name,
+            package_dir.display()
+        )));
+    }
+    if !package_metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": \"{}\" is not a directory.",
+            name,
+            package_dir.display()
+        )));
+    }
+
+    let canonical_package = package_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify package directory \"{}\": {}",
+            package_dir.display(),
+            error
+        ))
+    })?;
+    if canonical_package.parent() != Some(canonical_packages.as_path()) {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": package directory escapes the packages directory.",
+            name
+        )));
+    }
+
+    Ok(Some(canonical_package))
+}
 
 /// Remove a dependency from the project.
 pub fn remove_dependency(name: &str, project_dir: &Path) -> Result<(), PackageError> {
-    let manifest_path = project_dir.join("project.wfl");
-    if !manifest_path.exists() {
-        return Err(PackageError::ManifestNotFound(
-            project_dir.display().to_string(),
-        ));
+    validate_package_name(name)?;
+
+    let requested_manifest_path = project_dir.join("project.wfl");
+    let manifest_metadata = match std::fs::symlink_metadata(&requested_manifest_path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            return Err(PackageError::ManifestNotFound(
+                project_dir.display().to_string(),
+            ));
+        }
+        Err(error) => return Err(error.into()),
+    };
+    if manifest_metadata.file_type().is_symlink() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": project manifest \"{}\" is a symbolic link.",
+            name,
+            requested_manifest_path.display()
+        )));
     }
+    if !manifest_metadata.is_file() {
+        return Err(PackageError::General(format!(
+            "Refusing to remove package \"{}\": project manifest \"{}\" is not a regular file.",
+            name,
+            requested_manifest_path.display()
+        )));
+    }
+    let canonical_project = project_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify project directory \"{}\": {}",
+            project_dir.display(),
+            error
+        ))
+    })?;
+    let manifest_path = canonical_project.join("project.wfl");
 
     let mut manifest = ProjectManifest::load(&manifest_path)?;
 
-    if !manifest.remove_dependency(name) {
+    if manifest.find_dependency(name).is_none() {
         return Err(PackageError::General(format!(
             "The package \"{}\" is not listed as a dependency in your project.wfl.\n\n\
              To see your current dependencies, open project.wfl and look for\n\
@@ -23,12 +132,17 @@ pub fn remove_dependency(name: &str, project_dir: &Path) -> Result<(), PackageEr
         )));
     }
 
+    // Resolve and verify every component before changing the manifest. In
+    // particular, never pass a caller-controlled or symlinked path to the
+    // recursive remover.
+    let package_dir = directory_to_remove(name, &canonical_project)?;
+
+    manifest.remove_dependency(name);
     manifest.save(&manifest_path)?;
 
     // Clean up local packages directory
-    let pkg_dir = project_dir.join("packages").join(name);
-    if pkg_dir.exists() {
-        std::fs::remove_dir_all(&pkg_dir)?;
+    if let Some(package_dir) = package_dir {
+        std::fs::remove_dir_all(package_dir)?;
     }
 
     // TODO: Update lock file

--- a/crates/wflpkg/src/manifest/parser.rs
+++ b/crates/wflpkg/src/manifest/parser.rs
@@ -161,7 +161,7 @@ fn parse_dependency(s: &str, line_num: usize) -> Result<Dependency, PackageError
 }
 
 /// Validate a package name.
-fn validate_package_name(name: &str) -> Result<(), PackageError> {
+pub(crate) fn validate_package_name(name: &str) -> Result<(), PackageError> {
     if name.is_empty() || name.len() > 64 {
         return Err(PackageError::InvalidPackageName(name.to_string()));
     }

--- a/crates/wflpkg/src/resolver/package_path.rs
+++ b/crates/wflpkg/src/resolver/package_path.rs
@@ -1,30 +1,127 @@
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use crate::error::PackageError;
 use crate::manifest::ProjectManifest;
+use crate::manifest::parser::validate_package_name;
 
-/// Resolve the entry point for a package installed in `packages/<name>/`.
-pub fn resolve_package_entry(name: &str, project_dir: &Path) -> Result<PathBuf, PackageError> {
-    if name.contains('/') || name.contains('\\') || name.contains("..") || name.is_empty() {
+fn not_installed(name: &str) -> PackageError {
+    PackageError::General(format!(
+        "The package \"{}\" is not installed.\n\n\
+         To install it, run:\n\
+         \x20 wfl add {}",
+        name, name
+    ))
+}
+
+fn verified_package_directory(name: &str, project_dir: &Path) -> Result<PathBuf, PackageError> {
+    let canonical_project = project_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify project directory \"{}\": {}",
+            project_dir.display(),
+            error
+        ))
+    })?;
+    let packages_dir = canonical_project.join("packages");
+    let packages_metadata = match std::fs::symlink_metadata(&packages_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Err(not_installed(name)),
+        Err(error) => return Err(error.into()),
+    };
+    if packages_metadata.file_type().is_symlink() {
         return Err(PackageError::General(format!(
-            "Invalid package name \"{}\": must not contain path separators or '..' components.",
+            "Refusing to resolve package \"{}\": packages directory \"{}\" is a symbolic link.",
+            name,
+            packages_dir.display()
+        )));
+    }
+    if !packages_metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to resolve package \"{}\": \"{}\" is not a directory.",
+            name,
+            packages_dir.display()
+        )));
+    }
+
+    let canonical_packages = packages_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify packages directory \"{}\": {}",
+            packages_dir.display(),
+            error
+        ))
+    })?;
+    if canonical_packages.parent() != Some(canonical_project.as_path()) {
+        return Err(PackageError::General(format!(
+            "Refusing to resolve package \"{}\": packages directory escapes the project.",
             name
         )));
     }
-    let package_dir = project_dir.join("packages").join(name);
 
-    if !package_dir.exists() {
+    let package_dir = canonical_packages.join(name);
+    let package_metadata = match std::fs::symlink_metadata(&package_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Err(not_installed(name)),
+        Err(error) => return Err(error.into()),
+    };
+    if package_metadata.file_type().is_symlink() {
         return Err(PackageError::General(format!(
-            "The package \"{}\" is not installed.\n\n\
-             To install it, run:\n\
-             \x20 wfl add {}",
-            name, name
+            "Refusing to resolve package \"{}\": package directory \"{}\" is a symbolic link.",
+            name,
+            package_dir.display()
+        )));
+    }
+    if !package_metadata.is_dir() {
+        return Err(PackageError::General(format!(
+            "Refusing to resolve package \"{}\": \"{}\" is not a directory.",
+            name,
+            package_dir.display()
         )));
     }
 
+    let canonical_package = package_dir.canonicalize().map_err(|error| {
+        PackageError::General(format!(
+            "Could not verify package directory \"{}\": {}",
+            package_dir.display(),
+            error
+        ))
+    })?;
+    if canonical_package.parent() != Some(canonical_packages.as_path()) {
+        return Err(PackageError::General(format!(
+            "Refusing to resolve package \"{}\": package directory escapes the packages directory.",
+            name
+        )));
+    }
+
+    Ok(canonical_package)
+}
+
+/// Resolve the entry point for a package installed in `packages/<name>/`.
+pub fn resolve_package_entry(name: &str, project_dir: &Path) -> Result<PathBuf, PackageError> {
+    validate_package_name(name)?;
+    let package_dir = verified_package_directory(name, project_dir)?;
+
     // Look for project.wfl in the package directory
     let manifest_path = package_dir.join("project.wfl");
-    if manifest_path.exists() {
+    let manifest_metadata = match std::fs::symlink_metadata(&manifest_path) {
+        Ok(metadata) => Some(metadata),
+        Err(error) if error.kind() == ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    if let Some(manifest_metadata) = manifest_metadata {
+        if manifest_metadata.file_type().is_symlink() {
+            return Err(PackageError::General(format!(
+                "Refusing to resolve package \"{}\": package manifest \"{}\" is a symbolic link.",
+                name,
+                manifest_path.display()
+            )));
+        }
+        if !manifest_metadata.is_file() {
+            return Err(PackageError::General(format!(
+                "Refusing to resolve package \"{}\": package manifest \"{}\" is not a regular file.",
+                name,
+                manifest_path.display()
+            )));
+        }
         let manifest = ProjectManifest::load(&manifest_path)?;
         let entry = manifest.entry_point();
         let entry_path = package_dir.join(entry);

--- a/crates/wflpkg/tests/security_tests.rs
+++ b/crates/wflpkg/tests/security_tests.rs
@@ -128,6 +128,41 @@ fn test_extract_archive_rejects_hardlink_entry() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn test_extract_archive_rejects_preexisting_symlink_ancestor() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let archive_path = temp.path().join("bad.wflpkg");
+    build_malicious_archive(
+        &archive_path,
+        tar::EntryType::Regular,
+        b"linked/escaped.txt",
+        b"",
+        b"escape",
+    );
+
+    let dest = temp.path().join("output");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&dest).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, "must survive").unwrap();
+    symlink(&outside, dest.join("linked")).unwrap();
+
+    let result = wflpkg::archive::extract_archive(&archive_path, &dest);
+    assert!(
+        result.is_err(),
+        "a pre-existing symlink ancestor must be rejected"
+    );
+    assert!(sentinel.exists(), "outside content must survive extraction");
+    assert!(
+        !outside.join("escaped.txt").exists(),
+        "archive content must not escape the destination"
+    );
+}
+
 #[test]
 fn test_create_archive_excludes_expected_dirs() {
     let temp = TempDir::new().unwrap();
@@ -229,8 +264,8 @@ fn test_resolve_package_rejects_slash_in_name() {
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("Invalid package name"),
-        "expected 'Invalid package name', got: {msg}"
+        msg.contains("not valid"),
+        "expected exact package-name validation, got: {msg}"
     );
 }
 
@@ -241,8 +276,8 @@ fn test_resolve_package_rejects_backslash_in_name() {
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("Invalid package name"),
-        "expected 'Invalid package name', got: {msg}"
+        msg.contains("not valid"),
+        "expected exact package-name validation, got: {msg}"
     );
 }
 
@@ -253,8 +288,8 @@ fn test_resolve_package_rejects_dotdot_in_name() {
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("Invalid package name"),
-        "expected 'Invalid package name', got: {msg}"
+        msg.contains("not valid"),
+        "expected exact package-name validation, got: {msg}"
     );
 }
 
@@ -265,8 +300,70 @@ fn test_resolve_package_rejects_empty_name() {
     assert!(result.is_err());
     let msg = result.unwrap_err().to_string();
     assert!(
-        msg.contains("Invalid package name"),
-        "expected 'Invalid package name', got: {msg}"
+        msg.contains("not valid"),
+        "expected exact package-name validation, got: {msg}"
+    );
+}
+
+#[test]
+fn test_resolve_package_rejects_windows_path_prefix() {
+    let temp = TempDir::new().unwrap();
+    let result = wflpkg::resolver::package_path::resolve_package_entry("c:escape", temp.path());
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("not valid"),
+        "drive-prefixed names must fail the manifest's package-name rules"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_resolve_package_rejects_symlinked_packages_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let outside = temp.path().join("outside");
+    let package = outside.join("my-lib");
+    fs::create_dir_all(&package).unwrap();
+    fs::write(package.join("main.wfl"), "// outside").unwrap();
+    symlink(&outside, temp.path().join("packages")).unwrap();
+
+    let result = wflpkg::resolver::package_path::resolve_package_entry("my-lib", temp.path());
+    assert!(
+        result.is_err(),
+        "a symlinked packages root must be rejected"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("symbolic link"),
+        "the error should identify the unsafe package boundary"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_resolve_package_rejects_symlinked_manifest() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let package = temp.path().join("packages/my-lib");
+    fs::create_dir_all(package.join("src")).unwrap();
+    fs::write(package.join("src/main.wfl"), "// entry").unwrap();
+    let outside_manifest = temp.path().join("outside-project.wfl");
+    fs::write(
+        &outside_manifest,
+        "name is my-lib\nversion is 26.1.1\ndescription is Outside",
+    )
+    .unwrap();
+    symlink(&outside_manifest, package.join("project.wfl")).unwrap();
+
+    let result = wflpkg::resolver::package_path::resolve_package_entry("my-lib", temp.path());
+    assert!(
+        result.is_err(),
+        "a symlinked package manifest must be rejected"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("symbolic link"),
+        "the error should identify the unsafe manifest"
     );
 }
 
@@ -556,4 +653,98 @@ fn test_cache_install_not_cached_fails() {
         msg.contains("not in the cache"),
         "expected 'not in the cache', got: {msg}"
     );
+}
+
+#[test]
+fn test_cache_rejects_invalid_package_names() {
+    let temp = TempDir::new().unwrap();
+    let cache = wflpkg::cache::PackageCache::with_dir(temp.path().join("cache")).unwrap();
+    let version = wflpkg::Version::new(26, 1, Some(0));
+    let invalid_name = temp.path().join("outside").to_string_lossy().into_owned();
+
+    let src = temp.path().join("src-pkg");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("main.wfl"), "display \"hi\"").unwrap();
+    assert!(!cache.is_cached(&invalid_name, &version));
+    assert!(cache.store(&invalid_name, &version, &src).is_err());
+    assert!(cache.list_versions(&invalid_name).is_err());
+
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    assert!(
+        cache
+            .install_to_project(&invalid_name, &version, &project)
+            .is_err()
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cache_rejects_symlinked_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let outside = temp.path().join("outside-cache");
+    fs::create_dir_all(&outside).unwrap();
+    let cache_link = temp.path().join("cache-link");
+    symlink(&outside, &cache_link).unwrap();
+
+    match wflpkg::cache::PackageCache::with_dir(cache_link) {
+        Err(error) => assert!(error.to_string().contains("symbolic link")),
+        Ok(_) => panic!("a symlinked package cache root must be rejected"),
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cache_store_rejects_symlinked_package_target() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let cache = wflpkg::cache::PackageCache::with_dir(temp.path().join("cache")).unwrap();
+    let version = wflpkg::Version::new(26, 1, Some(0));
+    let outside = temp.path().join("outside-package");
+    let outside_version = outside.join(version.to_string());
+    fs::create_dir_all(&outside_version).unwrap();
+    let sentinel = outside_version.join("sentinel.txt");
+    fs::write(&sentinel, "must survive").unwrap();
+    symlink(&outside, cache.cache_dir().join("my-pkg")).unwrap();
+
+    let src = temp.path().join("src-pkg");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("main.wfl"), "display \"hi\"").unwrap();
+    assert!(!cache.is_cached("my-pkg", &version));
+    let result = cache.store("my-pkg", &version, &src);
+    assert!(result.is_err(), "a symlinked cache target must be rejected");
+    assert!(sentinel.exists(), "outside cached content must survive");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_cache_install_rejects_symlinked_packages_root() {
+    use std::os::unix::fs::symlink;
+
+    let temp = TempDir::new().unwrap();
+    let cache = wflpkg::cache::PackageCache::with_dir(temp.path().join("cache")).unwrap();
+    let version = wflpkg::Version::new(26, 1, Some(0));
+    let src = temp.path().join("src-pkg");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("main.wfl"), "display \"hi\"").unwrap();
+    cache.store("my-pkg", &version, &src).unwrap();
+
+    let project = temp.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let outside = temp.path().join("outside-packages");
+    let outside_package = outside.join("my-pkg");
+    fs::create_dir_all(&outside_package).unwrap();
+    let sentinel = outside_package.join("sentinel.txt");
+    fs::write(&sentinel, "must survive").unwrap();
+    symlink(&outside, project.join("packages")).unwrap();
+
+    let result = cache.install_to_project("my-pkg", &version, &project);
+    assert!(
+        result.is_err(),
+        "a symlinked project packages root must be rejected"
+    );
+    assert!(sentinel.exists(), "outside installed content must survive");
 }

--- a/crates/wflpkg/tests/workflow_integration.rs
+++ b/crates/wflpkg/tests/workflow_integration.rs
@@ -154,6 +154,108 @@ fn test_remove_dependency_cleans_packages_dir() {
 }
 
 #[test]
+fn test_remove_dependency_rejects_invalid_name() {
+    let (_temp, project_dir) = create_test_project("remove-name-test");
+    let result = wflpkg::commands::remove::remove_dependency("../outside", &project_dir);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().to_string().contains("not valid"),
+        "path-like dependency names must be rejected before path construction"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_remove_dependency_rejects_symlinked_packages_root() {
+    use std::os::unix::fs::symlink;
+
+    let (temp, project_dir) = create_test_project("remove-root-link-test");
+    wflpkg::commands::add::add_dependency(&["http-client".to_string()], &project_dir).unwrap();
+
+    let outside = temp.path().join("outside-packages");
+    let outside_package = outside.join("http-client");
+    fs::create_dir_all(&outside_package).unwrap();
+    let sentinel = outside_package.join("sentinel.txt");
+    fs::write(&sentinel, "must survive").unwrap();
+    symlink(&outside, project_dir.join("packages")).unwrap();
+
+    let result = wflpkg::commands::remove::remove_dependency("http-client", &project_dir);
+    assert!(
+        result.is_err(),
+        "a symlinked packages root must be rejected"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("symbolic link"),
+        "the error should explain why recursive removal was refused"
+    );
+    assert!(sentinel.exists(), "outside package content must survive");
+
+    let manifest = wflpkg::ProjectManifest::load(&project_dir.join("project.wfl")).unwrap();
+    assert!(
+        manifest.find_dependency("http-client").is_some(),
+        "a refused removal must not change the manifest"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn test_remove_dependency_rejects_symlinked_package_target() {
+    use std::os::unix::fs::symlink;
+
+    let (temp, project_dir) = create_test_project("remove-target-link-test");
+    wflpkg::commands::add::add_dependency(&["http-client".to_string()], &project_dir).unwrap();
+
+    let outside = temp.path().join("outside-package");
+    fs::create_dir_all(&outside).unwrap();
+    let sentinel = outside.join("sentinel.txt");
+    fs::write(&sentinel, "must survive").unwrap();
+    fs::create_dir_all(project_dir.join("packages")).unwrap();
+    symlink(&outside, project_dir.join("packages/http-client")).unwrap();
+
+    let result = wflpkg::commands::remove::remove_dependency("http-client", &project_dir);
+    assert!(
+        result.is_err(),
+        "a symlinked package target must be rejected"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("symbolic link"),
+        "the error should explain why recursive removal was refused"
+    );
+    assert!(sentinel.exists(), "outside package content must survive");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_remove_dependency_rejects_symlinked_project_manifest() {
+    use std::os::unix::fs::symlink;
+
+    let (temp, project_dir) = create_test_project("remove-manifest-link-test");
+    wflpkg::commands::add::add_dependency(&["http-client".to_string()], &project_dir).unwrap();
+
+    let project_manifest = project_dir.join("project.wfl");
+    let outside_manifest = temp.path().join("outside-project.wfl");
+    let original = fs::read_to_string(&project_manifest).unwrap();
+    fs::write(&outside_manifest, &original).unwrap();
+    fs::remove_file(&project_manifest).unwrap();
+    symlink(&outside_manifest, &project_manifest).unwrap();
+
+    let result = wflpkg::commands::remove::remove_dependency("http-client", &project_dir);
+    assert!(
+        result.is_err(),
+        "a symlinked project manifest must be rejected"
+    );
+    assert!(
+        result.unwrap_err().to_string().contains("symbolic link"),
+        "the error should identify the unsafe manifest"
+    );
+    assert_eq!(
+        fs::read_to_string(&outside_manifest).unwrap(),
+        original,
+        "a refused removal must not rewrite an outside manifest"
+    );
+}
+
+#[test]
 fn test_remove_dependency_not_found() {
     let (_temp, project_dir) = create_test_project("remove-nf-test");
     let result = wflpkg::commands::remove::remove_dependency("nonexistent", &project_dir);


### PR DESCRIPTION
## Summary

- reuse the manifest's exact package-name validator in cache, resolver, and remove paths
- reject symlinked or non-directory cache/package roots and verify canonical parent containment before recursive mutations
- reject symlinked/non-regular project and installed-package manifests
- use `tar::Entry::unpack_in` so extraction cannot traverse a pre-existing symlink ancestor
- reject special filesystem objects while copying packages
- add regression coverage with outside-directory sentinels for removal, resolution, caching, installation, and extraction

## Security impact

A repository-controlled `packages` symlink could make `wfl remove` recursively delete a directory outside the project. Related cache, resolver, manifest, and archive paths also trusted path joins without consistently validating each filesystem boundary. These operations now fail closed on symlinks, invalid names, non-directory targets, escaped canonical parents, and special files before mutating or executing anything outside the expected package roots.

## Validation

- `cargo test -p wflpkg --locked`: all 216 tests passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- all GitHub CI, config lint, and review checks passed on the final head

Part of the Rust-source production-readiness work tracked in #610.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hardened package and cache filesystem operations against symlink-based traversal and unsafe paths.
  * Validated package names and prevented operations outside expected project or cache directories.
  * Secured archive extraction from escaping its destination.
  * Added safeguards when resolving, installing, storing, or removing packages and manifests.
* **Tests**
  * Added regression coverage for unsafe paths, symlinked directories and manifests, and archive extraction escapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->