### PR TITLE
test(exec): deflake the short-input lexer deadline test (companion to #634)

### DIFF
--- a/tests/execution_budget_test.rs
+++ b/tests/execution_budget_test.rs
@@ -814,6 +814,29 @@ fn checked_lexer_reports_cancellation_on_a_short_input() {
     );
 }
 
+/// Spin until `budget`'s monotonic clock has advanced past creation, so a
+/// zero-second deadline is genuinely elapsed (`elapsed() > 0`).
+///
+/// `Instant` resolution is coarse on some platforms (notably the virtualized
+/// Windows CI runner), where the deadline read can land in the same tick as
+/// budget creation and see `elapsed() == 0`. Bounded by an iteration cap rather
+/// than a wall-clock timeout — which would depend on the very clock under
+/// suspicion — so a frozen clock fails loudly instead of hanging the suite.
+/// Mirrors the helper of the same shape in `src/exec/budget.rs`.
+fn wait_for_clock_to_advance(budget: &wfl::exec::budget::ExecutionBudget) {
+    const MAX_SPINS: u64 = 100_000_000;
+    for _ in 0..MAX_SPINS {
+        if budget.elapsed() != std::time::Duration::ZERO {
+            return;
+        }
+        std::hint::spin_loop();
+    }
+    panic!(
+        "monotonic clock did not advance past budget creation within {MAX_SPINS} spins; \
+         cannot exercise the zero-second deadline"
+    );
+}
+
 #[test]
 fn checked_lexer_reports_expired_deadline_on_a_short_input() {
     // Companion to the cancellation case: an already-expired deadline must abort
@@ -825,6 +848,11 @@ fn checked_lexer_reports_expired_deadline_on_a_short_input() {
         ..Default::default()
     };
     let budget = std::sync::Arc::new(ExecutionBudget::new(limits));
+    // The input is too short to reach a strided checkpoint, so the entry
+    // checkpoint is the only deadline read — wait (bounded) for the clock to
+    // advance so a coarse CI timer cannot leave the zero-second deadline
+    // not-yet-strictly-elapsed.
+    wait_for_clock_to_advance(&budget);
     let _guard = ExecutionBudget::enter(budget);
     let result = wfl::lexer::lex_wfl_with_positions_checked("display 1\n");
     assert!(


### PR DESCRIPTION
> **Scope note:** this PR originally also fixed the two `src/exec/budget.rs` tests, but **#634** (opened ~9 minutes earlier) already does that, and does it slightly better. I've dropped the overlapping commits — this branch is now a **non-conflicting companion** to #634 covering the one test it doesn't reach. Merge #634 first; this is additive.

## Context — the nightly has been red two nights

| Run | Date | Failing step | Cause |
|---|---|---|---|
| [29558591835](https://github.com/WebFirstLanguage/wfl/actions/runs/29558591835) | 07-17 | `Run clippy` | dead-code lints in `wflpkg` registry auth — fixed by #633 |
| [29632865488](https://github.com/WebFirstLanguage/wfl/actions/runs/29632865488) | 07-18 | `Run tests` | `deadline_trips_when_elapsed` — fixed by **#634** |

`Create or Update Nightly Release` was skipped on both, so no nightly artifacts were published for `main@884448e`.

## What this PR adds

The 07-18 failure was a latent flake, and **it has a third sibling that #634 doesn't touch**: `checked_lexer_reports_expired_deadline_on_a_short_input` in `tests/execution_budget_test.rs`.

That test lexes `"display 1\n"` — deliberately too short to reach a strided checkpoint — so the lexer's *entry* checkpoint is the only deadline read on the whole path:

```rust
budget.check_deadline()?;   // src/lexer/mod.rs
```

which is the same strict comparison as the unit tests:

```rust
if let Some(limit) = self.limits.max_duration
    && self.started.elapsed() > limit
```

With `limit == 0` that only trips once the monotonic clock has *strictly* advanced. `Instant::elapsed()` returns exactly `Duration::ZERO` when both reads land in the same tick — measured on a Linux dev box, back-to-back reads return `ZERO` **102,732 / 200,000** times (min non-zero delta 41ns). The virtualized Windows runner's counter is coarser still. So this test is the same coin-flip that `deadline_trips_when_elapsed` lost on 07-18; it simply hasn't come up tails yet.

The fix mirrors #634's helper exactly — a bounded, iteration-capped spin on `budget.elapsed()` that panics loudly rather than hanging if the clock is genuinely frozen.

### Why the `>` comparison was NOT changed

Worth recording, since `>` → `>=` is the tempting one-character fix: `max_duration` is built straight from user config —

```rust
max_duration: Some(Duration::from_secs(config.timeout_seconds)),
```

— so anyone with `timeout_seconds = 0` in `.wflcfg` would go from "effectively no timeout" to "every program aborts instantly". That's a backward-compatibility break on a live config value. Runtime semantics are deliberately untouched in both PRs; only the tests change.

## Verification

Linux aarch64, Rust 1.97.1:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean, exit 0
- `cargo test --test execution_budget_test` — **39 passed, 0 failed**
- `cargo test --lib` — **587 passed, 0 failed** (the suite that broke the nightly)

Honest caveat: the original failure **does not reproduce on Linux** — the unpatched test passed 400/400 runs here, because this box's 41ns clock resolution always advances across the work between the two reads. The diagnosis rests on path analysis (`Ok(())` is reachable only when `elapsed() == 0`, since `index` is 0, `max_operations` is 10, and the budget isn't cancelled) plus the `ZERO`-elapsed measurement above — not on a local red-to-green transition.

---

*Automated triage PR from the WFL repo warden — please review and merge; the warden does not merge its own PRs.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timing reliability for execution deadline coverage.
  * Ensured short-input lexing tests consistently verify immediate deadline handling across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->