### PR TITLE
Harden package publishing and registry credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Security
+- **WFL package publishing now keeps credentials registry-scoped.** A
+  project-controlled `registry` setting can no longer redirect a saved token to
+  another origin; registry URLs are canonicalized and must use HTTPS without
+  userinfo, paths, queries, or fragments.
+- **Package archives are created in private external temporary files** and
+  cleaned up automatically. Archive creation refuses existing output paths, so
+  a project-supplied symlink can no longer redirect `wfl share` into truncating
+  another file.
+- **Published packages now honor root and nested `.gitignore` rules.** Ignored
+  logs, debug reports, `.env` files, and other local-only content are excluded
+  from both the archive and its checksum instead of being uploaded silently.
+- **Registry credentials are written atomically with private permissions.** On
+  Unix, the auth directory is mode `0700` and the token file is mode `0600`
+  before any secret bytes are written.
+- **Package integrity checks now use an explicitly versioned
+  `wflhash:v2:` transcript.** File records include domain, path, and content
+  lengths; paths use portable `/` separators; verification hashes every
+  extracted regular file; and publishing derives the digest from the completed
+  archive instead of re-reading a mutable source tree.
+- **Package publishing now fails closed on unsafe inputs and resource abuse.**
+  Manifests and entry points must be in-project regular files, unsupported
+  filesystem objects and ambiguous `.gitignore` patterns are rejected, package
+  traversal is bounded, archives upload as bounded streams, and registry
+  response bodies are capped at 1 MiB.
+- **Registry login supports an explicit registry address.** `wfl login
+  [registry]` scopes a token to that HTTPS origin, mismatched logins are
+  rejected, and `wfl logout` can recover malformed or incomplete credentials.
 - **Subprocess policy is enforced on every process launch** (shell path and
   direct-exec / `with arguments` path). Previously, `shell_execution_mode` and
   related checks ran only when the engine believed a shell was required, so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1175,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1635,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2528,12 +2567,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3948,6 +3989,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4049,6 +4103,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "flate2",
+ "ignore",
+ "libc",
  "reqwest",
  "rpassword",
  "rustyline",

--- a/crates/wflpkg/Cargo.toml
+++ b/crates/wflpkg/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 tokio = { version = "1.52.3", features = ["full"] }
-reqwest = { version = "0.13.4", features = ["json", "multipart"] }
+reqwest = { version = "0.13.4", features = ["json", "multipart", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.150"
 rustyline = "18.0.1"
@@ -17,9 +17,11 @@ sha2 = "0.10"
 zeroize = "1.9"
 flate2 = "1.0"
 tar = "0.4"
-
-[dev-dependencies]
+ignore = "0.4.23"
 tempfile = "3.27.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [[bin]]
 name = "wflpkg"

--- a/crates/wflpkg/src/archive.rs
+++ b/crates/wflpkg/src/archive.rs
@@ -1,22 +1,57 @@
 use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
+use std::io::{Read, Write};
 use std::path::Path;
-use tar::Archive;
+use tar::{Archive, Header};
 
 use crate::error::PackageError;
+use crate::package_files::IgnoreStack;
+
+const MAX_PACKAGE_ENTRIES: u64 = 10_000;
+const MAX_PACKAGE_SOURCE_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_PACKAGE_DEPTH: usize = 128;
 
 /// Create a `.wflpkg` archive (tar.gz) from a project directory.
 /// Excludes `packages/`, `.git/`, `node_modules/`, and other non-source files.
 pub fn create_archive(project_dir: &Path, output_path: &Path) -> Result<(), PackageError> {
-    let file = std::fs::File::create(output_path)?;
-    let enc = GzEncoder::new(file, Compression::default());
+    let file = create_new_private_file(output_path)?;
+    let mut cleanup = RemoveOnDrop::new(output_path);
+    create_archive_to_writer(project_dir, file)?;
+    cleanup.keep();
+    Ok(())
+}
+
+/// Create an archive on a caller-owned output stream.
+///
+/// The share command uses this with an already-open private temporary file, so
+/// an untrusted project cannot redirect archive creation through a symlink.
+pub(crate) fn create_archive_to_writer<W: Write>(
+    project_dir: &Path,
+    writer: W,
+) -> Result<(), PackageError> {
+    let enc = GzEncoder::new(writer, Compression::default());
     let mut tar = tar::Builder::new(enc);
+    // A path that is swapped to a symlink while packaging must never cause
+    // tar to follow and disclose its target.
+    tar.follow_symlinks(false);
+    let mut ignore_stack = IgnoreStack::new(project_dir)?;
+    let mut budget = TraversalBudget::default();
 
-    add_dir_to_archive(&mut tar, project_dir, project_dir)?;
+    add_dir_to_archive(
+        &mut tar,
+        project_dir,
+        project_dir,
+        &mut ignore_stack,
+        &mut budget,
+        0,
+    )?;
 
-    tar.finish()
+    let enc = tar
+        .into_inner()
         .map_err(|e| PackageError::General(format!("Failed to create archive: {}", e)))?;
+    enc.finish()
+        .map_err(|e| PackageError::General(format!("Failed to finish archive: {}", e)))?;
 
     Ok(())
 }
@@ -26,14 +61,39 @@ fn add_dir_to_archive<W: std::io::Write>(
     tar: &mut tar::Builder<W>,
     base: &Path,
     dir: &Path,
+    ignore_stack: &mut IgnoreStack,
+    budget: &mut TraversalBudget,
+    depth: usize,
 ) -> Result<(), PackageError> {
+    if depth > MAX_PACKAGE_DEPTH {
+        return Err(package_budget_error());
+    }
+    let mut entries = Vec::new();
     for entry in std::fs::read_dir(dir)? {
-        let entry = entry?;
+        budget.add_entry()?;
+        entries.push(entry?);
+    }
+    for entry in &entries {
+        if entry.file_name().to_str().is_none() {
+            return Err(PackageError::General(format!(
+                "Package path is not valid Unicode: {}",
+                entry.path().display()
+            )));
+        }
+    }
+    entries.sort_by(|left, right| {
+        left.file_name()
+            .to_str()
+            .expect("validated above")
+            .cmp(right.file_name().to_str().expect("validated above"))
+    });
+
+    for entry in entries {
         let path = entry.path();
         let name = entry.file_name();
-        let name_str = name.to_string_lossy();
+        let name_str = name.to_str().expect("validated above");
 
-        if crate::is_excluded(&name_str) {
+        if crate::is_excluded(name_str) {
             continue;
         }
 
@@ -47,16 +107,135 @@ fn add_dir_to_archive<W: std::io::Write>(
         }
 
         let relative = path.strip_prefix(base).unwrap_or(&path);
-
+        if ignore_stack.is_ignored(relative, ft.is_dir())? {
+            continue;
+        }
+        if !ft.is_dir() && !ft.is_file() {
+            return Err(PackageError::General(format!(
+                "Package contains an unsupported filesystem object: {}",
+                path.display()
+            )));
+        }
         if ft.is_dir() {
-            add_dir_to_archive(tar, base, &path)?;
+            let added_rules = ignore_stack.push_for_dir(&path, relative)?;
+            let result = add_dir_to_archive(tar, base, &path, ignore_stack, budget, depth + 1);
+            ignore_stack.pop(added_rules);
+            result?;
         } else {
-            tar.append_path_with_name(&path, relative).map_err(|e| {
-                PackageError::General(format!("Failed to add file to archive: {}", e))
-            })?;
+            let mut options = std::fs::OpenOptions::new();
+            options.read(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_NOFOLLOW);
+            }
+            let mut file = options.open(&path)?;
+            let metadata = file.metadata()?;
+            if !metadata.is_file() {
+                return Err(PackageError::General(format!(
+                    "Package file changed type while it was being archived: {}",
+                    path.display()
+                )));
+            }
+            budget.add_bytes(metadata.len())?;
+            let captured_size = metadata.len();
+            let mut header = Header::new_gnu();
+            header.set_metadata(&metadata);
+            header.set_size(captured_size);
+            {
+                let mut limited = (&mut file).take(captured_size);
+                tar.append_data(&mut header, relative, &mut limited)
+                    .map_err(|e| {
+                        PackageError::General(format!("Failed to add file to archive: {}", e))
+                    })?;
+                if limited.limit() != 0 {
+                    return Err(PackageError::General(format!(
+                        "Package file changed while it was being archived: {}",
+                        path.display()
+                    )));
+                }
+            }
+            let mut extra = [0_u8; 1];
+            if file.read(&mut extra)? != 0 {
+                return Err(PackageError::General(format!(
+                    "Package file changed while it was being archived: {}",
+                    path.display()
+                )));
+            }
         }
     }
     Ok(())
+}
+
+#[derive(Default)]
+struct TraversalBudget {
+    entries: u64,
+    source_bytes: u64,
+}
+
+impl TraversalBudget {
+    fn add_entry(&mut self) -> Result<(), PackageError> {
+        self.entries = self
+            .entries
+            .checked_add(1)
+            .ok_or_else(package_budget_error)?;
+        if self.entries > MAX_PACKAGE_ENTRIES {
+            return Err(package_budget_error());
+        }
+        Ok(())
+    }
+
+    fn add_bytes(&mut self, bytes: u64) -> Result<(), PackageError> {
+        self.source_bytes = self
+            .source_bytes
+            .checked_add(bytes)
+            .ok_or_else(package_budget_error)?;
+        if self.source_bytes > MAX_PACKAGE_SOURCE_BYTES {
+            return Err(package_budget_error());
+        }
+        Ok(())
+    }
+}
+
+fn package_budget_error() -> PackageError {
+    PackageError::General(
+        "The project exceeds the safe package size, file-count, or directory-depth limit."
+            .to_string(),
+    )
+}
+
+fn create_new_private_file(path: &Path) -> Result<std::fs::File, PackageError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path).map_err(PackageError::Io)
+}
+
+struct RemoveOnDrop<'a> {
+    path: &'a Path,
+    keep: bool,
+}
+
+impl<'a> RemoveOnDrop<'a> {
+    fn new(path: &'a Path) -> Self {
+        Self { path, keep: false }
+    }
+
+    fn keep(&mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for RemoveOnDrop<'_> {
+    fn drop(&mut self) {
+        if !self.keep {
+            let _ = std::fs::remove_file(self.path);
+        }
+    }
 }
 
 /// Extract a `.wflpkg` archive to a destination directory.
@@ -194,5 +373,116 @@ mod tests {
         // Excluded directories should not be present
         assert!(!dest.join("packages").exists());
         assert!(!dest.join(".git").exists());
+    }
+
+    #[test]
+    fn test_create_archive_honors_gitignore_rules() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("project");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::write(src.join("main.wfl"), "display \"hello\"").unwrap();
+        std::fs::write(
+            src.join(".gitignore"),
+            ".env\n*.log\nsecret-dir/\n!important.log\n!nested/\n",
+        )
+        .unwrap();
+        std::fs::write(src.join(".env"), "API_TOKEN=secret").unwrap();
+        std::fs::write(src.join("debug.log"), "credentials").unwrap();
+        std::fs::write(src.join("important.log"), "safe asset").unwrap();
+        std::fs::create_dir_all(src.join("secret-dir")).unwrap();
+        std::fs::write(src.join("secret-dir/token.txt"), "secret").unwrap();
+        std::fs::write(src.join("nested/debug.log"), "credentials").unwrap();
+
+        let archive_path = temp.path().join("test.wflpkg");
+        create_archive(&src, &archive_path).unwrap();
+        let dest = temp.path().join("extracted");
+        extract_archive(&archive_path, &dest).unwrap();
+
+        assert!(dest.join("main.wfl").exists());
+        assert!(dest.join("important.log").exists());
+        assert!(!dest.join(".env").exists());
+        assert!(!dest.join("debug.log").exists());
+        assert!(!dest.join("nested/debug.log").exists());
+        assert!(!dest.join("secret-dir").exists());
+    }
+
+    #[test]
+    fn test_create_archive_honors_nested_gitignore_rules() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("project");
+        std::fs::create_dir_all(src.join("nested")).unwrap();
+        std::fs::write(src.join("main.wfl"), "display \"hello\"").unwrap();
+        std::fs::write(src.join("nested/.gitignore"), "private.txt\n").unwrap();
+        std::fs::write(src.join("nested/private.txt"), "secret").unwrap();
+        std::fs::write(src.join("nested/public.txt"), "public").unwrap();
+
+        let archive_path = temp.path().join("test.wflpkg");
+        create_archive(&src, &archive_path).unwrap();
+        let dest = temp.path().join("extracted");
+        extract_archive(&archive_path, &dest).unwrap();
+
+        assert!(!dest.join("nested/private.txt").exists());
+        assert!(dest.join("nested/public.txt").exists());
+    }
+
+    #[test]
+    fn test_create_archive_refuses_existing_output() {
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("project");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.wfl"), "display \"hello\"").unwrap();
+        let archive_path = temp.path().join("existing.wflpkg");
+        std::fs::write(&archive_path, "do not overwrite").unwrap();
+
+        assert!(create_archive(&src, &archive_path).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&archive_path).unwrap(),
+            "do not overwrite"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_create_archive_refuses_symlink_output() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("project");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.wfl"), "display \"hello\"").unwrap();
+        let target = temp.path().join("target.txt");
+        std::fs::write(&target, "do not overwrite").unwrap();
+        let archive_path = temp.path().join("linked.wflpkg");
+        symlink(&target, &archive_path).unwrap();
+
+        assert!(create_archive(&src, &archive_path).is_err());
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "do not overwrite"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_package_traversal_rejects_special_files() {
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let temp = TempDir::new().unwrap();
+        let src = temp.path().join("project");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.wfl"), "display \"hello\"").unwrap();
+        let special = src.join("pipe");
+        let special_c = CString::new(special.as_os_str().as_bytes()).unwrap();
+        assert_eq!(unsafe { libc::mkfifo(special_c.as_ptr(), 0o600) }, 0);
+
+        let archive_path = temp.path().join("test.wflpkg");
+        assert!(create_archive(&src, &archive_path).is_err());
+        assert!(!archive_path.exists());
+        assert!(crate::checksum::compute_checksum(&src).is_err());
+
+        std::fs::write(src.join(".gitignore"), "pipe\n").unwrap();
+        create_archive(&src, &archive_path).unwrap();
+        assert!(crate::checksum::compute_checksum(&src).is_ok());
     }
 }

--- a/crates/wflpkg/src/checksum.rs
+++ b/crates/wflpkg/src/checksum.rs
@@ -1,61 +1,308 @@
+use flate2::read::GzDecoder;
 use sha2::{Digest, Sha256};
-use std::path::Path;
+use std::io::Read;
+use std::path::{Component, Path};
+use tar::Archive;
 
 use crate::error::PackageError;
+use crate::package_files::IgnoreStack;
 
-/// Compute a WFLHASH checksum over a directory's contents.
-/// Uses SHA-256 internally, prefixed with "wflhash:" for display.
+const CHECKSUM_PREFIX: &str = "wflhash:v2:";
+const CHECKSUM_DOMAIN: &[u8] = b"WFL package checksum\0v2\0";
+
+/// Compute a v2 WFL package checksum over selected source contents.
+///
+/// Publishing uses `compute_archive_checksum` after the immutable archive has
+/// been created. This public helper remains useful for source trees and uses
+/// the same selection rules as archive creation.
 pub fn compute_checksum(path: &Path) -> Result<String, PackageError> {
-    let mut hasher = Sha256::new();
-    hash_directory(path, path, &mut hasher)?;
-    let result = hasher.finalize();
-    Ok(format!("wflhash:{:x}", result))
+    let metadata = std::fs::symlink_metadata(path)?;
+    let mut hasher = new_hasher();
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() {
+        return Err(unsupported_object(path));
+    }
+    if file_type.is_dir() {
+        let mut ignore_stack = IgnoreStack::new(path)?;
+        hash_source_directory(path, path, &mut hasher, &mut ignore_stack)?;
+    } else if file_type.is_file() {
+        hash_file(path, path, &mut hasher)?;
+    } else {
+        return Err(unsupported_object(path));
+    }
+    Ok(finish_checksum(hasher))
 }
 
-/// Recursively hash directory contents in sorted order for determinism.
-fn hash_directory(base: &Path, path: &Path, hasher: &mut Sha256) -> Result<(), PackageError> {
-    if !path.is_dir() {
-        // Hash a single file
-        let content = std::fs::read(path)?;
-        let relative = path.strip_prefix(base).unwrap_or(path);
-        let rel_bytes = relative.to_string_lossy();
-        hasher.update((rel_bytes.len() as u64).to_le_bytes());
-        hasher.update(rel_bytes.as_bytes());
-        hasher.update(&content);
-        return Ok(());
+/// Compute the checksum from the completed upload archive itself.
+///
+/// This prevents a concurrent source edit from producing archive A with the
+/// checksum of source state B. The required entry point must be present as a
+/// regular file in that exact archive.
+pub(crate) fn compute_archive_checksum(
+    archive_path: &Path,
+    required_entry: &Path,
+) -> Result<String, PackageError> {
+    let file = std::fs::File::open(archive_path)?;
+    let decoder = GzDecoder::new(file);
+    let mut archive = Archive::new(decoder);
+    let required = portable_relative_path(required_entry)?;
+    if required.is_empty() {
+        return Err(PackageError::General(
+            "The project entry point cannot be empty.".to_string(),
+        ));
     }
 
-    let mut entries: Vec<_> = std::fs::read_dir(path)?.collect::<Result<Vec<_>, _>>()?;
-    entries.sort_by_key(|e| e.file_name());
+    let mut hasher = new_hasher();
+    let mut found_entry = false;
+    let mut found_manifest = false;
+
+    for item in archive
+        .entries()
+        .map_err(|error| PackageError::General(format!("Failed to read archive: {}", error)))?
+    {
+        let mut entry = item
+            .map_err(|error| PackageError::General(format!("Invalid archive entry: {}", error)))?;
+        if !entry.header().entry_type().is_file() {
+            return Err(PackageError::General(
+                "The generated package archive contains a non-regular entry.".to_string(),
+            ));
+        }
+        let entry_path = entry
+            .path()
+            .map_err(|error| PackageError::General(format!("Invalid archive path: {}", error)))?;
+        let portable = portable_relative_path(&entry_path)?;
+        if portable.is_empty() {
+            return Err(PackageError::General(
+                "The generated package archive contains an empty path.".to_string(),
+            ));
+        }
+        found_entry |= portable == required;
+        found_manifest |= portable == "project.wfl";
+        let size = entry.size();
+        hash_record(&portable, size, &mut entry, &mut hasher)?;
+    }
+
+    if !found_manifest {
+        return Err(PackageError::General(
+            "project.wfl is not included in the package archive. Check .gitignore and try again."
+                .to_string(),
+        ));
+    }
+    if !found_entry {
+        return Err(PackageError::General(format!(
+            "The entry point \"{}\" is not included in the package archive. Check .gitignore and make sure it is a regular file.",
+            required_entry.display()
+        )));
+    }
+    Ok(finish_checksum(hasher))
+}
+
+/// Recursively hash source contents in deterministic order.
+fn hash_source_directory(
+    base: &Path,
+    path: &Path,
+    hasher: &mut Sha256,
+    ignore_stack: &mut IgnoreStack,
+) -> Result<(), PackageError> {
+    let entries = sorted_entries(path)?;
 
     for entry in entries {
         let entry_path = entry.path();
         let file_name = entry.file_name();
-        let name = file_name.to_string_lossy();
+        let name = file_name.to_str().ok_or_else(|| {
+            PackageError::General(format!(
+                "Package path is not valid Unicode: {}",
+                entry_path.display()
+            ))
+        })?;
 
-        if crate::is_excluded(&name) {
+        if crate::is_excluded(name) {
             continue;
         }
 
-        if entry_path.is_dir() {
-            hash_directory(base, &entry_path, hasher)?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        let relative = entry_path.strip_prefix(base).unwrap_or(&entry_path);
+        if ignore_stack.is_ignored(relative, file_type.is_dir())? {
+            continue;
+        }
+        if !file_type.is_dir() && !file_type.is_file() {
+            return Err(unsupported_object(&entry_path));
+        }
+
+        if file_type.is_dir() {
+            let added_rules = ignore_stack.push_for_dir(&entry_path, relative)?;
+            let result = hash_source_directory(base, &entry_path, hasher, ignore_stack);
+            ignore_stack.pop(added_rules);
+            result?;
         } else {
-            let content = std::fs::read(&entry_path)?;
-            let relative = entry_path.strip_prefix(base).unwrap_or(&entry_path);
-            let rel_bytes = relative.to_string_lossy();
-            hasher.update((rel_bytes.len() as u64).to_le_bytes());
-            hasher.update(rel_bytes.as_bytes());
-            hasher.update(&content);
+            hash_file(base, &entry_path, hasher)?;
         }
     }
 
     Ok(())
 }
 
-/// Verify a checksum against an expected value.
+/// Hash every regular file in an installed package. Unlike source selection,
+/// verification deliberately honors neither fixed exclusions nor a package's
+/// `.gitignore`, so an added payload can never be invisible to verification.
+fn hash_verified_directory(
+    base: &Path,
+    path: &Path,
+    hasher: &mut Sha256,
+) -> Result<(), PackageError> {
+    for entry in sorted_entries(path)? {
+        let entry_path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() || (!file_type.is_dir() && !file_type.is_file()) {
+            return Err(unsupported_object(&entry_path));
+        }
+        if file_type.is_dir() {
+            hash_verified_directory(base, &entry_path, hasher)?;
+        } else {
+            hash_file(base, &entry_path, hasher)?;
+        }
+    }
+    Ok(())
+}
+
+fn sorted_entries(path: &Path) -> Result<Vec<std::fs::DirEntry>, PackageError> {
+    let mut entries: Vec<_> = std::fs::read_dir(path)?.collect::<Result<Vec<_>, _>>()?;
+    for entry in &entries {
+        if entry.file_name().to_str().is_none() {
+            return Err(PackageError::General(format!(
+                "Package path is not valid Unicode: {}",
+                entry.path().display()
+            )));
+        }
+    }
+    entries.sort_by(|left, right| {
+        left.file_name()
+            .to_str()
+            .expect("validated above")
+            .cmp(right.file_name().to_str().expect("validated above"))
+    });
+    Ok(entries)
+}
+
+fn hash_file(base: &Path, path: &Path, hasher: &mut Sha256) -> Result<(), PackageError> {
+    let path_metadata = std::fs::symlink_metadata(path)?;
+    if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+        return Err(unsupported_object(path));
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(unsupported_object(path));
+    }
+    let relative = path.strip_prefix(base).unwrap_or(path);
+    let portable = portable_relative_path(relative)?;
+    hash_record(&portable, metadata.len(), &mut file, hasher)?;
+
+    // Refuse a file that grew after its length was recorded. A short read is
+    // already rejected inside `hash_record`.
+    let mut extra = [0_u8; 1];
+    if file.read(&mut extra)? != 0 {
+        return Err(PackageError::General(format!(
+            "Package file changed while it was being checksummed: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn hash_record<R: Read>(
+    portable_path: &str,
+    content_len: u64,
+    reader: &mut R,
+    hasher: &mut Sha256,
+) -> Result<(), PackageError> {
+    let path_bytes = portable_path.as_bytes();
+    hasher.update([0x01]);
+    hasher.update((path_bytes.len() as u64).to_le_bytes());
+    hasher.update(path_bytes);
+    hasher.update(content_len.to_le_bytes());
+
+    let mut remaining = content_len;
+    let mut buffer = [0_u8; 64 * 1024];
+    while remaining > 0 {
+        let wanted = usize::try_from(remaining.min(buffer.len() as u64)).unwrap_or(buffer.len());
+        let read = reader.read(&mut buffer[..wanted])?;
+        if read == 0 {
+            return Err(PackageError::General(
+                "Package file changed while it was being checksummed.".to_string(),
+            ));
+        }
+        hasher.update(&buffer[..read]);
+        remaining -= read as u64;
+    }
+    Ok(())
+}
+
+fn portable_relative_path(path: &Path) -> Result<String, PackageError> {
+    let mut portable = String::new();
+    for component in path.components() {
+        let Component::Normal(value) = component else {
+            return Err(PackageError::General(format!(
+                "Package path is not a normalized relative path: {}",
+                path.display()
+            )));
+        };
+        let value = value.to_str().ok_or_else(|| {
+            PackageError::General(format!(
+                "Package path is not valid Unicode: {}",
+                path.display()
+            ))
+        })?;
+        if !portable.is_empty() {
+            portable.push('/');
+        }
+        portable.push_str(value);
+    }
+    Ok(portable)
+}
+
+fn new_hasher() -> Sha256 {
+    let mut hasher = Sha256::new();
+    hasher.update(CHECKSUM_DOMAIN);
+    hasher
+}
+
+fn finish_checksum(hasher: Sha256) -> String {
+    format!("{}{:x}", CHECKSUM_PREFIX, hasher.finalize())
+}
+
+fn unsupported_object(path: &Path) -> PackageError {
+    PackageError::General(format!(
+        "Package contains an unsupported filesystem object: {}",
+        path.display()
+    ))
+}
+
+/// Verify an installed package against an expected checksum.
 pub fn verify_checksum(path: &Path, expected: &str) -> Result<bool, PackageError> {
-    let actual = compute_checksum(path)?;
-    Ok(actual == expected)
+    let metadata = std::fs::symlink_metadata(path)?;
+    let file_type = metadata.file_type();
+    if file_type.is_symlink() || (!file_type.is_dir() && !file_type.is_file()) {
+        return Err(unsupported_object(path));
+    }
+
+    let mut hasher = new_hasher();
+    if file_type.is_dir() {
+        hash_verified_directory(path, path, &mut hasher)?;
+    } else {
+        hash_file(path, path, &mut hasher)?;
+    }
+    Ok(finish_checksum(hasher) == expected)
 }
 
 #[cfg(test)]
@@ -68,8 +315,8 @@ mod tests {
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join("test.wfl"), "display \"hello\"").unwrap();
         let checksum = compute_checksum(temp.path()).unwrap();
-        assert!(checksum.starts_with("wflhash:"));
-        assert_eq!(checksum.len(), 8 + 64); // "wflhash:" (8) + 64 hex chars
+        assert!(checksum.starts_with("wflhash:v2:"));
+        assert_eq!(checksum.len(), 11 + 64);
     }
 
     #[test]
@@ -78,13 +325,7 @@ mod tests {
         std::fs::write(temp.path().join("test.wfl"), "display \"hello\"").unwrap();
         let checksum = compute_checksum(temp.path()).unwrap();
         assert!(verify_checksum(temp.path(), &checksum).unwrap());
-        assert!(
-            !verify_checksum(
-                temp.path(),
-                "wflhash:0000000000000000000000000000000000000000000000000000000000000000"
-            )
-            .unwrap()
-        );
+        assert!(!verify_checksum(temp.path(), "wflhash:v2:invalid").unwrap());
     }
 
     #[test]
@@ -92,25 +333,108 @@ mod tests {
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join("a.wfl"), "store x as 1").unwrap();
         std::fs::write(temp.path().join("b.wfl"), "store y as 2").unwrap();
-        let c1 = compute_checksum(temp.path()).unwrap();
-        let c2 = compute_checksum(temp.path()).unwrap();
-        assert_eq!(c1, c2);
+        assert_eq!(
+            compute_checksum(temp.path()).unwrap(),
+            compute_checksum(temp.path()).unwrap()
+        );
     }
 
     #[test]
-    fn test_wflpkg_files_excluded_from_checksum() {
+    fn record_boundaries_cannot_collide() {
+        let one = TempDir::new().unwrap();
+        let two = TempDir::new().unwrap();
+        let mut collision_payload = 1_u64.to_le_bytes().to_vec();
+        collision_payload.push(b'b');
+        std::fs::write(one.path().join("a"), collision_payload).unwrap();
+        std::fs::write(two.path().join("a"), []).unwrap();
+        std::fs::write(two.path().join("b"), []).unwrap();
+
+        assert_ne!(
+            compute_checksum(one.path()).unwrap(),
+            compute_checksum(two.path()).unwrap()
+        );
+    }
+
+    #[test]
+    fn verification_does_not_hide_source_exclusions() {
         let temp = TempDir::new().unwrap();
         std::fs::write(temp.path().join("main.wfl"), "display \"hello\"").unwrap();
+        let expected = compute_checksum(temp.path()).unwrap();
+        std::fs::create_dir(temp.path().join("packages")).unwrap();
+        std::fs::write(temp.path().join("packages/evil.wfl"), "display \"evil\"").unwrap();
 
-        let checksum_before = compute_checksum(temp.path()).unwrap();
+        assert!(!verify_checksum(temp.path(), &expected).unwrap());
+    }
 
+    #[test]
+    fn completed_archive_checksum_matches_strict_extracted_verification() {
+        let temp = TempDir::new().unwrap();
+        let source = temp.path().join("source");
+        std::fs::create_dir_all(source.join("a")).unwrap();
+        std::fs::write(source.join("a/nested.wfl"), "display \"nested\"").unwrap();
+        std::fs::write(source.join("a.txt"), "asset").unwrap();
+        std::fs::write(source.join("main.wfl"), "display \"main\"").unwrap();
+        std::fs::write(
+            source.join("project.wfl"),
+            "name is demo\nversion is 26.1.1\ndescription is demo\nentry is main.wfl\n",
+        )
+        .unwrap();
+        std::fs::write(source.join(".gitignore"), "secret.env\n").unwrap();
+        std::fs::write(source.join("secret.env"), "TOKEN=secret").unwrap();
+
+        let archive = temp.path().join("package.wflpkg");
+        crate::archive::create_archive(&source, &archive).unwrap();
+        let checksum = compute_archive_checksum(&archive, Path::new("main.wfl")).unwrap();
+        assert_eq!(checksum, compute_checksum(&source).unwrap());
+
+        let extracted = temp.path().join("extracted");
+        crate::archive::extract_archive(&archive, &extracted).unwrap();
+        assert!(verify_checksum(&extracted, &checksum).unwrap());
+    }
+
+    #[test]
+    fn test_wflpkg_files_excluded_from_source_checksum() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("main.wfl"), "display \"hello\"").unwrap();
+        let before = compute_checksum(temp.path()).unwrap();
         std::fs::write(temp.path().join("myproject.wflpkg"), b"archive data").unwrap();
+        assert_eq!(before, compute_checksum(temp.path()).unwrap());
+    }
 
-        let checksum_after = compute_checksum(temp.path()).unwrap();
+    #[test]
+    fn test_gitignored_files_excluded_from_source_checksum() {
+        let temp = TempDir::new().unwrap();
+        std::fs::create_dir(temp.path().join("nested")).unwrap();
+        std::fs::write(temp.path().join("main.wfl"), "display \"hello\"").unwrap();
+        std::fs::write(temp.path().join(".gitignore"), ".env\n*.log\n!nested/\n").unwrap();
+        let before = compute_checksum(temp.path()).unwrap();
+        std::fs::write(temp.path().join(".env"), "API_TOKEN=secret").unwrap();
+        std::fs::write(temp.path().join("debug.log"), "credential output").unwrap();
+        std::fs::write(temp.path().join("nested/debug.log"), "credential output").unwrap();
+        assert_eq!(before, compute_checksum(temp.path()).unwrap());
+    }
 
+    #[test]
+    fn portable_path_uses_forward_slashes() {
+        let path = Path::new("first").join("second").join("file.wfl");
         assert_eq!(
-            checksum_before, checksum_after,
-            "Checksum should not change when a .wflpkg file is added"
+            portable_relative_path(&path).unwrap(),
+            "first/second/file.wfl"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_symlinks_and_special_files_are_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("target");
+        std::fs::write(&target, "content").unwrap();
+        let link = temp.path().join("link");
+        symlink(&target, &link).unwrap();
+        assert!(compute_checksum(&link).is_err());
+
+        assert!(compute_checksum(Path::new("/dev/null")).is_err());
     }
 }

--- a/crates/wflpkg/src/commands/login.rs
+++ b/crates/wflpkg/src/commands/login.rs
@@ -1,5 +1,5 @@
 use crate::error::PackageError;
-use crate::registry::auth::AuthManager;
+use crate::registry::auth::{AuthManager, normalize_registry_origin};
 
 /// Default token reader that uses rpassword to hide input.
 fn default_token_reader(prompt: &str) -> Result<String, PackageError> {
@@ -21,24 +21,31 @@ fn login_with_reader<F>(
 where
     F: FnOnce(&str) -> Result<String, PackageError>,
 {
-    if auth.is_authenticated() {
-        println!("You are already logged in.");
+    let registry_origin = normalize_registry_origin(registry_url)?;
+    if let Some(credentials) = auth.get_credentials()? {
+        if credentials.registry_origin() != registry_origin {
+            return Err(PackageError::General(format!(
+                "You are logged in to {}, not {}. Run `wfl logout`, verify the registry address, then log in again.",
+                credentials.registry_origin(),
+                registry_origin
+            )));
+        }
+        println!(
+            "You are already logged in to {}.",
+            credentials.registry_origin()
+        );
         println!("To log out first, run: wfl logout");
         return Ok(());
     }
 
-    let bare_host = registry_url
-        .trim_start_matches("https://")
-        .trim_start_matches("http://");
-
-    println!("Logging in to {}...", bare_host);
+    println!("Logging in to {}...", registry_origin);
     println!();
 
     // For now, use a simple token-based login via CLI prompt.
     // In the future, this will use browser-based OAuth.
     println!(
-        "Visit https://{}/settings/tokens to generate an API token.",
-        bare_host
+        "Visit {}/settings/tokens to generate an API token.",
+        registry_origin
     );
     println!();
 
@@ -49,8 +56,8 @@ where
         return Err(PackageError::General("No token provided.".to_string()));
     }
 
-    auth.store_token(token, registry_url)?;
-    println!("Logged in successfully to {}.", bare_host);
+    auth.store_token(token, &registry_origin)?;
+    println!("Logged in successfully to {}.", registry_origin);
 
     Ok(())
 }
@@ -58,8 +65,11 @@ where
 /// Log out from the registry.
 pub fn logout() -> Result<(), PackageError> {
     let auth = AuthManager::new()?;
+    logout_with_auth(&auth)
+}
 
-    if !auth.is_authenticated() {
+fn logout_with_auth(auth: &AuthManager) -> Result<(), PackageError> {
+    if !auth.credentials_file_exists()? {
         println!("You are not currently logged in.");
         return Ok(());
     }
@@ -149,6 +159,43 @@ mod tests {
 
         let result = login_with_reader("https://registry.example.com", &auth, reader);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_login_rejects_different_authenticated_registry() {
+        let (auth, _dir) = temp_auth();
+        auth.store_token("existing-token", "https://registry.example.com")
+            .unwrap();
+
+        let result = login_with_reader("https://other.example.com", &auth, |_| {
+            panic!("reader should not be called for existing credentials")
+        });
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("not https://other.example.com")
+        );
+    }
+
+    #[test]
+    fn test_logout_recovers_malformed_auth_then_allows_login() {
+        let (auth, dir) = temp_auth();
+        let path = dir.path().join("credentials.json");
+
+        for malformed in [
+            "not json",
+            r#"{"token":"secret"}"#,
+            r#"{"token":"secret","registry":"http://registry.example"}"#,
+        ] {
+            std::fs::write(&path, malformed).unwrap();
+            logout_with_auth(&auth).unwrap();
+            assert!(!path.exists());
+            login_with_reader("registry.example", &auth, |_| Ok("replacement".to_string()))
+                .unwrap();
+            auth.clear_token().unwrap();
+        }
     }
 
     #[test]

--- a/crates/wflpkg/src/commands/share.rs
+++ b/crates/wflpkg/src/commands/share.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use crate::archive;
 use crate::checksum;
@@ -6,23 +6,25 @@ use crate::error::PackageError;
 use crate::manifest::ProjectManifest;
 use crate::manifest::version::Version;
 use crate::registry::api::RegistryClient;
-use crate::registry::auth::AuthManager;
+use crate::registry::auth::{AuthManager, normalize_registry_origin};
+
+const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 
 /// Share (publish) the current project to the registry.
 pub async fn share_package(project_dir: &Path) -> Result<(), PackageError> {
+    let project_dir = std::fs::canonicalize(project_dir)?;
+    let project_dir = project_dir.as_path();
     let manifest_path = project_dir.join("project.wfl");
-    if !manifest_path.exists() {
-        return Err(PackageError::ManifestNotFound(
-            project_dir.display().to_string(),
-        ));
-    }
-
-    let manifest = ProjectManifest::load(&manifest_path)?;
+    let manifest = load_manifest_no_follow(&manifest_path, project_dir)?;
     let version = Version::parse(&manifest.version_string)?;
 
     // Check authentication
     let auth = AuthManager::new()?;
-    let token = auth.get_token()?.ok_or(PackageError::NotAuthenticated)?;
+    let credentials = auth
+        .get_credentials()?
+        .ok_or(PackageError::NotAuthenticated)?;
+    let registry_origin =
+        registry_for_credentials(manifest.registry_url(), credentials.registry_origin())?;
 
     // Validate manifest
     if manifest.name.is_empty() || manifest.description.is_empty() {
@@ -31,42 +33,257 @@ pub async fn share_package(project_dir: &Path) -> Result<(), PackageError> {
         ));
     }
 
-    // Verify entry point exists
-    let entry_path = project_dir.join(manifest.entry_point());
-    if !entry_path.exists() {
-        return Err(PackageError::General(format!(
-            "The entry point \"{}\" does not exist.\n\
-             Update the entry field in project.wfl or create the file.",
-            manifest.entry_point()
-        )));
-    }
+    // Reject absolute/traversing/symlink/directory entry points before doing
+    // any packaging work. Presence in the completed archive is checked below
+    // as the authoritative validation against ignore rules and races.
+    let entry_point = validate_entry_point(project_dir, manifest.entry_point())?;
 
     println!("Preparing to share {} {}...", manifest.name, version);
 
-    // Create archive
-    let archive_path = project_dir.join(format!("{}-{}.wflpkg", manifest.name, version));
-    archive::create_archive(project_dir, &archive_path)?;
+    // Create the upload in a private, external temporary directory. Keeping
+    // the TempDir alive provides automatic cleanup on every return path and
+    // prevents a project-controlled symlink from redirecting archive output.
+    let archive_file = create_upload_archive(project_dir)?;
 
-    // Compute checksum
-    let checksum = checksum::compute_checksum(project_dir)?;
+    // Derive the checksum from the completed immutable archive. This also
+    // verifies that the declared regular entry point is actually included.
+    let checksum = checksum::compute_archive_checksum(archive_file.path(), &entry_point)?;
 
     // Upload to registry
-    let mut client = RegistryClient::new(&format!("https://{}", manifest.registry_url()))?;
-    client.set_auth_token(token);
+    let mut client = RegistryClient::new(&registry_origin)?;
+    client.set_auth_token(credentials.token().to_string());
 
     client
-        .publish(&manifest.name, &version, &archive_path, &checksum)
+        .publish(&manifest.name, &version, archive_file.path(), &checksum)
         .await?;
-
-    // Clean up archive
-    let _ = std::fs::remove_file(&archive_path);
 
     println!(
         "Shared {} {} to {}",
-        manifest.name,
-        version,
-        manifest.registry_url()
+        manifest.name, version, registry_origin
     );
 
     Ok(())
+}
+
+fn load_manifest_no_follow(
+    manifest_path: &Path,
+    project_dir: &Path,
+) -> Result<ProjectManifest, PackageError> {
+    use std::io::Read;
+
+    match std::fs::symlink_metadata(manifest_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(PackageError::General(
+                "project.wfl must be a regular, non-symlink file.".to_string(),
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(PackageError::ManifestNotFound(
+                project_dir.display().to_string(),
+            ));
+        }
+        Err(error) => return Err(PackageError::Io(error)),
+    }
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = match options.open(manifest_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Err(PackageError::ManifestNotFound(
+                project_dir.display().to_string(),
+            ));
+        }
+        Err(error) => return Err(PackageError::Io(error)),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_MANIFEST_BYTES {
+        return Err(PackageError::General(
+            "project.wfl must be a regular file no larger than 1 MiB.".to_string(),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_MANIFEST_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_MANIFEST_BYTES {
+        return Err(PackageError::General(
+            "project.wfl must be no larger than 1 MiB.".to_string(),
+        ));
+    }
+    let content = String::from_utf8(bytes)
+        .map_err(|_| PackageError::General("project.wfl must contain valid UTF-8.".to_string()))?;
+    crate::manifest::parser::parse_manifest(&content)
+}
+
+fn validate_entry_point(project_dir: &Path, entry: &str) -> Result<PathBuf, PackageError> {
+    let entry_path = Path::new(entry);
+    if entry_path.as_os_str().is_empty() || entry_path.is_absolute() {
+        return Err(invalid_entry_point(entry));
+    }
+    for component in entry_path.components() {
+        if !matches!(component, Component::Normal(_)) {
+            return Err(invalid_entry_point(entry));
+        }
+    }
+
+    let metadata = std::fs::symlink_metadata(project_dir.join(entry_path)).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            invalid_entry_point(entry)
+        } else {
+            PackageError::Io(error)
+        }
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(invalid_entry_point(entry));
+    }
+    Ok(entry_path.to_path_buf())
+}
+
+fn invalid_entry_point(entry: &str) -> PackageError {
+    PackageError::General(format!(
+        "The entry point \"{}\" must be a normalized relative path to a regular, non-symlink file inside the project.",
+        entry
+    ))
+}
+
+fn registry_for_credentials(
+    manifest_registry: &str,
+    authenticated_registry: &str,
+) -> Result<String, PackageError> {
+    let requested_origin = normalize_registry_origin(manifest_registry)?;
+    let authenticated_origin = normalize_registry_origin(authenticated_registry)?;
+    if requested_origin != authenticated_origin {
+        return Err(PackageError::General(format!(
+            "This project is configured to use {}, but your saved credentials belong to {}.\n\n\
+             Refusing to send that token to a different registry. Log out, verify the project's registry setting, and log in to the intended registry.",
+            requested_origin, authenticated_origin
+        )));
+    }
+    Ok(requested_origin)
+}
+
+struct UploadArchive {
+    _directory: tempfile::TempDir,
+    path: std::path::PathBuf,
+}
+
+impl UploadArchive {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+fn create_upload_archive(project_dir: &Path) -> Result<UploadArchive, PackageError> {
+    let directory = tempfile::Builder::new()
+        .prefix("wflpkg-upload-")
+        .tempdir()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(directory.path(), std::fs::Permissions::from_mode(0o700))?;
+    }
+    let path = directory.path().join("package.wflpkg");
+    archive::create_archive(project_dir, &path)?;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&path)?
+        .sync_all()?;
+    Ok(UploadArchive {
+        _directory: directory,
+        path,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credentials_are_bound_to_the_same_origin() {
+        assert_eq!(
+            registry_for_credentials("wflhub.org", "https://wflhub.org/").unwrap(),
+            "https://wflhub.org"
+        );
+        assert!(registry_for_credentials("wflhub.org@evil.example", "wflhub.org").is_err());
+        assert!(registry_for_credentials("evil.example", "wflhub.org").is_err());
+    }
+
+    #[test]
+    fn upload_archive_is_external_and_removed_on_drop() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("main.wfl"), "display \"hello\"").unwrap();
+
+        let archive_path = {
+            let archive = create_upload_archive(project.path()).unwrap();
+            assert!(!archive.path().starts_with(project.path()));
+            assert!(archive.path().exists());
+            archive.path().to_path_buf()
+        };
+        assert!(!archive_path.exists());
+    }
+
+    #[test]
+    fn entry_point_must_be_an_in_project_regular_file() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::create_dir(project.path().join("src")).unwrap();
+        std::fs::write(project.path().join("src/main.wfl"), "display \"hello\"").unwrap();
+
+        assert_eq!(
+            validate_entry_point(project.path(), "src/main.wfl").unwrap(),
+            Path::new("src/main.wfl")
+        );
+        assert!(validate_entry_point(project.path(), "../outside.wfl").is_err());
+        assert!(validate_entry_point(project.path(), project.path().to_str().unwrap()).is_err());
+        assert!(validate_entry_point(project.path(), "src").is_err());
+    }
+
+    #[test]
+    fn ignored_entry_point_is_rejected_from_completed_archive() {
+        let project = tempfile::tempdir().unwrap();
+        std::fs::create_dir(project.path().join("src")).unwrap();
+        std::fs::write(project.path().join("src/main.wfl"), "display \"hello\"").unwrap();
+        std::fs::write(
+            project.path().join("project.wfl"),
+            "name is demo\nversion is 26.1.1\ndescription is demo\nentry is src/main.wfl\n",
+        )
+        .unwrap();
+        std::fs::write(project.path().join(".gitignore"), "src/main.wfl\n").unwrap();
+
+        let entry = validate_entry_point(project.path(), "src/main.wfl").unwrap();
+        let archive = create_upload_archive(project.path()).unwrap();
+        assert!(checksum::compute_archive_checksum(archive.path(), &entry).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_manifest_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let project = tempfile::tempdir().unwrap();
+        let target = project.path().join("manifest-target");
+        std::fs::write(
+            &target,
+            "name is demo\nversion is 26.1.1\ndescription is demo\n",
+        )
+        .unwrap();
+        let manifest = project.path().join("project.wfl");
+        symlink(&target, &manifest).unwrap();
+        assert!(load_manifest_no_follow(&manifest, project.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_entry_point_is_rejected() {
+        use std::os::unix::fs::symlink;
+
+        let project = tempfile::tempdir().unwrap();
+        std::fs::write(project.path().join("target.wfl"), "display \"hello\"").unwrap();
+        symlink("target.wfl", project.path().join("main.wfl")).unwrap();
+        assert!(validate_entry_point(project.path(), "main.wfl").is_err());
+    }
 }

--- a/crates/wflpkg/src/lib.rs
+++ b/crates/wflpkg/src/lib.rs
@@ -5,6 +5,7 @@ pub mod commands;
 pub mod error;
 pub mod lockfile;
 pub mod manifest;
+mod package_files;
 pub mod permissions;
 pub mod registry;
 pub mod resolver;

--- a/crates/wflpkg/src/main.rs
+++ b/crates/wflpkg/src/main.rs
@@ -83,7 +83,7 @@ async fn run_command(args: &[String], cwd: &Path) -> Result<(), wflpkg::PackageE
             wflpkg::commands::info::show_package_info(&args[1], DEFAULT_REGISTRY).await?;
         }
         "login" => {
-            wflpkg::commands::login::login(DEFAULT_REGISTRY)?;
+            wflpkg::commands::login::login(login_registry_arg(&args[1..]))?;
         }
         "logout" => {
             wflpkg::commands::login::logout()?;
@@ -160,11 +160,15 @@ fn print_help() {
     println!("    share                               Share (publish) to the registry");
     println!("    search <query>                      Search for packages");
     println!("    info <package>                      Show package details");
-    println!("    login                               Log in to the registry");
+    println!("    login [registry]                    Log in to a registry");
     println!("    logout                              Log out from the registry");
     println!("    check security                      Check for security advisories");
     println!("    check compatibility                 Check API compatibility");
     println!("    help                                Show this help message");
+}
+
+fn login_registry_arg(args: &[String]) -> &str {
+    args.first().map(String::as_str).unwrap_or(DEFAULT_REGISTRY)
 }
 
 #[cfg(test)]
@@ -205,6 +209,15 @@ mod tests {
     fn test_parse_create_args_called_without_name() {
         let args = vec![s("project"), s("called")];
         assert_eq!(parse_create_args(&args), None);
+    }
+
+    #[test]
+    fn test_login_registry_arg() {
+        assert_eq!(login_registry_arg(&[]), DEFAULT_REGISTRY);
+        assert_eq!(
+            login_registry_arg(&[s("registry.example")]),
+            "registry.example"
+        );
     }
 
     // --- run_command tests ---

--- a/crates/wflpkg/src/package_files.rs
+++ b/crates/wflpkg/src/package_files.rs
@@ -1,0 +1,301 @@
+use std::path::{Path, PathBuf};
+
+use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+use crate::error::PackageError;
+
+const MAX_IGNORE_FILE_BYTES: u64 = 1024 * 1024;
+const MAX_TOTAL_IGNORE_BYTES: u64 = 4 * 1024 * 1024;
+const MAX_TOTAL_IGNORE_RULES: usize = 4096;
+const MAX_IGNORE_FILES: usize = 1024;
+
+/// Git-ignore matchers active for the directory currently being traversed.
+///
+/// Each `.gitignore` is parsed by the same mature matcher used by ripgrep's
+/// ignore walker. Nested matchers are evaluated after their parents so they
+/// have Git's expected precedence. Callers must pop the number returned by
+/// `push_for_dir` when they leave a directory.
+pub(crate) struct IgnoreStack {
+    files: Vec<IgnoreFile>,
+    total_bytes: u64,
+    total_rules: usize,
+    ignore_files: usize,
+}
+
+struct IgnoreFile {
+    base: PathBuf,
+    matcher: Gitignore,
+}
+
+impl IgnoreStack {
+    pub(crate) fn new(project_dir: &Path) -> Result<Self, PackageError> {
+        let mut stack = Self {
+            files: Vec::new(),
+            total_bytes: 0,
+            total_rules: 0,
+            ignore_files: 0,
+        };
+        stack.push_for_dir(project_dir, Path::new(""))?;
+        Ok(stack)
+    }
+
+    /// Load the `.gitignore` in `dir`, scoped to `relative_dir`.
+    pub(crate) fn push_for_dir(
+        &mut self,
+        dir: &Path,
+        relative_dir: &Path,
+    ) -> Result<usize, PackageError> {
+        let ignore_path = dir.join(".gitignore");
+        match std::fs::symlink_metadata(&ignore_path) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err(PackageError::General(format!(
+                    ".gitignore must be a regular, non-symlink file: {}",
+                    ignore_path.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(error) => return Err(PackageError::Io(error)),
+        }
+
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW);
+        }
+        let file = match options.open(&ignore_path) {
+            Ok(file) => file,
+            Err(error) => return Err(PackageError::Io(error)),
+        };
+
+        let metadata = file.metadata()?;
+        if !metadata.is_file() {
+            return Ok(0);
+        }
+        if metadata.len() > MAX_IGNORE_FILE_BYTES {
+            return Err(PackageError::General(format!(
+                ".gitignore is too large to process safely: {}",
+                ignore_path.display()
+            )));
+        }
+
+        use std::io::Read;
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.take(MAX_IGNORE_FILE_BYTES + 1)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() as u64 > MAX_IGNORE_FILE_BYTES {
+            return Err(PackageError::General(format!(
+                ".gitignore grew too large while it was being read: {}",
+                ignore_path.display()
+            )));
+        }
+        let content = String::from_utf8(bytes).map_err(|_| {
+            PackageError::General(format!(
+                ".gitignore is not valid UTF-8: {}",
+                ignore_path.display()
+            ))
+        })?;
+
+        let mut builder = GitignoreBuilder::new("");
+        builder
+            .case_insensitive(cfg!(windows))
+            .map_err(ignore_pattern_error)?;
+        for line in content.lines() {
+            reject_unsupported_git_classes(line)?;
+            builder
+                .add_line(Some(ignore_path.clone()), line)
+                .map_err(ignore_pattern_error)?;
+        }
+        let matcher = builder.build().map_err(ignore_pattern_error)?;
+        let rule_count = (matcher.num_ignores() + matcher.num_whitelists()) as usize;
+
+        let next_bytes = self
+            .total_bytes
+            .checked_add(content.len() as u64)
+            .ok_or_else(ignore_budget_error)?;
+        let next_files = self
+            .ignore_files
+            .checked_add(1)
+            .ok_or_else(ignore_budget_error)?;
+        let next_rules = self
+            .total_rules
+            .checked_add(rule_count)
+            .ok_or_else(ignore_budget_error)?;
+        if next_bytes > MAX_TOTAL_IGNORE_BYTES
+            || next_files > MAX_IGNORE_FILES
+            || next_rules > MAX_TOTAL_IGNORE_RULES
+        {
+            return Err(ignore_budget_error());
+        }
+
+        self.total_bytes = next_bytes;
+        self.ignore_files = next_files;
+        self.total_rules = next_rules;
+        if rule_count == 0 {
+            return Ok(0);
+        }
+        self.files.push(IgnoreFile {
+            base: relative_dir.to_path_buf(),
+            matcher,
+        });
+        Ok(1)
+    }
+
+    pub(crate) fn pop(&mut self, count: usize) {
+        self.files.truncate(self.files.len().saturating_sub(count));
+    }
+
+    pub(crate) fn is_ignored(
+        &self,
+        relative_path: &Path,
+        is_dir: bool,
+    ) -> Result<bool, PackageError> {
+        // Fail closed instead of publishing a path that cannot be represented
+        // consistently in a portable package checksum.
+        if relative_path.to_str().is_none() {
+            return Err(PackageError::General(format!(
+                "Package path is not valid Unicode: {}",
+                relative_path.display()
+            )));
+        }
+
+        let mut ignored = false;
+        for file in &self.files {
+            let Ok(scoped_path) = relative_path.strip_prefix(&file.base) else {
+                continue;
+            };
+            if scoped_path.as_os_str().is_empty() {
+                continue;
+            }
+            match file.matcher.matched(scoped_path, is_dir) {
+                Match::Ignore(_) => ignored = true,
+                Match::Whitelist(_) => ignored = false,
+                Match::None => {}
+            }
+        }
+        Ok(ignored)
+    }
+}
+
+fn reject_unsupported_git_classes(line: &str) -> Result<(), PackageError> {
+    // Git wildmatch supports POSIX bracket classes, while the matcher used by
+    // `ignore` currently accepts but does not match them. Refuse these forms
+    // instead of silently publishing an intended secret.
+    if line.contains("[[:") || line.contains("[[.") || line.contains("[[=") {
+        return Err(PackageError::General(
+            "A .gitignore uses a POSIX bracket class that cannot be evaluated safely; refusing to publish."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn ignore_pattern_error(error: ignore::Error) -> PackageError {
+    PackageError::General(format!(
+        "A .gitignore contains a pattern that cannot be evaluated safely; refusing to publish: {}",
+        error
+    ))
+}
+
+fn ignore_budget_error() -> PackageError {
+    PackageError::General(
+        "The project's .gitignore rules exceed the safe processing limit; refusing to publish."
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_rules_ignore_logs_and_allow_negation() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "*.log\n!important.log\n").unwrap();
+        let stack = IgnoreStack::new(temp.path()).unwrap();
+
+        assert!(stack.is_ignored(Path::new("debug.log"), false).unwrap());
+        assert!(
+            stack
+                .is_ignored(Path::new("nested/debug.log"), false)
+                .unwrap()
+        );
+        assert!(!stack.is_ignored(Path::new("important.log"), false).unwrap());
+    }
+
+    #[test]
+    fn directory_rules_exclude_descendants_by_pruning() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "secrets/\n").unwrap();
+        let stack = IgnoreStack::new(temp.path()).unwrap();
+
+        assert!(stack.is_ignored(Path::new("secrets"), true).unwrap());
+        assert!(stack.is_ignored(Path::new("nested/secrets"), true).unwrap());
+    }
+
+    #[test]
+    fn negated_parent_does_not_clear_leaf_ignore() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "*.log\n!a/b\n").unwrap();
+        let stack = IgnoreStack::new(temp.path()).unwrap();
+
+        assert!(stack.is_ignored(Path::new("a/b/x.log"), false).unwrap());
+    }
+
+    #[test]
+    fn anchored_rules_only_match_from_their_base() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "/.env\n").unwrap();
+        let stack = IgnoreStack::new(temp.path()).unwrap();
+
+        assert!(stack.is_ignored(Path::new(".env"), false).unwrap());
+        assert!(!stack.is_ignored(Path::new("nested/.env"), false).unwrap());
+    }
+
+    #[test]
+    fn escaped_metacharacters_and_star_runs_follow_git_syntax() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            temp.path().join(".gitignore"),
+            "secret\\?.txt\nliteral\\*.env\nname\\ \nfoo**bar\n",
+        )
+        .unwrap();
+        let stack = IgnoreStack::new(temp.path()).unwrap();
+
+        assert!(stack.is_ignored(Path::new("secret?.txt"), false).unwrap());
+        assert!(!stack.is_ignored(Path::new("secret1.txt"), false).unwrap());
+        assert!(stack.is_ignored(Path::new("literal*.env"), false).unwrap());
+        assert!(
+            !stack
+                .is_ignored(Path::new("literal-secret.env"), false)
+                .unwrap()
+        );
+        assert!(stack.is_ignored(Path::new("name "), false).unwrap());
+        assert!(
+            stack
+                .is_ignored(Path::new("foo-anything-bar"), false)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn posix_character_class_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join(".gitignore"), "file[[:digit:]].env\n").unwrap();
+        assert!(IgnoreStack::new(temp.path()).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_gitignore_fails_closed() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("rules"), ".env\n").unwrap();
+        symlink("rules", temp.path().join(".gitignore")).unwrap();
+        assert!(IgnoreStack::new(temp.path()).is_err());
+    }
+}

--- a/crates/wflpkg/src/registry/api.rs
+++ b/crates/wflpkg/src/registry/api.rs
@@ -5,6 +5,10 @@ use crate::manifest::version::Version;
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 /// Default request timeout for registry requests (5 minutes).
 const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+/// Maximum compressed package accepted for one publish request (100 MiB).
+const MAX_PUBLISH_ARCHIVE_BYTES: u64 = 100 * 1024 * 1024;
+/// Maximum registry response body retained by the client (1 MiB).
+const MAX_REGISTRY_RESPONSE_BYTES: usize = 1024 * 1024;
 
 /// A client for communicating with the WFL package registry.
 pub struct RegistryClient {
@@ -69,9 +73,8 @@ impl RegistryClient {
             )));
         }
 
-        let body: serde_json::Value = response
-            .json()
-            .await
+        let bytes = read_response_bounded(response).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)
             .map_err(|e| PackageError::Http(format!("Failed to parse response: {}", e)))?;
 
         let results = body
@@ -113,9 +116,8 @@ impl RegistryClient {
             )));
         }
 
-        let body: serde_json::Value = response
-            .json()
-            .await
+        let bytes = read_response_bounded(response).await?;
+        let body: serde_json::Value = serde_json::from_slice(&bytes)
             .map_err(|e| PackageError::Http(format!("Failed to parse response: {}", e)))?;
 
         let versions: Vec<Version> = body["versions"]
@@ -162,9 +164,7 @@ impl RegistryClient {
             .ok_or(PackageError::NotAuthenticated)?;
 
         let url = format!("{}/api/v1/packages", self.base_url);
-        let archive_data = tokio::fs::read(archive_path)
-            .await
-            .map_err(PackageError::Io)?;
+        let (archive_file, archive_len) = open_publish_archive(archive_path).await?;
 
         let form = reqwest::multipart::Form::new()
             .text("name", name.to_string())
@@ -172,7 +172,7 @@ impl RegistryClient {
             .text("checksum", checksum.to_string())
             .part(
                 "archive",
-                reqwest::multipart::Part::bytes(archive_data)
+                reqwest::multipart::Part::stream_with_length(archive_file, archive_len)
                     .file_name(format!("{}-{}.wflpkg", name, version)),
             );
 
@@ -186,7 +186,8 @@ impl RegistryClient {
             .map_err(|e| PackageError::RegistryUnreachable(format!("{}: {}", self.base_url, e)))?;
 
         if !response.status().is_success() {
-            let body = response.text().await.unwrap_or_default();
+            let body = read_response_bounded(response).await?;
+            let body = String::from_utf8_lossy(&body);
             return Err(PackageError::Http(format!("Failed to publish: {}", body)));
         }
 
@@ -197,6 +198,75 @@ impl RegistryClient {
     pub fn base_url(&self) -> &str {
         &self.base_url
     }
+}
+
+async fn open_publish_archive(
+    archive_path: &std::path::Path,
+) -> Result<(tokio::fs::File, u64), PackageError> {
+    let metadata = tokio::fs::symlink_metadata(archive_path)
+        .await
+        .map_err(PackageError::Io)?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PackageError::General(
+            "The upload archive is not a regular file.".to_string(),
+        ));
+    }
+    if metadata.len() > MAX_PUBLISH_ARCHIVE_BYTES {
+        return Err(PackageError::General(format!(
+            "The compressed package exceeds the {} MiB publish limit.",
+            MAX_PUBLISH_ARCHIVE_BYTES / (1024 * 1024)
+        )));
+    }
+    let file = tokio::fs::File::open(archive_path)
+        .await
+        .map_err(PackageError::Io)?;
+    let opened_metadata = file.metadata().await.map_err(PackageError::Io)?;
+    if !opened_metadata.is_file() || opened_metadata.len() != metadata.len() {
+        return Err(PackageError::General(
+            "The upload archive changed while it was being opened.".to_string(),
+        ));
+    }
+    Ok((file, opened_metadata.len()))
+}
+
+async fn read_response_bounded(mut response: reqwest::Response) -> Result<Vec<u8>, PackageError> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_REGISTRY_RESPONSE_BYTES as u64)
+    {
+        return Err(response_too_large_error());
+    }
+
+    let mut body = Vec::with_capacity(
+        response
+            .content_length()
+            .unwrap_or(0)
+            .min(MAX_REGISTRY_RESPONSE_BYTES as u64) as usize,
+    );
+    while let Some(chunk) = response
+        .chunk()
+        .await
+        .map_err(|error| PackageError::Http(format!("Failed to read response: {}", error)))?
+    {
+        append_response_chunk(&mut body, &chunk)?;
+    }
+    Ok(body)
+}
+
+fn append_response_chunk(body: &mut Vec<u8>, chunk: &[u8]) -> Result<(), PackageError> {
+    let next_len = body
+        .len()
+        .checked_add(chunk.len())
+        .ok_or_else(response_too_large_error)?;
+    if next_len > MAX_REGISTRY_RESPONSE_BYTES {
+        return Err(response_too_large_error());
+    }
+    body.extend_from_slice(chunk);
+    Ok(())
+}
+
+fn response_too_large_error() -> PackageError {
+    PackageError::Http("Registry response exceeded the 1 MiB safety limit.".to_string())
 }
 
 /// Percent-encode a string for use as a URL path segment (RFC 3986).
@@ -239,6 +309,22 @@ mod tests {
     use super::*;
 
     const BASE: &str = "https://registry.example.com";
+
+    #[tokio::test]
+    async fn oversized_publish_archive_is_rejected_before_upload() {
+        let temp = tempfile::tempdir().unwrap();
+        let archive = temp.path().join("oversized.wflpkg");
+        let file = std::fs::File::create(&archive).unwrap();
+        file.set_len(MAX_PUBLISH_ARCHIVE_BYTES + 1).unwrap();
+        assert!(open_publish_archive(&archive).await.is_err());
+    }
+
+    #[test]
+    fn oversized_registry_response_is_rejected() {
+        let mut body = vec![0; MAX_REGISTRY_RESPONSE_BYTES];
+        assert!(append_response_chunk(&mut body, &[1]).is_err());
+        assert_eq!(body.len(), MAX_REGISTRY_RESPONSE_BYTES);
+    }
 
     // --- search URL tests ---
 

--- a/crates/wflpkg/src/registry/auth.rs
+++ b/crates/wflpkg/src/registry/auth.rs
@@ -2,9 +2,13 @@ use std::path::PathBuf;
 
 use crate::error::PackageError;
 
+const MAX_AUTH_FILE_BYTES: u64 = 64 * 1024;
+const MAX_TOKEN_BYTES: usize = 16 * 1024;
+
 /// Manages authentication tokens for registry access.
 pub struct AuthManager {
     auth_file: PathBuf,
+    manage_parent_permissions: bool,
 }
 
 /// Stored authentication data.
@@ -14,56 +18,139 @@ struct AuthData {
     registry: Option<String>,
 }
 
+/// Authentication data bound to one canonical HTTPS registry origin.
+pub struct RegistryCredentials {
+    token: String,
+    registry_origin: String,
+}
+
+impl RegistryCredentials {
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    pub fn registry_origin(&self) -> &str {
+        &self.registry_origin
+    }
+}
+
 impl AuthManager {
     /// Create a new auth manager using the default auth file location.
     pub fn new() -> Result<Self, PackageError> {
         let home = get_home_dir()?;
         let auth_file = home.join(".wfl").join("auth.json");
-        Ok(Self { auth_file })
+        Ok(Self {
+            auth_file,
+            manage_parent_permissions: true,
+        })
     }
 
     /// Create an auth manager with a custom path (for testing).
     pub fn with_path(path: PathBuf) -> Self {
-        Self { auth_file: path }
+        Self {
+            auth_file: path,
+            manage_parent_permissions: false,
+        }
     }
 
     /// Get the stored authentication token.
     pub fn get_token(&self) -> Result<Option<String>, PackageError> {
-        if !self.auth_file.exists() {
-            return Ok(None);
+        Ok(self.get_credentials()?.map(|credentials| credentials.token))
+    }
+
+    /// Get the stored token together with its canonical registry origin.
+    pub fn get_credentials(&self) -> Result<Option<RegistryCredentials>, PackageError> {
+        match std::fs::symlink_metadata(&self.auth_file) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+                return Err(PackageError::General(
+                    "The credentials path is not a regular file. Run `wfl logout`, then `wfl login` again."
+                        .to_string(),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(PackageError::Io(error)),
         }
-        let content = std::fs::read_to_string(&self.auth_file)?;
+        let content = read_auth_file_no_follow(&self.auth_file)?;
         let data: AuthData = serde_json::from_str(&content)
             .map_err(|e| PackageError::General(format!("Failed to parse auth file: {}", e)))?;
-        Ok(data.token)
+        match (data.token, data.registry) {
+            (Some(token), Some(registry)) if !token.trim().is_empty() => {
+                let registry_origin = normalize_registry_origin(&registry).map_err(|_| {
+                    PackageError::General(
+                        "Stored credentials have an invalid registry scope. Run `wfl logout`, then `wfl login` again."
+                            .to_string(),
+                    )
+                })?;
+                Ok(Some(RegistryCredentials {
+                    token,
+                    registry_origin,
+                }))
+            }
+            (None, None) => Ok(None),
+            _ => Err(PackageError::General(
+                "Stored credentials are incomplete. Run `wfl logout`, then `wfl login` again."
+                    .to_string(),
+            )),
+        }
     }
 
     /// Store an authentication token.
     pub fn store_token(&self, token: &str, registry: &str) -> Result<(), PackageError> {
         use zeroize::Zeroize;
 
-        if let Some(parent) = self.auth_file.parent() {
-            std::fs::create_dir_all(parent)?;
+        if token.trim().is_empty() {
+            return Err(PackageError::General(
+                "Cannot store an empty authentication token.".to_string(),
+            ));
+        }
+        if token.len() > MAX_TOKEN_BYTES {
+            return Err(PackageError::General(
+                "Authentication token exceeds the 16 KiB safety limit.".to_string(),
+            ));
+        }
+        let registry_origin = normalize_registry_origin(registry)?;
+
+        {
+            let parent = self
+                .auth_file
+                .parent()
+                .filter(|path| !path.as_os_str().is_empty())
+                .unwrap_or_else(|| std::path::Path::new("."));
+            let mut created_parent = false;
+            match std::fs::symlink_metadata(parent) {
+                Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                    return Err(PackageError::General(
+                        "The credentials directory must be a real directory, not a symlink."
+                            .to_string(),
+                    ));
+                }
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    std::fs::create_dir_all(parent)?;
+                    created_parent = true;
+                }
+                Err(error) => return Err(PackageError::Io(error)),
+            }
+
+            #[cfg(unix)]
+            if created_parent || self.manage_parent_permissions {
+                use std::os::unix::fs::PermissionsExt;
+                let parent_handle = open_directory_no_follow(parent)?;
+                parent_handle.set_permissions(std::fs::Permissions::from_mode(0o700))?;
+            }
         }
 
         let mut token_owned = token.to_string();
         let mut data = AuthData {
             token: Some(token_owned.clone()),
-            registry: Some(registry.to_string()),
+            registry: Some(registry_origin),
         };
 
         let mut content = serde_json::to_string_pretty(&data)
             .map_err(|e| PackageError::General(format!("Failed to serialize auth data: {}", e)))?;
 
-        std::fs::write(&self.auth_file, &content)?;
-
-        // Set restrictive permissions on Unix (owner read/write only).
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let perms = std::fs::Permissions::from_mode(0o600);
-            std::fs::set_permissions(&self.auth_file, perms)?;
-        }
+        let write_result = self.write_auth_file(content.as_bytes());
 
         // Zeroize secrets to prevent them lingering in memory.
         content.zeroize();
@@ -75,21 +162,163 @@ impl AuthManager {
             r.zeroize();
         }
 
-        Ok(())
+        write_result
     }
 
     /// Remove the stored authentication token.
     pub fn clear_token(&self) -> Result<(), PackageError> {
-        if self.auth_file.exists() {
-            std::fs::remove_file(&self.auth_file)?;
+        match std::fs::symlink_metadata(&self.auth_file) {
+            Ok(_) => std::fs::remove_file(&self.auth_file)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(PackageError::Io(error)),
         }
         Ok(())
     }
 
+    /// Check whether anything exists at the credentials path without parsing
+    /// or following it. This lets logout recover malformed and symlinked auth.
+    pub fn credentials_file_exists(&self) -> Result<bool, PackageError> {
+        match std::fs::symlink_metadata(&self.auth_file) {
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(PackageError::Io(error)),
+        }
+    }
+
     /// Check if we have a stored token.
     pub fn is_authenticated(&self) -> bool {
-        self.get_token().ok().flatten().is_some()
+        self.get_credentials().ok().flatten().is_some()
     }
+
+    fn write_auth_file(&self, content: &[u8]) -> Result<(), PackageError> {
+        use std::io::Write;
+
+        let parent = self
+            .auth_file
+            .parent()
+            .filter(|path| !path.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let mut temp = tempfile::Builder::new()
+            .prefix(".auth-")
+            .tempfile_in(parent)?;
+
+        // NamedTempFile is private by default. Set the mode before writing as
+        // an explicit invariant so the token is never briefly world-readable.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            temp.as_file()
+                .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+
+        temp.write_all(content)?;
+        temp.as_file().sync_all()?;
+        let persisted = temp
+            .persist(&self.auth_file)
+            .map_err(|error| PackageError::Io(error.error))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            persisted.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        persisted.sync_all()?;
+        Ok(())
+    }
+}
+
+fn read_auth_file_no_follow(path: &std::path::Path) -> Result<String, PackageError> {
+    use std::io::Read;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() || metadata.len() > MAX_AUTH_FILE_BYTES {
+        return Err(PackageError::General(
+            "The credentials file is not a safe regular file.".to_string(),
+        ));
+    }
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(MAX_AUTH_FILE_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_AUTH_FILE_BYTES {
+        return Err(PackageError::General(
+            "The credentials file exceeds the 64 KiB safety limit.".to_string(),
+        ));
+    }
+    String::from_utf8(bytes)
+        .map_err(|_| PackageError::General("The credentials file is not valid UTF-8.".to_string()))
+}
+
+#[cfg(unix)]
+fn open_directory_no_follow(path: &std::path::Path) -> Result<std::fs::File, PackageError> {
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    use std::os::unix::fs::OpenOptionsExt;
+    options.custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW);
+    let directory = options.open(path)?;
+    if !directory.metadata()?.is_dir() {
+        return Err(PackageError::General(
+            "The credentials directory is not a directory.".to_string(),
+        ));
+    }
+    Ok(directory)
+}
+
+/// Parse a registry setting and reduce it to a canonical HTTPS origin.
+///
+/// Manifests traditionally contain a bare host (for example `wflhub.org`),
+/// while auth files may contain either that form or a full HTTPS URL. Paths,
+/// userinfo, queries, and fragments are rejected because credentials are
+/// scoped to an origin, not to an attacker-controlled URL string.
+pub fn normalize_registry_origin(registry: &str) -> Result<String, PackageError> {
+    let registry = registry.trim();
+    if registry.is_empty() {
+        return Err(PackageError::General(
+            "Registry address cannot be empty.".to_string(),
+        ));
+    }
+
+    let candidate = if registry.contains("://") {
+        registry.to_string()
+    } else {
+        format!("https://{}", registry)
+    };
+    let url = reqwest::Url::parse(&candidate)
+        .map_err(|_| PackageError::General("Registry address is not a valid URL.".to_string()))?;
+
+    if url.scheme() != "https" {
+        return Err(PackageError::General(
+            "Registry credentials may only be sent to an HTTPS registry.".to_string(),
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(PackageError::General(
+            "Registry address must include a host.".to_string(),
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(PackageError::General(
+            "Registry address must not contain a username or password.".to_string(),
+        ));
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(PackageError::General(
+            "Registry address must not contain a query or fragment.".to_string(),
+        ));
+    }
+    if url.path() != "/" && !url.path().is_empty() {
+        return Err(PackageError::General(
+            "Registry address must not contain a path.".to_string(),
+        ));
+    }
+
+    Ok(url.origin().ascii_serialization())
 }
 
 /// Get the user's home directory.
@@ -124,6 +353,10 @@ mod tests {
         auth.store_token("test-token-123", "wflhub.org").unwrap();
         assert!(auth.is_authenticated());
         assert_eq!(auth.get_token().unwrap().unwrap(), "test-token-123");
+        assert_eq!(
+            auth.get_credentials().unwrap().unwrap().registry_origin(),
+            "https://wflhub.org"
+        );
     }
 
     #[test]
@@ -136,5 +369,106 @@ mod tests {
 
         auth.clear_token().unwrap();
         assert!(!auth.is_authenticated());
+    }
+
+    #[test]
+    fn test_clear_token_removes_malformed_credentials() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("auth.json");
+        let auth = AuthManager::with_path(path.clone());
+
+        for malformed in [
+            "not json",
+            r#"{"token":"secret"}"#,
+            r#"{"token":"secret","registry":"http://registry.example"}"#,
+        ] {
+            std::fs::write(&path, malformed).unwrap();
+            assert!(auth.get_credentials().is_err());
+            assert!(auth.credentials_file_exists().unwrap());
+            auth.clear_token().unwrap();
+            assert!(!auth.credentials_file_exists().unwrap());
+            auth.store_token("replacement", "registry.example").unwrap();
+            assert!(auth.is_authenticated());
+            auth.clear_token().unwrap();
+        }
+    }
+
+    #[test]
+    fn test_normalize_registry_origin() {
+        assert_eq!(
+            normalize_registry_origin("wflhub.org").unwrap(),
+            "https://wflhub.org"
+        );
+        assert_eq!(
+            normalize_registry_origin("HTTPS://WFLHUB.ORG:443/").unwrap(),
+            "https://wflhub.org"
+        );
+        assert!(normalize_registry_origin("http://wflhub.org").is_err());
+        assert!(normalize_registry_origin("wflhub.org@evil.example").is_err());
+        assert!(normalize_registry_origin("wflhub.org/api").is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_store_token_replaces_symlink_without_touching_target() {
+        use std::os::unix::fs::symlink;
+
+        let temp = TempDir::new().unwrap();
+        let target = temp.path().join("target.txt");
+        std::fs::write(&target, "keep me").unwrap();
+        let auth_path = temp.path().join("auth.json");
+        symlink(&target, &auth_path).unwrap();
+        let auth = AuthManager::with_path(auth_path.clone());
+
+        auth.store_token("secret", "wflhub.org").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "keep me");
+        assert!(
+            !std::fs::symlink_metadata(&auth_path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(auth.get_token().unwrap().as_deref(), Some("secret"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_store_token_creates_private_file_and_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let auth_dir = temp.path().join("credentials");
+        let auth_path = auth_dir.join("auth.json");
+        let auth = AuthManager::with_path(auth_path.clone());
+
+        auth.store_token("secret", "wflhub.org").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&auth_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert_eq!(
+            std::fs::metadata(&auth_dir).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_custom_auth_path_does_not_chmod_existing_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let parent = temp.path().join("custom");
+        std::fs::create_dir(&parent).unwrap();
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o750)).unwrap();
+        let auth = AuthManager::with_path(parent.join("auth.json"));
+
+        auth.store_token("secret", "wflhub.org").unwrap();
+        assert_eq!(
+            std::fs::metadata(&parent).unwrap().permissions().mode() & 0o777,
+            0o750
+        );
     }
 }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -172,6 +172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,6 +390,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +574,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
@@ -735,6 +770,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "h2"
@@ -1167,6 +1215,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ffa3a0547a138e59ddd6fa3b7c672ed47e6ad6a3cd177984ff1116aa5ba742"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1881,12 +1945,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -2632,6 +2698,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3225,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3327,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "flate2",
+ "ignore",
+ "libc",
  "reqwest",
  "rpassword",
  "rustyline",
@@ -3242,6 +3336,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tar",
+ "tempfile",
  "tokio",
  "zeroize",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn print_help() {
     println!("    share                              Publish to the registry");
     println!("    search <query>                     Search for packages");
     println!("    info <package>                     Show package details");
-    println!("    login / logout                     Registry authentication");
+    println!("    login [registry] / logout          Registry authentication");
     println!("    check security                     Audit for vulnerabilities");
     println!("    check compatibility                Check API compatibility");
     println!();
@@ -304,7 +304,12 @@ async fn run() -> io::Result<()> {
                     }
                 }
             }
-            "login" => match wflpkg::commands::login::login(DEFAULT_REGISTRY) {
+            "login" => match wflpkg::commands::login::login(
+                sub_args
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or(DEFAULT_REGISTRY),
+            ) {
                 Ok(()) => return Ok(()),
                 Err(e) => {
                     eprintln!("{}", e);


### PR DESCRIPTION
## Summary

- bind saved registry credentials to one canonical HTTPS origin and refuse project-directed cross-origin token use
- add `wfl login [registry]`, recover malformed auth via logout, and write credentials atomically with private permissions
- create upload archives in private external temporary files with create-new semantics
- honor root and nested Git-compatible `.gitignore` rules while failing closed on unsupported patterns, symlinks, special files, unsafe manifests/entry points, and traversal budgets
- derive a portable, prefix-free `wflhash:v2:` checksum from the completed immutable archive and make installed-package verification hash every regular file
- stream compressed uploads under a 100 MiB ceiling and cap registry response bodies at 1 MiB

## Security impact

A project-controlled registry setting could send the user's saved bearer token to another host. Publishing also created its archive inside the untrusted project, followed an existing output path, ignored `.gitignore` (which could upload `.env`, logs, and debug reports), and checksummed a separately reread live tree with an ambiguous transcript. These paths now bind credentials to the authenticated origin, package an immutable private snapshot without following symlinks, apply Git-compatible exclusions and resource ceilings, and verify a versioned checksum over the exact archive contents.

## Validation

- `cargo test -p wflpkg`: 238 tests passed
- `cargo fmt --all -- --check` passed
- `git diff --check` passed
- locked fuzz targets compile in CI passed
- all GitHub CI matrix jobs passed on the final head
- substantive Clippy checks passed for all `wflpkg` targets; the remaining `field_reassign_with_default` warning is pre-existing in `version_and_lockfile_tests.rs`

Complementary package removal/cache/extraction confinement is isolated in #630. Part of the Rust-source production-readiness work tracked in #610.