### PR TITLE
Fix flaky deadline tests on coarse-resolution timers

### DIFF
--- a/src/exec/budget.rs
+++ b/src/exec/budget.rs
@@ -1148,7 +1148,15 @@ mod tests {
         let mut limits = tiny_limits();
         limits.max_duration = Some(Duration::from_secs(0));
         let budget = ExecutionBudget::new(limits);
-        // A zero-second deadline is already elapsed at the first sample point.
+        // The deadline trips when `elapsed() > limit`, so a zero-second deadline
+        // is only "elapsed" once the monotonic clock has advanced at least one
+        // tick past creation. `Instant`'s resolution is coarse on some platforms
+        // (notably Windows), where the first charge can otherwise land within the
+        // same tick and read `elapsed() == 0`. Spin until the clock moves so the
+        // assertion is deterministic rather than racing the timer.
+        while budget.elapsed() == Duration::ZERO {
+            std::hint::spin_loop();
+        }
         assert_eq!(
             budget.charge_operation(true),
             Err(BudgetExceeded::Deadline { limit_secs: 0 })
@@ -1244,6 +1252,13 @@ mod tests {
         let mut limits = tiny_limits();
         limits.max_duration = Some(Duration::from_secs(0));
         let budget = Arc::new(ExecutionBudget::new(limits));
+        // See `deadline_trips_when_elapsed`: the zero-second deadline only trips
+        // once the monotonic clock has moved past creation. Wait for the first
+        // tick so the post-main-loop assertion below is deterministic on
+        // coarse-resolution timers (e.g. Windows).
+        while budget.elapsed() == Duration::ZERO {
+            std::hint::spin_loop();
+        }
         // ONE meter reused across a main-loop boundary (the VM-reuse case);
         // `reset()` runs per top-level op, so each op's first charge (index 0) is
         // a sample point.

--- a/src/exec/budget.rs
+++ b/src/exec/budget.rs
@@ -1107,6 +1107,27 @@ mod tests {
         }
     }
 
+    /// Spin until the budget's monotonic clock has advanced past creation, so a
+    /// zero-second deadline is genuinely elapsed (`elapsed() > 0`). `Instant`
+    /// resolution is coarse on some platforms (notably Windows), where the first
+    /// charge can otherwise land within the same tick and read `elapsed() == 0`.
+    /// The wait is bounded by an iteration cap — not a wall-clock timeout, which
+    /// would depend on the very clock we suspect — so a pathologically frozen
+    /// clock fails loudly instead of hanging the suite.
+    fn wait_for_clock_to_advance(budget: &ExecutionBudget) {
+        const MAX_SPINS: u64 = 100_000_000;
+        for _ in 0..MAX_SPINS {
+            if budget.elapsed() != Duration::ZERO {
+                return;
+            }
+            std::hint::spin_loop();
+        }
+        panic!(
+            "monotonic clock did not advance past budget creation within {MAX_SPINS} spins; \
+             cannot exercise the zero-second deadline"
+        );
+    }
+
     #[test]
     fn operation_ceiling_trips_after_limit() {
         let budget = ExecutionBudget::new(tiny_limits());
@@ -1149,14 +1170,10 @@ mod tests {
         limits.max_duration = Some(Duration::from_secs(0));
         let budget = ExecutionBudget::new(limits);
         // The deadline trips when `elapsed() > limit`, so a zero-second deadline
-        // is only "elapsed" once the monotonic clock has advanced at least one
-        // tick past creation. `Instant`'s resolution is coarse on some platforms
-        // (notably Windows), where the first charge can otherwise land within the
-        // same tick and read `elapsed() == 0`. Spin until the clock moves so the
-        // assertion is deterministic rather than racing the timer.
-        while budget.elapsed() == Duration::ZERO {
-            std::hint::spin_loop();
-        }
+        // is only "elapsed" once the monotonic clock has advanced past creation.
+        // Wait for that (bounded) so the assertion is deterministic rather than
+        // racing the timer resolution.
+        wait_for_clock_to_advance(&budget);
         assert_eq!(
             budget.charge_operation(true),
             Err(BudgetExceeded::Deadline { limit_secs: 0 })
@@ -1253,12 +1270,10 @@ mod tests {
         limits.max_duration = Some(Duration::from_secs(0));
         let budget = Arc::new(ExecutionBudget::new(limits));
         // See `deadline_trips_when_elapsed`: the zero-second deadline only trips
-        // once the monotonic clock has moved past creation. Wait for the first
-        // tick so the post-main-loop assertion below is deterministic on
-        // coarse-resolution timers (e.g. Windows).
-        while budget.elapsed() == Duration::ZERO {
-            std::hint::spin_loop();
-        }
+        // once the monotonic clock has moved past creation. Wait (bounded) so the
+        // post-main-loop assertion below is deterministic on coarse-resolution
+        // timers (e.g. Windows).
+        wait_for_clock_to_advance(&budget);
         // ONE meter reused across a main-loop boundary (the VM-reuse case);
         // `reset()` runs per top-level op, so each op's first charge (index 0) is
         // a sample point.

--- a/src/exec/budget.rs
+++ b/src/exec/budget.rs
@@ -1116,11 +1116,20 @@ mod tests {
     /// clock fails loudly instead of hanging the suite.
     fn wait_for_clock_to_advance(budget: &ExecutionBudget) {
         const MAX_SPINS: u64 = 100_000_000;
-        for _ in 0..MAX_SPINS {
+        for i in 0..MAX_SPINS {
             if budget.elapsed() != Duration::ZERO {
                 return;
             }
-            std::hint::spin_loop();
+            // Cheap CPU hint most iterations, but yield to the scheduler
+            // periodically so we don't monopolise a core while waiting for the
+            // next timer tick (which can be ~15ms on Windows) on a loaded CI
+            // runner. Yielding also lets the wall clock advance sooner under
+            // contention, so the wait usually exits earlier.
+            if i % 1024 == 0 {
+                std::thread::yield_now();
+            } else {
+                std::hint::spin_loop();
+            }
         }
         panic!(
             "monotonic clock did not advance past budget creation within {MAX_SPINS} spins; \


### PR DESCRIPTION
## Summary
Fix race conditions in execution-budget deadline tests on platforms with coarse timer resolution (notably Windows). The tests were non-deterministic because they assumed the monotonic clock would advance between budget creation and the first deadline check, but on some platforms the clock may not tick within that window — so `elapsed()` read `0`, `0 > 0` was false, and a zero-second deadline returned `Ok(())` instead of the expected `Err(Deadline)`.

This was the cause of the failing nightly build.

## Changes
- **`deadline_trips_when_elapsed` test**: waits for the monotonic clock to advance past budget creation before asserting the deadline has been exceeded, ensuring `elapsed() > 0` before the assertion.

- **`pattern_meter_deadline_exemption_is_read_live` test**: applies the same wait before entering the main-loop boundary, so the post-loop deadline assertion is deterministic on coarse-resolution timers.

- **Shared `wait_for_clock_to_advance` helper**: both tests share one bounded wait. It is capped by an iteration count (not a wall-clock timeout, which would depend on the very clock under suspicion), so a pathologically frozen clock fails loudly with a clear panic rather than hanging the suite.

## Implementation Details
The helper spins with `std::hint::spin_loop()` while `budget.elapsed() == Duration::ZERO`, up to a fixed iteration cap. This approach:
- Is platform-agnostic and works on all timer resolutions.
- Avoids artificial delays (e.g. `sleep()`) that would slow the tests.
- Respects the tests' intent: verify deadline behavior once the clock has actually moved.
- Leaves production deadline semantics (`elapsed() > limit`) untouched — this is a test-only change, so existing WFL program behavior is unaffected.

## Verification
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --lib exec::budget` (18/18) all pass locally. The original failure is a coarse-Windows-timer race not reproducible on Linux; the fix removes the timing dependency entirely.

https://claude.ai/code/session_01S8qrho14PuMRudxgh1hVUm


---


<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/634" rel="nofollow noreferrer noopener" target="_blank">
  ``&lt;img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review"&gt;``
</a>


## Summary by CodeRabbit

* **Tests**
  * Improved timing test reliability across platforms with coarse timer resolution.
  * Ensured deadline enforcement checks produce consistent results.
