### PR TITLE
Suppress dead_code warnings for Unix-only auth fields

### DIFF
--- a/crates/wflpkg/src/registry/auth.rs
+++ b/crates/wflpkg/src/registry/auth.rs
@@ -8,6 +8,9 @@ const MAX_TOKEN_BYTES: usize = 16 * 1024;
 /// Manages authentication tokens for registry access.
 pub struct AuthManager {
     auth_file: PathBuf,
+    // Only consulted when tightening directory permissions, which is a
+    // Unix-only concern. On non-Unix targets the field is intentionally unread.
+    #[cfg_attr(not(unix), allow(dead_code))]
     manage_parent_permissions: bool,
 }
 
@@ -117,21 +120,23 @@ impl AuthManager {
                 .parent()
                 .filter(|path| !path.as_os_str().is_empty())
                 .unwrap_or_else(|| std::path::Path::new("."));
-            let mut created_parent = false;
-            match std::fs::symlink_metadata(parent) {
+            // Whether we just created the directory. Only read on Unix, where a
+            // freshly created credentials directory is locked down to 0o700.
+            #[cfg_attr(not(unix), allow(unused_variables))]
+            let created_parent = match std::fs::symlink_metadata(parent) {
                 Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
                     return Err(PackageError::General(
                         "The credentials directory must be a real directory, not a symlink."
                             .to_string(),
                     ));
                 }
-                Ok(_) => {}
+                Ok(_) => false,
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
                     std::fs::create_dir_all(parent)?;
-                    created_parent = true;
+                    true
                 }
                 Err(error) => return Err(PackageError::Io(error)),
-            }
+            };
 
             #[cfg(unix)]
             if created_parent || self.manage_parent_permissions {


### PR DESCRIPTION
## Summary
Adds `#[cfg_attr]` attributes to suppress compiler warnings for fields and variables in `AuthManager` that are only used on Unix platforms, improving code clarity and reducing noise in the build output.

## Changes
- Added `#[cfg_attr(not(unix), allow(dead_code))]` to the `manage_parent_permissions` field, which is only consulted when tightening directory permissions (a Unix-only concern)
- Refactored the `created_parent` variable from a mutable binding to an immutable `let` binding that captures the result of a `match` expression
- Added `#[cfg_attr(not(unix), allow(unused_variables))]` to the `created_parent` binding, which is only read on Unix where freshly created credentials directories are locked down to `0o700`
- Updated comments to clarify the platform-specific usage of these fields

## Implementation Details
The changes maintain the same runtime behavior while making the platform-specific nature of the code more explicit. The `created_parent` variable is now assigned directly from the match expression rather than being mutated in separate branches, which is more idiomatic Rust and aligns with the immutable-by-default philosophy.

https://claude.ai/code/session_01RypGs2Z4voxkKN7Y7FgZtR
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform handling when securely storing authentication credentials.
  * Preserved validation that credential directories are real directories and not symlinks.
  * Continued applying appropriate directory permissions on Unix systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->