### PR TITLE
Support multiple space-separated values in `display` statements

### DIFF
--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -10,7 +10,7 @@ A user wrote what reads as perfectly natural WFL:
 
 ```wfl
 store user age as 28
-display user age "user age is" user age
+display "user age is " user age
 change user age to 9
 
 check if user age is greater than 18:
@@ -205,3 +205,60 @@ return value, an action with arguments and one with a side effect, a
 container instance/property/method, and — the one that matters most — the
 mutating-list case proving space-separated `display` and `with` now produce
 byte-identical output.
+
+## New-head follow-up: centralization and more same-line boundaries
+
+A second maintainer review of `fef9fb7` asked for `is_value_start` to stop
+being an independently-maintained token list and instead be defined in terms
+of the *same* classification `parse_primary_expression` uses, plus asked for
+the `count`/`read` same-line fix from the deep-review pass to be regression
+tested as whole programs rather than trusted by inspection.
+
+- **Centralization.** `src/parser/helpers.rs` now has
+  `Parser::can_start_primary_expression`, a single predicate mirroring every
+  arm of `parse_primary_expression` (explicit keyword arms plus the
+  contextual-keyword catch-all via `Token::is_contextual_keyword`).
+  `is_value_start` is now `can_start_primary_expression` minus an explicit,
+  documented exclusion list, instead of its own hand-maintained list — so a
+  new `parse_primary_expression` arm is included by default rather than
+  requiring a second edit to opt in. A coupling test in `parser/tests.rs`
+  (`can_start_primary_expression_matches_parse_primary_expression`) feeds a
+  representative token through both functions and asserts they agree, so the
+  two can't silently drift apart again. This also added `back` and `error` to
+  `is_value_start` (previously left out only because they weren't flagged by
+  review, not because they were unsafe — see finding 2 above).
+- **New same-line statement boundaries.** Actually centralizing the
+  classification (rather than hand-curating a short list) surfaced six more
+  tokens with the exact same shape as the `count`/`read` finding: `create`,
+  `change`, `push`, `parent`, `skip`, and `give` are all contextual keywords
+  (bare variables in expression position) that are *also* dedicated arms of
+  `parse_statement`'s top-level dispatch, with no expression-position
+  equivalent for their statement form. Unlike `count`/`read`, none of the six
+  has one unambiguous continuation token to guard on (`create` alone forks
+  into containers, lists, patterns, directories, files, maps, dates, times,
+  and plain variable declarations), so — same reasoning as the pre-existing
+  `loop`/`exit`/`repeat`/`try`/`when` exclusions — they're excluded from
+  `is_value_start` outright rather than guarded. `skip` was the sharpest case
+  to catch: as a bare statement it's `continue` (a control-flow effect, one
+  token), with *no syntactic difference at all* from folding it as a value
+  (also one token) — an unguarded inclusion would have silently turned a
+  loop's `continue` into inert display output instead of a parse error.
+  `parse_display_statement`'s fold loop also gained a real lookahead guard,
+  `Parser::is_display_fold_statement_boundary`, so `display "x" count from 1
+  to 3:` and `display "x" read output from process p` keep parsing as two
+  statements (the count-loop/read-output form) instead of the display
+  swallowing just the keyword and stranding the rest. Each of the eight
+  excluded tokens (the original five plus these six) now has an explicit
+  `*_after_display_stays_a_separate_statement` whole-program regression test
+  in `parser/tests.rs`.
+- **Test determinism.** The `file exists at "does-not-exist-for-sure.txt"`
+  stdout case depended on the test runner's working directory not happening
+  to contain a file by that name. It now builds a unique, absolute path under
+  the OS temp directory via `test_helpers::get_unique_test_file_path`, the
+  same helper the rest of the integration suite already uses to avoid
+  cross-test and cross-machine collisions.
+- **Tooling note.** `cargo build`/`test`/`clippy`/`fmt` were blocked by this
+  session's tool-approval policy with no human available to grant it, so this
+  pass was verified by careful manual trace against the current source rather
+  than a local build — flagged as a blocker in the PR thread, consistent with
+  the deep-review pass's first attempt.

--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -1,0 +1,105 @@
+# Dev Diary — Multi-value `display`
+
+**Date:** 2026-07-18
+**Area:** Parser (`display` statement)
+**Type:** Bug fix / small language ergonomics improvement
+
+## The report
+
+A user wrote what reads as perfectly natural WFL:
+
+```wfl
+store user age as 28
+display user age "user age is" user age
+change user age to 9
+
+check if user age is greater than 18:
+    display "Access granted"
+otherwise:
+    display "Must be 18 or older"
+end check
+```
+
+…and found that `display` only ever printed the **first** value:
+
+- `display user age` → prints the age ✅
+- `display "user age is" user age` → prints only `user age is` ❌
+- `display user age "user age is"` → prints only the age ❌
+
+## Root cause
+
+`parse_display_statement` (in `src/parser/stmt/io.rs`) consumed exactly **one**
+expression after `display` and returned. Because WFL statements are terminated
+by `Eol`, any additional value tokens on the same line were left on the cursor
+and re-parsed by the top-level loop as their own `ExpressionStatement` — which
+evaluates the value and throws it away. The result was silent, partial output
+with no error: the worst kind of surprise for a beginner-first language.
+
+Note that two *adjacent bare variables* can't hit this (the lexer merges
+consecutive identifier words into a single multi-word identifier, so
+`first name` is one variable). The bug shows up whenever values straddle a type
+boundary — string↔variable↔number — which is exactly the "label plus value"
+shape people reach for first.
+
+## The fix
+
+Per the reporter's own rule — *"anything in quotes is text, anything else is a
+variable or an action, and I should be able to have more than one"* — `display`
+now accepts multiple space-separated values and folds them into a single
+left-associative `Concatenation`:
+
+```
+display a b c   ≡   display a with b with c
+```
+
+Implementation:
+
+- Added `Parser::is_value_start` (`src/parser/helpers.rs`) — true for the tokens
+  that begin a fresh value (string/int/float/bool/nothing literals, identifiers,
+  `(`).
+- After parsing the first value, `parse_display_statement` loops while the next
+  token is a value-start, parsing each additional value with the full
+  expression parser and folding it into a `Concatenation`.
+
+### Why this is backward-compatible
+
+- **Direct index access is untouched.** `display numbers 0` is absorbed by the
+  first `parse_expression` call (the `0` is the index), so the trailing token
+  never reaches the fold. Verified: `display "first score: " scores 0` →
+  `first score: 100`.
+- **Line breaks still terminate.** `Eol` is not a value-start, so
+  `display numbers` followed by `0` on the next line keeps the `0` as its own
+  statement.
+- **Single values are unchanged** — no `Concatenation` wrapper is created.
+- The only programs whose behavior changes are ones that previously
+  *silently dropped* trailing values — i.e. ones that were already broken.
+
+### Spacing
+
+Values are joined directly, exactly like `with` — no separator is inserted.
+Spaces come from the quotes: `display "I am " age " years old"` →
+`I am 25 years old`. This keeps a single concatenation semantics in the
+language (No-Unlearning: the space-separated form and the `with` form are the
+same form), rather than inventing a second, space-adding rule that only
+`display` would follow.
+
+### Scope left alone (deliberately)
+
+A leading unary minus (`display "x" -5`) and bracket list literals still aren't
+value-start triggers, so those rare shapes are unchanged. They were never part
+of the report, and treating operator/bracket tokens as new values risks
+colliding with arithmetic and index syntax. `with` still covers them.
+
+## Tests
+
+- Parser unit tests (`src/parser/tests.rs`): string→var, var→string, three-value
+  left-associative fold, index-access regression, single-value regression, and a
+  "doesn't leak into the next statement" test (the following `change` still
+  parses).
+- E2E: `TestPrograms/display_multiple_values.wfl` (the original report, the
+  `with` equivalent, mixed values, an expression, index access, and the
+  `check`/`otherwise` block).
+- Docs: `TestPrograms/docs_examples/basic_syntax/display_multiple_01.wfl`
+  (manifest-tracked, 5-layer validated) backing the new
+  *Display Several Values at Once* section in
+  `Docs/02-getting-started/hello-world.md`.

--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -55,8 +55,9 @@ display a b c   ≡   display a with b with c
 Implementation:
 
 - Added `Parser::is_value_start` (`src/parser/helpers.rs`) — true for the tokens
-  that begin a fresh value (string/int/float/bool/nothing literals, identifiers,
-  `(`).
+  that begin a fresh value: string/int/float/bool/nothing literals, identifiers,
+  `(`, and the keyword-led value expressions `call`, `count`, and `current`
+  (see the review follow-up below).
 - After parsing the first value, `parse_display_statement` loops while the next
   token is a value-start, parsing each additional value with the full
   expression parser and folding it into a `Concatenation`.
@@ -83,22 +84,45 @@ language (No-Unlearning: the space-separated form and the `with` form are the
 same form), rather than inventing a second, space-adding rule that only
 `display` would follow.
 
-### Scope left alone (deliberately)
+### Review follow-up: keyword-led values
 
-A leading unary minus (`display "x" -5`) and bracket list literals still aren't
-value-start triggers, so those rare shapes are unchanged. They were never part
-of the report, and treating operator/bracket tokens as new values risks
-colliding with arithmetic and index syntax. `with` still covers them.
+Automated review (Codex/Copilot) flagged that the first cut only folded
+literals, identifiers and `(`, so a value that *starts* with a keyword was
+still dropped — or worse. Two concrete cases:
+
+- `display "number: " call get_number` printed only `number: ` and evaluated
+  the call separately.
+- `display "count is " count` inside a count loop **failed to parse**: `count`
+  reached `parse_statement` as leftover and was treated as the start of a new
+  count loop (`Expected 'from' after 'count'`). That's a hard error on natural,
+  documented code (the count-loop variable), strictly worse than the original
+  silent drop.
+
+Fix: `is_value_start` now also accepts `call`, `count`, and `current` — the
+keyword-led primary expressions that are *not* also binary operators. Keywords
+the binary parser already consumes after a value (`with`, `find`, `replace`,
+`split`, `matches`) never reach the fold, and a leading `-` is parsed as
+subtraction against the previous value (so `display "x" -5` was never a fold
+case). `current` requires its full form (`current time in milliseconds` /
+`formatted as ...`) exactly as it does as a first value — an incomplete
+`current time` errors identically whether folded or not. The docs were also
+tightened to describe values honestly (a variable, number, action call, or
+arithmetic expression) rather than promising arbitrary expression forms.
+
+Also addressed in the same pass: `parse_display_statement` now `expect`s the
+`display` token (it is only dispatched on `display`) instead of defaulting the
+statement position to a misleading `(0, 0)`.
 
 ## Tests
 
 - Parser unit tests (`src/parser/tests.rs`): string→var, var→string, three-value
-  left-associative fold, index-access regression, single-value regression, and a
+  left-associative fold, index-access regression, single-value regression, a
   "doesn't leak into the next statement" test (the following `change` still
-  parses).
+  parses), and the review-driven keyword-value folds (`count` variable and a
+  `call` action).
 - E2E: `TestPrograms/display_multiple_values.wfl` (the original report, the
-  `with` equivalent, mixed values, an expression, index access, and the
-  `check`/`otherwise` block).
+  `with` equivalent, mixed values, an expression, index access, a folded `call`,
+  the `count` loop variable, and the `check`/`otherwise` block).
 - Docs: `TestPrograms/docs_examples/basic_syntax/display_multiple_01.wfl`
   (manifest-tracked, 5-layer validated) backing the new
   *Display Several Values at Once* section in

--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -117,7 +117,7 @@ statement position to a misleading `(0, 0)`.
 ## Tests
 
 - Parser unit tests (`src/parser/tests.rs`): string→var, var→string, three-value
-  left-associative fold, index-access regression, single-value regression, a
+  right-associative fold, index-access regression, single-value regression, a
   "doesn't leak into the next statement" test (the following `change` still
   parses), and the review-driven keyword-value folds (`count` variable and a
   `call` action).

--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -262,3 +262,70 @@ tested as whole programs rather than trusted by inspection.
   pass was verified by careful manual trace against the current source rather
   than a local build — flagged as a blocker in the PR thread, consistent with
   the deep-review pass's first attempt.
+
+## Third-head follow-up: fixing CI formatting, a Windows path bug, and real centralization
+
+A third maintainer review of `e95b0a2` found CI red on `cargo fmt --all --
+--check` (two call sites over rustfmt's 100-column width), a Windows-specific
+lexer bug in the new stdout test, and — the substantive finding — that
+`can_start_primary_expression` was *still* an independently hand-maintained
+`matches!` list, no different in kind from the token list it replaced; only
+the coupling *test* had changed, not the coupling itself.
+
+- **Formatting.** Reformatted the `PushStatement` `matches!` assertion in
+  `src/parser/tests.rs` and the `missing_path` builder in
+  `tests/display_multiple_values_stdout_test.rs` to match rustfmt's actual
+  output (confirmed against the CI diff for run `29660025888`, since `cargo
+  fmt` itself was not runnable locally — see the tooling note above, still
+  unresolved this pass).
+- **Windows-unsafe path interpolation.** `env::temp_dir()` on Windows returns
+  a `\`-separated path (e.g. `C:\Users\...\Temp\...`), and WFL string literals
+  only recognize `\n`, `\t`, `\r`, `\\`, `\0`, and `\"` as escapes (see
+  `parse_string` in `src/lexer/token.rs`) — anything else after a backslash is
+  a lex error. The `keyword_led_values_fold_with_exact_output` stdout test
+  embedded `missing_path` directly into a WFL string literal, so on Windows a
+  component like `\Local` or `\Temp` would lex as an invalid escape and fail
+  the whole test. Fixed by escaping each `\` as `\\` before interpolating, so
+  the embedded literal round-trips to the exact same path on every OS.
+- **Actual centralization.** The previous pass's `can_start_primary_expression`
+  was compared against `parse_primary_expression` only by a *sample-based*
+  unit test — a real improvement in coverage, but structurally the same kind
+  of list `is_value_start` always was: a new `parse_primary_expression` arm
+  for a token outside the sample would still silently pass every test. Fixing
+  this without hand-enumerating the ~200-variant `Token` enum meant moving the
+  enforcement out of a test and into the parser itself:
+  `parse_primary_expression` (`src/parser/expr/primary.rs`) is now a thin
+  wrapper around its real dispatch, renamed
+  `parse_primary_expression_dispatch`. The wrapper captures the leading token
+  before dispatching, then compares `can_start_primary_expression`'s
+  prediction against what the dispatch actually did — via a pair of
+  `debug_assert!`s, compiled out in release builds like the rest of this
+  crate's runtime invariants. This runs on *every* primary-expression parse,
+  not a curated sample: every parser test, every `TestPrograms/*.wfl` run,
+  every program compiled in a debug build. A new dispatch arm added without
+  updating the predicate (or the reverse) now panics the first time anything
+  exercises that token, rather than only when someone remembers to extend a
+  hand-picked list.
+
+  The one subtlety worth recording: naively comparing the *error message text*
+  between the two functions is unsound, because an arm that recurses (e.g.
+  `file size of <expr>`) can propagate a *nested* failure's generic
+  "Unexpected token in expression" text up through `?` even though the
+  *leading* token (`file`) genuinely has a dedicated arm. The fix compares
+  message text *and* source position: the generic fallback error is always
+  raised at the exact position of whichever token triggered it, and every arm
+  consumes its own leading token via `bump_sync()` before recursing into
+  anything else — so a nested failure's position is always strictly later
+  than the leading token's, never coincidentally equal. Requiring both to
+  match distinguishes "this token itself has no arm" from "this token's arm
+  recursed into something else that failed." The existing sample-based
+  coupling test in `parser/tests.rs` is kept as explicit, documented coverage
+  of each keyword-led arm, but it is no longer the only thing standing between
+  the two staying in sync.
+- **Tooling note (unresolved).** `cargo`, `rustc`, and `git` mutating commands
+  still require approval with no human available to grant it in this session.
+  This pass, like the two before it, was verified by careful manual trace
+  against the current source — including hand-tracing every
+  `parse_primary_expression` arm's error paths against the new `debug_assert!`
+  logic above to rule out false positives — rather than a local build. CI is
+  the first real compiler/test run these changes see.

--- a/Dev diary/2026-07-18-display-multiple-values.md
+++ b/Dev diary/2026-07-18-display-multiple-values.md
@@ -46,7 +46,8 @@ shape people reach for first.
 Per the reporter's own rule — *"anything in quotes is text, anything else is a
 variable or an action, and I should be able to have more than one"* — `display`
 now accepts multiple space-separated values and folds them into a single
-left-associative `Concatenation`:
+`Concatenation`, right-associative exactly like `with` (see "Deep-review fix
+pass" below for why the association direction matters, not just the shape):
 
 ```
 display a b c   ≡   display a with b with c
@@ -127,3 +128,80 @@ statement position to a misleading `(0, 0)`.
   (manifest-tracked, 5-layer validated) backing the new
   *Display Several Values at Once* section in
   `Docs/02-getting-started/hello-world.md`.
+
+## Deep-review fix pass
+
+A maintainer deep-review (and an independent `@claude` validation pass) of the
+first cut found five issues, all fixed in this pass:
+
+**1. Association direction was observably wrong.** The first cut folded
+left-associatively (`(a with b) with c`), while explicit `with` parses
+right-associatively (`a with (b with c)`, see the `KeywordWith` continuation
+in `expr/binary.rs`). `Expression::Concatenation` evaluates left, then right,
+then stringifies both — so association direction controls *when* a value gets
+stringified relative to a later value's side effects. With two identical
+lists each holding `[before, after]`:
+
+```wfl
+display left_items "" pop of left_items          // [before, after]after  (left-fold, WRONG)
+display right_items with "" with pop of right_items  // [before]after     (with, right-fold)
+```
+
+The left fold stringified `left_items` (as `"" `'s left operand) *before* the
+`pop` on the right ran, showing the pre-mutation list; `with` stringifies it
+*after*, per its evaluation order. `parse_display_statement` now parses every
+value into a `Vec<Expression>` first, then folds from the right, producing the
+identical tree — not just a similar one — to the equivalent `with` chain. See
+`test_display_four_values_right_associative_nesting` (parser) and the
+mutation-order case in `tests/display_multiple_values_stdout_test.rs`
+(interpreter, exact stdout).
+
+**2. `is_value_start` was still missing safe keyword starters.** Added `not`,
+`pattern`, `output`, `file`, `directory`, `process`, `header`, `list`, and
+`read` — each is a keyword-led `parse_primary_expression` arm that produces a
+standalone value and is never consumed as a continuation elsewhere, so it's
+safe to fold. Deliberately *not* added: `loop`, `exit`, `repeat`, `try`,
+`when` (these double as statement/block openers, so silently folding them
+into a `display` would swallow what's far more likely to be a missing line
+break than an intended value) and `Minus`/`LeftBracket` (both are always
+already consumed earlier in the parse — see the `is_value_start` doc comment
+in `helpers.rs` for the full reasoning). `back` and `error` are unambiguous by
+the same test as `not`, but weren't flagged by review, so they were left as a
+possible follow-up rather than added speculatively.
+
+**3. `find`/`replace`/`split` remain excluded — this is a pre-existing bug,
+not a `display` bug, and out of scope here.** When one of these keywords
+follows an already-parsed value at the *first* value's `parse_expression`
+call (before `display`'s fold loop is ever consulted), the general
+binary-expression parser's continuation arm for that keyword
+(`expr/binary.rs`, the `Token::KeywordFind`/`KeywordReplace`/`KeywordSplit`
+arms under `parse_binary_expression`) discards the preceding value in some
+paths — e.g. `display "parts: " split "a,b" by ","` prints only `[a, b]`, not
+`parts: [a, b]`, because `split`'s continuation arm never incorporates `left`.
+Adding these tokens to `is_value_start` would not fix this, since the bug
+happens one call frame earlier. Fixing the general grammar is a larger,
+independently-scoped change (it affects every expression, not just
+`display`) that deserves its own TDD pass and regression suite rather than
+being folded into this PR under time pressure — flagged in the PR thread as a
+follow-up question for the maintainer rather than silently left alone.
+
+**4. Ambiguity claims corrected.** The docs and this diary previously implied
+space-separated `display` values are free-form. In fact several forms that
+look like "two values" are actually one, by the same grammar rules that apply
+everywhere else in WFL, not anything `display`-specific: a run of bare words
+(`display a b c`) is one multi-word identifier (the lexer merges consecutive
+identifier tokens before the parser ever sees them); `display numbers 0` is a
+direct index, not two values; `display total -5` is subtraction, not two
+values (unary `-` is only reachable when nothing precedes it, and here the
+first value's `parse_expression` call already consumes `-5` as `total minus
+5` before the fold loop is ever reached). `Docs/02-getting-started/hello-world.md`
+now says this plainly instead of only demonstrating the happy path.
+
+**5. Added exact-stdout regression coverage.** Prior tests only checked AST
+shape (parser unit tests) or exit code (the `TestPrograms/*.wfl` CI runner
+redirects stdout to `/dev/null`). `tests/display_multiple_values_stdout_test.rs`
+now asserts exact stdout for the documented happy paths, a user-defined action
+return value, an action with arguments and one with a side effect, a
+container instance/property/method, and — the one that matters most — the
+mutating-list case proving space-separated `display` and `with` now produce
+byte-identical output.

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -135,6 +135,38 @@ display "Hello, " with name with "!"
 Hello, Bob!
 ```
 
+## Display Several Values at Once
+
+You don't have to write `with` between every piece. A `display` can list
+several values separated by spaces — quoted text is shown as-is, and anything
+else (a variable or an expression) is evaluated first:
+
+```wfl
+store name as "Alice"
+display "Hello, " name "!"
+```
+
+**Output:**
+```
+Hello, Alice!
+```
+
+This is just a shorthand: `display "Hello, " name "!"` means exactly the same
+thing as `display "Hello, " with name with "!"`. Both simply join the values
+together.
+
+Because the values are joined directly (no space is added for you), put any
+spaces you want inside the quotes:
+
+```wfl
+store age as 25
+display "I am " age " years old"   // I am 25 years old
+display "I am" age "years old"     // I am25years old  ← note the missing spaces
+```
+
+> **Tip:** `with` and the space-separated form do the same job. Use whichever
+> reads more clearly — mix them freely if you like.
+
 ## Experiment!
 
 WFL is designed for experimentation. Try these:

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -172,10 +172,13 @@ display "I am" age "years old"     // I am25years old  ← note the missing spac
 A run of plain words with nothing between them (no quotes, numbers, or
 keywords) is a single multi-word variable name, not several values — `display
 a b c` looks for one variable literally named `a b c`, the same as it would
-outside a `display`. Space-separated values only split apart where the
-grammar already has a boundary: a quote, a number, a parenthesis, or a
-keyword. Likewise, `display numbers 0` stays a single value — a direct index
-into `numbers` — and `display total -5` stays a single value — `total`
+outside a `display`. Space-separated values only split apart where the grammar
+already has a boundary: a quote, a number, a parenthesis, or one of the
+keywords that begins a value on its own (such as `not`, `file exists`, or an
+action `call`). Words joined by an operator like `plus` or `minus`, or a
+keyword that opens a new statement or block, stay part of the same value rather
+than starting a new one. So `display numbers 0` stays a single value — a direct
+index into `numbers` — and `display total -5` stays a single value — `total`
 *minus* `5` — because both `0` and `-5` attach to the item right before them
 the same way they would anywhere else in WFL. When you want two values that
 would otherwise merge like this, use `with` to make the boundary explicit.

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -175,13 +175,24 @@ a b c` looks for one variable literally named `a b c`, the same as it would
 outside a `display`. Space-separated values only split apart where the grammar
 already has a boundary: a quote, a number, a parenthesis, or one of the
 keywords that begins a value on its own (such as `not`, `file exists`, or an
-action `call`). Words joined by an operator like `plus` or `minus`, or a
-keyword that opens a new statement or block, stay part of the same value rather
-than starting a new one. So `display numbers 0` stays a single value — a direct
-index into `numbers` — and `display total -5` stays a single value — `total`
-*minus* `5` — because both `0` and `-5` attach to the item right before them
-the same way they would anywhere else in WFL. When you want two values that
-would otherwise merge like this, use `with` to make the boundary explicit.
+action `call`).
+
+Two kinds of tokens do *not* start a new value, for different reasons:
+
+- Words joined by an operator like `plus` or `minus` stay part of the *same*
+  value. `display numbers 0` stays a single value — a direct index into
+  `numbers` — and `display total -5` stays a single value — `total` *minus*
+  `5` — because both `0` and `-5` attach to the item right before them the
+  same way they would anywhere else in WFL.
+- A keyword that starts a *different kind of statement* — `count from ...`, a
+  loop, `create ...`, `change ... to ...`, and a few others — ends the
+  `display` right where it is, exactly as a line break would, and begins its
+  own statement immediately after. `display "start" count from 1 to 3:` still
+  displays `start` and then opens a count loop, just as it did before
+  `display` accepted multiple values.
+
+When you want two values that would otherwise merge like the first case, use
+`with` to make the boundary explicit.
 
 ## Experiment!
 

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -166,8 +166,11 @@ display "I am " age " years old"   // I am 25 years old
 display "I am" age "years old"     // I am25years old  ← note the missing spaces
 ```
 
-> **Tip:** `with` and the space-separated form do the same job. Use whichever
-> reads more clearly — mix them freely if you like.
+> **Tip:** `with` and the space-separated form do the same job — use whichever
+> reads more clearly. Just pick *one* form within a single `display`: mixing
+> them in the same statement (like `display a with b c`) can group the values
+> differently and change the order they're evaluated, so a run of pure `with`
+> or pure spaces stays predictable while a mix may not.
 
 A run of plain words with nothing between them (no quotes, numbers, or
 keywords) is a single multi-word variable name, not several values — `display

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -153,8 +153,9 @@ Hello, Alice!
 ```
 
 This is just a shorthand: `display "Hello, " name "!"` means exactly the same
-thing as `display "Hello, " with name with "!"`. Both simply join the values
-together.
+thing as `display "Hello, " with name with "!"` — not just the same result,
+but the same order of evaluation, so a value that changes as a side effect of
+a later item (e.g. popping from a list) behaves identically either way.
 
 Because the values are joined directly (no space is added for you), put any
 spaces you want inside the quotes:
@@ -167,6 +168,17 @@ display "I am" age "years old"     // I am25years old  ← note the missing spac
 
 > **Tip:** `with` and the space-separated form do the same job. Use whichever
 > reads more clearly — mix them freely if you like.
+
+A run of plain words with nothing between them (no quotes, numbers, or
+keywords) is a single multi-word variable name, not several values — `display
+a b c` looks for one variable literally named `a b c`, the same as it would
+outside a `display`. Space-separated values only split apart where the
+grammar already has a boundary: a quote, a number, a parenthesis, or a
+keyword. Likewise, `display numbers 0` stays a single value — a direct index
+into `numbers` — and `display total -5` stays a single value — `total`
+*minus* `5` — because both `0` and `-5` attach to the item right before them
+the same way they would anywhere else in WFL. When you want two values that
+would otherwise merge like this, use `with` to make the boundary explicit.
 
 ## Experiment!
 

--- a/Docs/02-getting-started/hello-world.md
+++ b/Docs/02-getting-started/hello-world.md
@@ -138,8 +138,9 @@ Hello, Bob!
 ## Display Several Values at Once
 
 You don't have to write `with` between every piece. A `display` can list
-several values separated by spaces — quoted text is shown as-is, and anything
-else (a variable or an expression) is evaluated first:
+several values separated by spaces — quoted text is shown as-is, and each other
+item is evaluated first: a variable, a number, an action call, or an expression
+like `age plus 10`:
 
 ```wfl
 store name as "Alice"

--- a/TestPrograms/display_multiple_values.wfl
+++ b/TestPrograms/display_multiple_values.wfl
@@ -1,0 +1,36 @@
+// Multi-value `display`: a display can list several space-separated values.
+// Quoted text is shown as-is; anything else (a variable or an expression) is
+// evaluated first. The values are joined exactly like `with`, so
+// `display a b c` means the same as `display a with b with c`.
+
+store user age as 28
+display "user age is " user age          // user age is 28
+
+change user age to 9
+display "user age is " user age          // user age is 9
+
+// Equivalent, written with `with`:
+display "user age is " with user age     // user age is 9
+
+// More than two values, mixing text, variables and an expression:
+store name as "Alice"
+display name " is " user age " years old"      // Alice is 9 years old
+display "in ten years: " user age plus 10      // in ten years: 19
+
+// A single value still behaves exactly as before:
+display user age                          // 9
+
+// Direct index access is unchanged: `list index` is one value, not two.
+create list scores:
+    add 100
+    add 200
+    add 300
+end list
+display "first score: " scores 0          // first score: 100
+
+// The following condition from the original report now sees the right value:
+check if user age is greater than 18:
+    display "Access granted"
+otherwise:
+    display "Must be 18 or older"
+end check

--- a/TestPrograms/display_multiple_values.wfl
+++ b/TestPrograms/display_multiple_values.wfl
@@ -31,7 +31,7 @@ end list
 display "first score: " scores 0          // first score: 100
 
 // Keyword-led values fold too. A `call` to a user-defined action:
-define action called doubled with n:
+define action called doubled with parameters n:
     give back n times 2
 end action
 display "doubled: " call doubled with 21    // doubled: 42

--- a/TestPrograms/display_multiple_values.wfl
+++ b/TestPrograms/display_multiple_values.wfl
@@ -1,7 +1,9 @@
 // Multi-value `display`: a display can list several space-separated values.
 // Quoted text is shown as-is; each other item (a variable, a number, an action
 // call, or an expression) is evaluated first. The values are joined exactly
-// like `with`, so `display a b c` means the same as `display a with b with c`.
+// like `with` — see the bottom of this file for where that "space-separated"
+// framing breaks down (bare multi-word identifiers, indexing, and arithmetic
+// all claim the space before a value-form fold ever gets a chance to run).
 
 store user age as 28
 display "user age is " user age          // user age is 28
@@ -45,3 +47,30 @@ check if user age is greater than 18:
 otherwise:
     display "Must be 18 or older"
 end check
+
+// Values are folded right-associatively, exactly matching `with`'s evaluation
+// order — not just its final text. Popping "after" off a list changes what
+// the list looks like when it gets stringified; both forms below stringify
+// the list *after* the pop runs, so both print "[before]after":
+create list left_items:
+    add "before"
+    add "after"
+end list
+display left_items "" pop of left_items          // [before]after
+
+create list right_items:
+    add "before"
+    add "after"
+end list
+display right_items with "" with pop of right_items   // [before]after
+
+// A few more keyword-led values that now fold safely (see is_value_start in
+// src/parser/helpers.rs for the full list and why each is unambiguous):
+store is_admin as no
+display "is admin: " not is_admin                // is admin: yes
+display "exists: " file exists at "does-not-exist.txt"   // exists: no
+
+// A run of plain words with nothing between them is ONE multi-word variable,
+// not several values — this looks up a variable literally named "a b c",
+// the same as it would anywhere else in WFL:
+// display a b c   ← NOT three values; would need `a with b with c`

--- a/TestPrograms/display_multiple_values.wfl
+++ b/TestPrograms/display_multiple_values.wfl
@@ -1,7 +1,7 @@
 // Multi-value `display`: a display can list several space-separated values.
-// Quoted text is shown as-is; anything else (a variable or an expression) is
-// evaluated first. The values are joined exactly like `with`, so
-// `display a b c` means the same as `display a with b with c`.
+// Quoted text is shown as-is; each other item (a variable, a number, an action
+// call, or an expression) is evaluated first. The values are joined exactly
+// like `with`, so `display a b c` means the same as `display a with b with c`.
 
 store user age as 28
 display "user age is " user age          // user age is 28
@@ -27,6 +27,17 @@ create list scores:
     add 300
 end list
 display "first score: " scores 0          // first score: 100
+
+// Keyword-led values fold too. A `call` to a user-defined action:
+define action called doubled with n:
+    give back n times 2
+end action
+display "doubled: " call doubled with 21    // doubled: 42
+
+// The count-loop variable `count` as a trailing value:
+count from 1 to 3:
+    display "count is " count              // count is 1 / 2 / 3
+end count
 
 // The following condition from the original report now sees the right value:
 check if user age is greater than 18:

--- a/TestPrograms/docs_examples/_meta/manifest.json
+++ b/TestPrograms/docs_examples/_meta/manifest.json
@@ -147,6 +147,25 @@
     ],
     "doc_purpose": "Demonstrates the simplest WFL program"
   },
+  "docs_examples/basic_syntax/display_multiple_01.wfl": {
+    "doc_section": "Docs/02-getting-started/hello-world.md#display-several-values-at-once",
+    "type": "executable",
+    "validate_layers": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "expected_exit_code": 0,
+    "tags": [
+      "beginner",
+      "getting-started",
+      "display",
+      "concatenation"
+    ],
+    "doc_purpose": "Shows that display accepts multiple space-separated values, equivalent to joining them with 'with'"
+  },
   "docs_examples/basic_syntax/variables_01.wfl": {
     "doc_section": "Docs/03-language-basics/variables-and-types.md",
     "type": "executable",

--- a/TestPrograms/docs_examples/basic_syntax/display_multiple_01.wfl
+++ b/TestPrograms/docs_examples/basic_syntax/display_multiple_01.wfl
@@ -1,0 +1,13 @@
+// Display several values at once (Docs/02-getting-started/hello-world.md).
+// Quoted text is shown as-is; a variable or expression is evaluated first.
+// The space-separated form is shorthand for joining values with `with`.
+
+store name as "Alice"
+display "Hello, " name "!"                 // Hello, Alice!
+
+// Exactly the same result, written with `with`:
+display "Hello, " with name with "!"       // Hello, Alice!
+
+// Spaces come from the quotes, not from the join:
+store age as 25
+display "I am " age " years old"           // I am 25 years old

--- a/src/parser/expr/primary.rs
+++ b/src/parser/expr/primary.rs
@@ -20,6 +20,74 @@ pub(crate) trait PrimaryExprParser<'a> {
 
 impl<'a> PrimaryExprParser<'a> for Parser<'a> {
     fn parse_primary_expression(&mut self) -> Result<Expression, ParseError> {
+        let leading = self.cursor.peek().cloned();
+        let result = self.parse_primary_expression_dispatch();
+
+        // Runtime coupling check between `can_start_primary_expression` (the
+        // predicate `display`'s multi-value fold is built on, in
+        // `src/parser/helpers.rs`) and this function's *actual* dispatch
+        // below. Unlike a hand-picked sample test, this runs on every
+        // primary-expression parse — every parser test, every
+        // `TestPrograms/*.wfl` run, every program compiled in a debug build —
+        // so a new dispatch arm added below without updating
+        // `can_start_primary_expression` (or the reverse) panics the first
+        // time anything exercises that token. Compiled out entirely in
+        // release builds, like the rest of this crate's `debug_assert!`
+        // invariants.
+        //
+        // Only the "predicted true" direction also checks position, not just
+        // message text: an arm that recurses (e.g. `file size of <expr>`) can
+        // propagate a nested failure's "Unexpected token in expression" text
+        // up through `?`, but that nested error's position belongs to
+        // whatever token deep inside actually failed, not to `leading` — so
+        // requiring both the message *and* the position to match tells "this
+        // token itself has no arm" apart from "this token's arm recursed into
+        // something else that failed". The "predicted false" direction needs
+        // no such check: every token classified as a non-starter always
+        // dispatches to an arm that errors unconditionally.
+        if let Some(leading) = leading {
+            let predicted_can_start = Self::can_start_primary_expression(&leading.token);
+            if !predicted_can_start {
+                debug_assert!(
+                    result.is_err(),
+                    "can_start_primary_expression predicted {:?} could not start an \
+                     expression, but parse_primary_expression succeeded",
+                    leading.token
+                );
+            } else {
+                let fell_through_to_fallback = if let Err(error) = &result {
+                    error.message.contains("Unexpected token in expression")
+                        && error.line == leading.line
+                        && error.column == leading.column
+                } else {
+                    false
+                };
+                debug_assert!(
+                    !fell_through_to_fallback,
+                    "can_start_primary_expression predicted {:?} could start an \
+                     expression, but parse_primary_expression had no dedicated arm for it",
+                    leading.token
+                );
+            }
+        }
+
+        result
+    }
+
+    fn parse_list_element(&mut self) -> Result<Expression, ParseError> {
+        // Parse a single list element without parsing binary operators
+        // This prevents "and" from being interpreted as a boolean operator
+        self.parse_primary_expression()
+    }
+}
+
+impl<'a> Parser<'a> {
+    /// The actual primary-expression dispatch. Call `parse_primary_expression`
+    /// (the trait method above), not this directly — it wraps this function
+    /// with a debug-only check that keeps `can_start_primary_expression` from
+    /// silently drifting away from what this dispatch really accepts, and
+    /// recursive calls from within the arms below go through that wrapper too.
+    fn parse_primary_expression_dispatch(&mut self) -> Result<Expression, ParseError> {
         // Strided run-budget checkpoint. Every operand (list element, operator-
         // chain term, call argument) routes through here, so this bounds a single
         // huge expression that the statement-boundary checkpoint would miss.
@@ -1293,11 +1361,5 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
                 0,
             ))
         }
-    }
-
-    fn parse_list_element(&mut self) -> Result<Expression, ParseError> {
-        // Parse a single list element without parsing binary operators
-        // This prevents "and" from being interpreted as a boolean operator
-        self.parse_primary_expression()
     }
 }

--- a/src/parser/expr/primary.rs
+++ b/src/parser/expr/primary.rs
@@ -20,6 +20,7 @@ pub(crate) trait PrimaryExprParser<'a> {
 
 impl<'a> PrimaryExprParser<'a> for Parser<'a> {
     fn parse_primary_expression(&mut self) -> Result<Expression, ParseError> {
+        #[cfg(debug_assertions)]
         let leading = self.cursor.peek().cloned();
         let result = self.parse_primary_expression_dispatch();
 
@@ -45,6 +46,12 @@ impl<'a> PrimaryExprParser<'a> for Parser<'a> {
         // something else that failed". The "predicted false" direction needs
         // no such check: every token classified as a non-starter always
         // dispatches to an arm that errors unconditionally.
+        //
+        // The whole check — the `leading` capture above included — is behind
+        // `#[cfg(debug_assertions)]`, so release builds pay nothing for it (no
+        // token clone, no reclassification, no error inspection), not merely a
+        // stripped `debug_assert!`.
+        #[cfg(debug_assertions)]
         if let Some(leading) = leading {
             let predicted_can_start = Self::can_start_primary_expression(&leading.token);
             if !predicted_can_start {

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -238,6 +238,70 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Returns `true` if `token` has a dedicated arm in
+    /// `parse_primary_expression` (`src/parser/expr/primary.rs`) that attempts
+    /// to parse a standalone value, rather than falling through to that
+    /// function's final `_ => Err("Unexpected token in expression")` arm.
+    ///
+    /// This is the single source of truth for "can this token begin a primary
+    /// expression" — `is_value_start` below is defined in terms of it (primary
+    /// starters minus an explicit, documented exclusion list) instead of
+    /// maintaining its own independent token list, so the two can no longer
+    /// silently drift apart as `parse_primary_expression` grows new arms.
+    /// `parser/tests.rs` has a coupling test
+    /// (`can_start_primary_expression_matches_parse_primary_expression`) that
+    /// feeds a representative token of every `Token` variant through both
+    /// this predicate and an actual `parse_primary_expression` call and
+    /// asserts they agree — so an arm added to one without the other fails a
+    /// test instead of quietly drifting.
+    ///
+    /// Mirrors, in match order: the literal/bracket/paren/identifier arms; the
+    /// explicit keyword-led arms (`call`, `not`, `-` unary, `with`, `count`,
+    /// `pattern`, `loop`, `output`, `repeat`, `exit`, `back`, `try`, `when`,
+    /// `error`, `file`, `directory`, `process`, `header`, `current`, `list`,
+    /// `read`, `find`, `replace`, `split`); and finally the contextual-keyword
+    /// catch-all (`_ if token.is_contextual_keyword()`), which covers every
+    /// other contextual keyword (e.g. `text`, `map`, `contains`, `create`,
+    /// `new`, ...) as a bare variable reference. `Token::Eol` has its own arm
+    /// but it always errors, so it is excluded here.
+    pub(crate) fn can_start_primary_expression(token: &Token) -> bool {
+        matches!(
+            token,
+            Token::LeftBracket
+                | Token::LeftParen
+                | Token::StringLiteral(_)
+                | Token::IntLiteral(_)
+                | Token::FloatLiteral(_)
+                | Token::BooleanLiteral(_)
+                | Token::NothingLiteral
+                | Token::KeywordCall
+                | Token::Identifier(_)
+                | Token::KeywordNot
+                | Token::Minus
+                | Token::KeywordWith
+                | Token::KeywordCount
+                | Token::KeywordPattern
+                | Token::KeywordLoop
+                | Token::KeywordOutput
+                | Token::KeywordRepeat
+                | Token::KeywordExit
+                | Token::KeywordBack
+                | Token::KeywordTry
+                | Token::KeywordWhen
+                | Token::KeywordError
+                | Token::KeywordFile
+                | Token::KeywordDirectory
+                | Token::KeywordProcess
+                | Token::KeywordHeader
+                | Token::KeywordCurrent
+                | Token::KeywordList
+                | Token::KeywordRead
+                | Token::KeywordFind
+                | Token::KeywordReplace
+                | Token::KeywordSplit
+        ) || token.is_contextual_keyword()
+    }
+
     /// Returns `true` if `token` can begin a fresh standalone value in a
     /// `display` list.
     ///
@@ -249,75 +313,138 @@ impl<'a> Parser<'a> {
     /// the preceding expression) and `display x\n0` keeps the `0` as its own
     /// statement across the line break.
     ///
-    /// This list tracks the keyword-led arms of `parse_primary_expression`'s
-    /// top-level match (`src/parser/expr/primary.rs`) that produce a
-    /// standalone value with no ambiguity against statement boundaries: `not`,
-    /// `pattern`, `output`, `file`, `directory`, `process`, `header`, `list`,
-    /// and `read`, alongside the pre-existing `call`/`count`/`current`. Each is
-    /// exercised end-to-end (parse *and* fold) by a
-    /// `test_display_folds_keyword_*` test in `parser/tests.rs`, so a
-    /// regression here — the token stops folding, or silently changes what it
-    /// parses to — fails loudly instead of drifting unnoticed.
+    /// Defined as `can_start_primary_expression` minus an explicit exclusion
+    /// list, so it can never accept a token the expression parser itself
+    /// rejects, and any *new* primary-expression starter is included by
+    /// default rather than requiring a second, easy-to-forget edit — the
+    /// opposite failure mode of the token list this replaced. Each included
+    /// keyword starter is exercised end-to-end (parse *and* fold) by a
+    /// `test_display_folds_keyword_*` test in `parser/tests.rs`.
     ///
-    /// Not every keyword-led primary-expression arm is included. Several are
-    /// deliberately left out because they double as statement/block openers
-    /// elsewhere in the grammar (`loop`, `exit`, `repeat`, `try`, `when` — the
-    /// first four are literal entries in `is_statement_starter` above, and
-    /// `when` opens route-arm blocks); folding them into a preceding `display`
-    /// on parse would swallow what is far more likely to be a genuine syntax
-    /// error (a missing line break) than an intended display value, so they
-    /// are left to surface that error instead of being silently absorbed.
-    /// `back` and `error` were also left out of this pass — they are
-    /// unambiguous by the same reasoning as `not`/`pattern`, but weren't
-    /// flagged by review, so they're a candidate for a follow-up rather than
-    /// bundled in here without an explicit ask.
-    ///
-    /// Deliberately excluded:
-    /// - `with`, `find`, `replace`, `split`, `matches`, `contains`,
-    ///   `starts`/`ends with`, `is`, `and`, `or`, and arithmetic keywords —
-    ///   `parse_binary_expression` already consumes these as continuations of
-    ///   the *first* value inside the initial `parse_expression()` call above,
-    ///   so they never reach this check as the head of a fresh value. (`find`,
-    ///   `replace`, and `split` have a separate, pre-existing bug where that
-    ///   continuation silently discards the value that precedes them — e.g.
+    /// Excluded, with reasons:
+    /// - `loop`, `exit`, `repeat`, `try`, `when` — these double as
+    ///   statement/block openers elsewhere in the grammar (the first four are
+    ///   literal entries in `is_statement_starter` above, and `when` opens
+    ///   route-arm blocks); folding them into a preceding `display` on parse
+    ///   would swallow what is far more likely to be a genuine syntax error (a
+    ///   missing line break) than an intended display value, so they are left
+    ///   to surface that error instead of being silently absorbed. `back` and
+    ///   `error` have no such conflict — each is *only* ever a bare-variable
+    ///   arm in `parse_primary_expression`, is not a dedicated arm of
+    ///   `parse_statement`'s top-level dispatch (`src/parser/mod.rs`), and
+    ///   (unlike `count`/`read`, see below) never leads a longer statement
+    ///   form — so they are included.
+    /// - `create`, `change`, `push`, `parent`, `skip`, `give` — each is
+    ///   contextual (`Token::is_contextual_keyword`), so in expression
+    ///   position it is just a bare-variable reference, but each is *also* a
+    ///   dedicated arm of `parse_statement`'s top-level dispatch leading a
+    ///   statement form with no expression-position equivalent: `create
+    ///   container/list/new/pattern/directory/file/map/date/time/... as`,
+    ///   `change X to Y` (assignment), `push with LIST and VALUE`, `parent
+    ///   method(...)` (parent method call), and `give back EXPR` (return).
+    ///   Centralizing on `can_start_primary_expression` surfaced these the
+    ///   same way it surfaced `count`/`read`; unlike those two, none has a
+    ///   single, unambiguous continuation token to guard on (`create` alone
+    ///   forks more than half a dozen ways), so — same reasoning as
+    ///   `loop`/`exit`/`repeat`/`try`/`when` — they are excluded outright
+    ///   rather than guarded. `skip` is the sharpest case: as a bare
+    ///   statement it's a *control-flow* effect (`continue`, one token,
+    ///   see `Token::KeywordContinue | Token::KeywordSkip` in
+    ///   `parse_statement`) with no visible syntax difference from folding it
+    ///   as a value — both consume exactly one token — so an unguarded
+    ///   inclusion would silently turn a loop's `continue` into inert display
+    ///   output instead of a parse-time error. See the
+    ///   `*_after_display_stays_a_separate_statement` tests in
+    ///   `parser/tests.rs` for `create`, `change`, `push`, `parent`, `skip`,
+    ///   and `give`.
+    /// - `with`, `find`, `replace`, `split` — `parse_binary_expression`
+    ///   already consumes these as continuations of the *first* value inside
+    ///   the initial `parse_expression()` call above, so they never reach this
+    ///   check as the head of a fresh value. (`find`, `replace`, and `split`
+    ///   have a separate, pre-existing bug where that continuation silently
+    ///   discards the value that precedes them — e.g.
     ///   `display "parts: " split "a,b" by ","` prints only the split result —
-    ///   but that lives in the general binary-expression grammar, not here; see
-    ///   the Dev Diary entry for this feature for the follow-up scope note.)
+    ///   but that lives in the general binary-expression grammar, not here;
+    ///   see the Dev Diary entry for this feature for the follow-up scope
+    ///   note.)
     /// - Unary `-` (`Minus`) can never be the head of a fresh display value:
     ///   after an operand, `parse_binary_expression` consumes a `-` as the
     ///   binary subtraction operator, so a leading `-` after the first value is
     ///   always folded into that first `parse_expression()` call as arithmetic
     ///   (`display "n: " -5` parses as `"n: " minus 5`, not as two values) —
     ///   adding it here would be dead code. `not` has no such conflict (it is
-    ///   never a binary continuation), so it is included below.
+    ///   never a binary continuation), so it is included.
     /// - `LeftBracket` (`[`) — postfix indexing (`Token::LeftBracket` in
     ///   `parse_primary_expression`'s postfix loop) unconditionally attaches a
     ///   following `[...]` to whatever expression was just parsed, so a `[` can
     ///   never be the head of a *fresh* value here either; it is always already
     ///   consumed as an index into the previous value.
+    ///
+    /// `count` and `read` are included (the count-loop variable, and
+    /// `read content/binary/N bytes from ...`), but each also leads a longer,
+    /// statement-only form on the same line — `count from ... to ...:` (a
+    /// count loop) and `read output from process ...`
+    /// (`parse_read_process_output_statement`) — that has no expression-position
+    /// parse of its own. Folding either as a bare value would truncate the
+    /// `display` at just the keyword and strand the rest as unparsable
+    /// leftover tokens. `parse_display_statement`'s fold loop therefore pairs
+    /// this predicate with `is_display_fold_statement_boundary`, which peeks
+    /// one token further to keep those two forms as their own statement,
+    /// exactly as they parsed before this feature existed.
     pub(crate) fn is_value_start(token: &Token) -> bool {
-        matches!(
-            token,
-            Token::StringLiteral(_)
-                | Token::IntLiteral(_)
-                | Token::FloatLiteral(_)
-                | Token::BooleanLiteral(_)
-                | Token::NothingLiteral
-                | Token::Identifier(_)
-                | Token::LeftParen
-                | Token::KeywordCall
-                | Token::KeywordCount
-                | Token::KeywordCurrent
-                | Token::KeywordNot
-                | Token::KeywordPattern
-                | Token::KeywordOutput
-                | Token::KeywordFile
-                | Token::KeywordDirectory
-                | Token::KeywordProcess
-                | Token::KeywordHeader
-                | Token::KeywordList
-                | Token::KeywordRead
-        )
+        Self::can_start_primary_expression(token)
+            && !matches!(
+                token,
+                Token::KeywordLoop
+                    | Token::KeywordExit
+                    | Token::KeywordRepeat
+                    | Token::KeywordTry
+                    | Token::KeywordWhen
+                    | Token::KeywordCreate
+                    | Token::KeywordChange
+                    | Token::KeywordPush
+                    | Token::KeywordParent
+                    | Token::KeywordSkip
+                    | Token::KeywordGive
+                    | Token::KeywordWith
+                    | Token::KeywordFind
+                    | Token::KeywordReplace
+                    | Token::KeywordSplit
+                    | Token::Minus
+                    | Token::LeftBracket
+            )
+    }
+
+    /// Returns `true` when the upcoming tokens begin a new statement rather
+    /// than a fresh `display` value, even though the leading token alone
+    /// passes `is_value_start`.
+    ///
+    /// `count` and `read` are each folded as expression starters (the
+    /// count-loop variable, and `read content`/`read binary`/`read N bytes
+    /// from`), but `count from ...` opens a count loop and
+    /// `read output from process ...` is statement-only
+    /// (`parse_read_process_output_statement`) — neither has an
+    /// expression-position parse, so folding them would silently truncate the
+    /// `display` at just the keyword and leave the rest of the statement
+    /// dangling as unparsable leftover tokens. This lookahead preserves the
+    /// pre-existing same-line behavior for both: `display "x" count from 1 to
+    /// 3:` and `display "x" read output from process p` still end the
+    /// `display` after `"x"` and parse the second statement normally.
+    pub(crate) fn is_display_fold_statement_boundary(&self) -> bool {
+        let Some(next) = self.cursor.peek() else {
+            return false;
+        };
+        match &next.token {
+            Token::KeywordCount => self
+                .cursor
+                .peek_next()
+                .is_some_and(|t| t.token == Token::KeywordFrom),
+            Token::KeywordRead => self
+                .cursor
+                .peek_next()
+                .is_some_and(|t| t.token == Token::KeywordOutput),
+            _ => false,
+        }
     }
 
     /// Synchronize parser state after an error by advancing to the next statement starter

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -238,6 +238,28 @@ impl<'a> Parser<'a> {
         )
     }
 
+    /// Returns `true` if `token` can begin a standalone value expression.
+    ///
+    /// Used by `display` to fold multiple space-separated values into a single
+    /// concatenation: quoted text is a string literal, everything else is a
+    /// variable/expression. Only tokens that start a fresh value trigger the
+    /// fold — operators, keywords, and statement boundaries (`Eol`) do not — so
+    /// `display numbers 0` stays a direct index access (the `0` is absorbed by
+    /// the preceding expression) and `display x\n0` keeps the `0` as its own
+    /// statement across the line break.
+    pub(crate) fn is_value_start(token: &Token) -> bool {
+        matches!(
+            token,
+            Token::StringLiteral(_)
+                | Token::IntLiteral(_)
+                | Token::FloatLiteral(_)
+                | Token::BooleanLiteral(_)
+                | Token::NothingLiteral
+                | Token::Identifier(_)
+                | Token::LeftParen
+        )
+    }
+
     /// Synchronize parser state after an error by advancing to the next statement starter
     #[allow(dead_code)]
     pub(crate) fn synchronize(&mut self) {

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -249,13 +249,53 @@ impl<'a> Parser<'a> {
     /// the preceding expression) and `display x\n0` keeps the `0` as its own
     /// statement across the line break.
     ///
-    /// Alongside literals, identifiers and `(`, this covers the keyword-led
-    /// value expressions that are *not* also binary operators (so they would
-    /// otherwise be left dangling and silently dropped or, in the case of
-    /// `count`, mis-parsed as a new statement): `call` action calls, the
-    /// count-loop variable `count`, and `current` date/time values. Keywords
-    /// that the binary parser already consumes after a value (`with`, `find`,
-    /// `replace`, `split`, `matches`, arithmetic) never reach this check.
+    /// This list tracks the keyword-led arms of `parse_primary_expression`'s
+    /// top-level match (`src/parser/expr/primary.rs`) that produce a
+    /// standalone value with no ambiguity against statement boundaries: `not`,
+    /// `pattern`, `output`, `file`, `directory`, `process`, `header`, `list`,
+    /// and `read`, alongside the pre-existing `call`/`count`/`current`. Each is
+    /// exercised end-to-end (parse *and* fold) by a
+    /// `test_display_folds_keyword_*` test in `parser/tests.rs`, so a
+    /// regression here — the token stops folding, or silently changes what it
+    /// parses to — fails loudly instead of drifting unnoticed.
+    ///
+    /// Not every keyword-led primary-expression arm is included. Several are
+    /// deliberately left out because they double as statement/block openers
+    /// elsewhere in the grammar (`loop`, `exit`, `repeat`, `try`, `when` — the
+    /// first four are literal entries in `is_statement_starter` above, and
+    /// `when` opens route-arm blocks); folding them into a preceding `display`
+    /// on parse would swallow what is far more likely to be a genuine syntax
+    /// error (a missing line break) than an intended display value, so they
+    /// are left to surface that error instead of being silently absorbed.
+    /// `back` and `error` were also left out of this pass — they are
+    /// unambiguous by the same reasoning as `not`/`pattern`, but weren't
+    /// flagged by review, so they're a candidate for a follow-up rather than
+    /// bundled in here without an explicit ask.
+    ///
+    /// Deliberately excluded:
+    /// - `with`, `find`, `replace`, `split`, `matches`, `contains`,
+    ///   `starts`/`ends with`, `is`, `and`, `or`, and arithmetic keywords —
+    ///   `parse_binary_expression` already consumes these as continuations of
+    ///   the *first* value inside the initial `parse_expression()` call above,
+    ///   so they never reach this check as the head of a fresh value. (`find`,
+    ///   `replace`, and `split` have a separate, pre-existing bug where that
+    ///   continuation silently discards the value that precedes them — e.g.
+    ///   `display "parts: " split "a,b" by ","` prints only the split result —
+    ///   but that lives in the general binary-expression grammar, not here; see
+    ///   the Dev Diary entry for this feature for the follow-up scope note.)
+    /// - `not` and unary `-` (`Minus`) as *binary*-operator continuations don't
+    ///   apply here, but `Minus` specifically can never be the head of a fresh
+    ///   display value either way: `parse_binary_expression` has no precedence
+    ///   guard on subtraction, so a leading `-` after the first value is always
+    ///   consumed as arithmetic *inside* that first `parse_expression()` call
+    ///   (`display "n: " -5` parses as `"n: " minus 5`, not as two values) —
+    ///   adding it here would be dead code. `not` has no such conflict (it is
+    ///   never a binary continuation), so it is included below.
+    /// - `LeftBracket` (`[`) — postfix indexing (`Token::LeftBracket` in
+    ///   `parse_primary_expression`'s postfix loop) unconditionally attaches a
+    ///   following `[...]` to whatever expression was just parsed, so a `[` can
+    ///   never be the head of a *fresh* value here either; it is always already
+    ///   consumed as an index into the previous value.
     pub(crate) fn is_value_start(token: &Token) -> bool {
         matches!(
             token,
@@ -269,6 +309,15 @@ impl<'a> Parser<'a> {
                 | Token::KeywordCall
                 | Token::KeywordCount
                 | Token::KeywordCurrent
+                | Token::KeywordNot
+                | Token::KeywordPattern
+                | Token::KeywordOutput
+                | Token::KeywordFile
+                | Token::KeywordDirectory
+                | Token::KeywordProcess
+                | Token::KeywordHeader
+                | Token::KeywordList
+                | Token::KeywordRead
         )
     }
 

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -238,15 +238,24 @@ impl<'a> Parser<'a> {
         )
     }
 
-    /// Returns `true` if `token` can begin a standalone value expression.
+    /// Returns `true` if `token` can begin a fresh standalone value in a
+    /// `display` list.
     ///
     /// Used by `display` to fold multiple space-separated values into a single
     /// concatenation: quoted text is a string literal, everything else is a
     /// variable/expression. Only tokens that start a fresh value trigger the
-    /// fold — operators, keywords, and statement boundaries (`Eol`) do not — so
+    /// fold — statement boundaries (`Eol`) and binary operators do not — so
     /// `display numbers 0` stays a direct index access (the `0` is absorbed by
     /// the preceding expression) and `display x\n0` keeps the `0` as its own
     /// statement across the line break.
+    ///
+    /// Alongside literals, identifiers and `(`, this covers the keyword-led
+    /// value expressions that are *not* also binary operators (so they would
+    /// otherwise be left dangling and silently dropped or, in the case of
+    /// `count`, mis-parsed as a new statement): `call` action calls, the
+    /// count-loop variable `count`, and `current` date/time values. Keywords
+    /// that the binary parser already consumes after a value (`with`, `find`,
+    /// `replace`, `split`, `matches`, arithmetic) never reach this check.
     pub(crate) fn is_value_start(token: &Token) -> bool {
         matches!(
             token,
@@ -257,6 +266,9 @@ impl<'a> Parser<'a> {
                 | Token::NothingLiteral
                 | Token::Identifier(_)
                 | Token::LeftParen
+                | Token::KeywordCall
+                | Token::KeywordCount
+                | Token::KeywordCurrent
         )
     }
 

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -283,11 +283,10 @@ impl<'a> Parser<'a> {
     ///   `display "parts: " split "a,b" by ","` prints only the split result —
     ///   but that lives in the general binary-expression grammar, not here; see
     ///   the Dev Diary entry for this feature for the follow-up scope note.)
-    /// - `not` and unary `-` (`Minus`) as *binary*-operator continuations don't
-    ///   apply here, but `Minus` specifically can never be the head of a fresh
-    ///   display value either way: `parse_binary_expression` has no precedence
-    ///   guard on subtraction, so a leading `-` after the first value is always
-    ///   consumed as arithmetic *inside* that first `parse_expression()` call
+    /// - Unary `-` (`Minus`) can never be the head of a fresh display value:
+    ///   after an operand, `parse_binary_expression` consumes a `-` as the
+    ///   binary subtraction operator, so a leading `-` after the first value is
+    ///   always folded into that first `parse_expression()` call as arithmetic
     ///   (`display "n: " -5` parses as `"n: " minus 5`, not as two values) —
     ///   adding it here would be dead code. `not` has no such conflict (it is
     ///   never a binary continuation), so it is included below.

--- a/src/parser/helpers.rs
+++ b/src/parser/helpers.rs
@@ -243,27 +243,45 @@ impl<'a> Parser<'a> {
     /// to parse a standalone value, rather than falling through to that
     /// function's final `_ => Err("Unexpected token in expression")` arm.
     ///
-    /// This is the single source of truth for "can this token begin a primary
-    /// expression" — `is_value_start` below is defined in terms of it (primary
-    /// starters minus an explicit, documented exclusion list) instead of
-    /// maintaining its own independent token list, so the two can no longer
-    /// silently drift apart as `parse_primary_expression` grows new arms.
-    /// `parser/tests.rs` has a coupling test
-    /// (`can_start_primary_expression_matches_parse_primary_expression`) that
-    /// feeds a representative token of every `Token` variant through both
-    /// this predicate and an actual `parse_primary_expression` call and
-    /// asserts they agree — so an arm added to one without the other fails a
-    /// test instead of quietly drifting.
+    /// `is_value_start` below is defined in terms of this predicate (primary
+    /// starters minus an explicit, documented exclusion list) rather than
+    /// maintaining its own independent token list, so display folding can
+    /// never accept a token the expression parser itself would reject.
+    ///
+    /// This function is still a hand-maintained `matches!` for the explicit
+    /// keyword-led arms below — that half is *not* structurally incapable of
+    /// drifting from `parse_primary_expression`. What actually enforces the
+    /// coupling is `parse_primary_expression` itself (`src/parser/expr/primary.rs`):
+    /// it wraps its real dispatch (`parse_primary_expression_dispatch`) in a
+    /// pair of `debug_assert!`s that compare this predicate's prediction
+    /// against what the dispatch actually did, on every call, in every debug
+    /// build — not a hand-picked sample, but every parser test, every
+    /// `TestPrograms/*.wfl` run, and every program compiled in a debug build.
+    /// An arm added to `parse_primary_expression` without a matching update
+    /// here (or the reverse) panics the first time anything exercises that
+    /// token, rather than only when a maintained sample list happens to cover
+    /// it.
+    /// `parser/tests.rs` additionally has an explicit, documented coupling
+    /// test (`can_start_primary_expression_matches_parse_primary_expression`)
+    /// covering a curated sample, kept as much for its documentation value as
+    /// its enforcement.
+    ///
+    /// The contextual-keyword half genuinely cannot drift, structurally:
+    /// both this predicate's `|| token.is_contextual_keyword()` and
+    /// `parse_primary_expression`'s catch-all
+    /// (`_ if token.is_contextual_keyword()`) call the exact same
+    /// `Token::is_contextual_keyword` function, so there is only one list to
+    /// maintain for every contextual keyword (`text`, `map`, `contains`,
+    /// `create`, `new`, ...) — adding one there automatically updates both
+    /// call sites at once.
     ///
     /// Mirrors, in match order: the literal/bracket/paren/identifier arms; the
     /// explicit keyword-led arms (`call`, `not`, `-` unary, `with`, `count`,
     /// `pattern`, `loop`, `output`, `repeat`, `exit`, `back`, `try`, `when`,
     /// `error`, `file`, `directory`, `process`, `header`, `current`, `list`,
     /// `read`, `find`, `replace`, `split`); and finally the contextual-keyword
-    /// catch-all (`_ if token.is_contextual_keyword()`), which covers every
-    /// other contextual keyword (e.g. `text`, `map`, `contains`, `create`,
-    /// `new`, ...) as a bare variable reference. `Token::Eol` has its own arm
-    /// but it always errors, so it is excluded here.
+    /// catch-all described above. `Token::Eol` has its own arm but it always
+    /// errors, so it is excluded here.
     pub(crate) fn can_start_primary_expression(token: &Token) -> bool {
         matches!(
             token,

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -392,207 +392,44 @@ impl<'a> IoParser<'a> for Parser<'a> {
     }
 
     fn parse_display_statement(&mut self) -> Result<Statement, ParseError> {
-        self.bump_sync(); // Consume "display"
+        // Anchor the statement at the `display` keyword itself.
+        let (line, column) = self
+            .bump_sync() // Consume "display"
+            .map_or((0, 0), |token| (token.line, token.column));
 
-        let expr = self.parse_expression()?;
+        // Parse the first value.
+        let mut value = self.parse_expression()?;
 
-        let token_pos = if let Some(token) = self.cursor.peek() {
-            token
-        } else {
-            return match expr {
-                Expression::Literal(_, line, column) => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::Variable(_, line, column) => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::BinaryOperation { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::UnaryOperation { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::FunctionCall { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::MemberAccess { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::IndexAccess { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::Concatenation { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::PatternMatch { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::PatternFind { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::PatternReplace { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::PatternSplit { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::StringSplit { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::AwaitExpression { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::ActionCall { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::StaticMemberAccess { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::MethodCall { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::PropertyAccess { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::FileExists { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::DirectoryExists { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::ListFiles { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::ReadContent { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::ReadBinaryContent { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::ReadBinaryN { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::FileSizeOf { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::ListFilesRecursive { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::ListFilesFiltered { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::HeaderAccess { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
-                Expression::CurrentTimeMilliseconds { line, column } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::CurrentTimeFormatted { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::ProcessRunning { line, column, .. } => {
-                    Ok(Statement::DisplayStatement {
-                        value: expr,
-                        line,
-                        column,
-                    })
-                }
-                Expression::DatabaseQuery { line, column, .. } => Ok(Statement::DisplayStatement {
-                    value: expr,
-                    line,
-                    column,
-                }),
+        // `display` accepts more than one space-separated value: quoted text is
+        // a string literal and anything else is a variable/expression. Fold
+        // each additional value into a left-associative Concatenation, giving
+        // the same result as joining them with `with`
+        // (`display a b c` == `display a with b with c`).
+        //
+        // Only tokens that begin a fresh value continue the fold (see
+        // `is_value_start`). Direct index access such as `display numbers 0` is
+        // already absorbed by `parse_expression` above — the trailing `0` never
+        // reaches this loop — and a line break ends the statement because `Eol`
+        // is not a value start, so both keep working unchanged.
+        loop {
+            let (cat_line, cat_column) = match self.cursor.peek() {
+                Some(token) if Self::is_value_start(&token.token) => (token.line, token.column),
+                _ => break,
             };
-        };
+
+            let next_value = self.parse_expression()?;
+            value = Expression::Concatenation {
+                left: Box::new(value),
+                right: Box::new(next_value),
+                line: cat_line,
+                column: cat_column,
+            };
+        }
 
         Ok(Statement::DisplayStatement {
-            value: expr,
-            line: token_pos.line,
-            column: token_pos.column,
+            value,
+            line,
+            column,
         })
     }
 

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -392,10 +392,13 @@ impl<'a> IoParser<'a> for Parser<'a> {
     }
 
     fn parse_display_statement(&mut self) -> Result<Statement, ParseError> {
-        // Anchor the statement at the `display` keyword itself.
-        let (line, column) = self
+        // Anchor the statement at the `display` keyword itself. This parser is
+        // only dispatched on `Token::KeywordDisplay`, so `bump_sync` is always
+        // `Some` here — expect rather than defaulting to a misleading (0, 0).
+        let display_token = self
             .bump_sync() // Consume "display"
-            .map_or((0, 0), |token| (token.line, token.column));
+            .expect("parse_display_statement is only called on the `display` keyword");
+        let (line, column) = (display_token.line, display_token.column);
 
         // Parse the first value.
         let mut value = self.parse_expression()?;

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -401,29 +401,42 @@ impl<'a> IoParser<'a> for Parser<'a> {
         let (line, column) = (display_token.line, display_token.column);
 
         // Parse the first value.
-        let mut value = self.parse_expression()?;
+        let mut values = vec![self.parse_expression()?];
+        let mut join_positions = Vec::new();
 
         // `display` accepts more than one space-separated value: quoted text is
-        // a string literal and anything else is a variable/expression. Fold
-        // each additional value into a left-associative Concatenation, giving
-        // the same result as joining them with `with`
-        // (`display a b c` == `display a with b with c`).
-        //
-        // Only tokens that begin a fresh value continue the fold (see
-        // `is_value_start`). Direct index access such as `display numbers 0` is
-        // already absorbed by `parse_expression` above — the trailing `0` never
-        // reaches this loop — and a line break ends the statement because `Eol`
-        // is not a value start, so both keep working unchanged.
+        // a string literal and anything else is a variable/expression. Collect
+        // every additional value here — only tokens that begin a fresh value
+        // continue the loop (see `is_value_start`). Direct index access such as
+        // `display numbers 0` is already absorbed by `parse_expression` above —
+        // the trailing `0` never reaches this loop — and a line break ends the
+        // statement because `Eol` is not a value start, so both keep working
+        // unchanged.
         loop {
             let (cat_line, cat_column) = match self.cursor.peek() {
                 Some(token) if Self::is_value_start(&token.token) => (token.line, token.column),
                 _ => break,
             };
 
-            let next_value = self.parse_expression()?;
+            values.push(self.parse_expression()?);
+            join_positions.push((cat_line, cat_column));
+        }
+
+        // Fold right-associatively — the same tree shape, evaluation order, and
+        // stringification order as explicit `with` (`a with b with c` parses as
+        // `a with (b with c)`, see the `with` handling in expr/binary.rs). This
+        // matters beyond cosmetics: `Concatenation` evaluates left, then right,
+        // then stringifies both, so a left-associative fold would stringify an
+        // earlier value *before* a later value's side effects (e.g. a list
+        // mutation) run, while this matches `with` exactly, value for value.
+        let mut value = values.pop().expect("at least one value was parsed");
+        while let Some(left) = values.pop() {
+            let (cat_line, cat_column) = join_positions
+                .pop()
+                .expect("one join position per folded value");
             value = Expression::Concatenation {
-                left: Box::new(value),
-                right: Box::new(next_value),
+                left: Box::new(left),
+                right: Box::new(value),
                 line: cat_line,
                 column: cat_column,
             };

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -407,14 +407,20 @@ impl<'a> IoParser<'a> for Parser<'a> {
         // `display` accepts more than one space-separated value: quoted text is
         // a string literal and anything else is a variable/expression. Collect
         // every additional value here — only tokens that begin a fresh value
-        // continue the loop (see `is_value_start`). Direct index access such as
-        // `display numbers 0` is already absorbed by `parse_expression` above —
-        // the trailing `0` never reaches this loop — and a line break ends the
-        // statement because `Eol` is not a value start, so both keep working
-        // unchanged.
+        // continue the loop (see `is_value_start`), and only when they aren't
+        // actually the start of a same-line statement in disguise (see
+        // `is_display_fold_statement_boundary`, which keeps `count from ...`
+        // and `read output from process ...` as their own statement). Direct
+        // index access such as `display numbers 0` is already absorbed by
+        // `parse_expression` above — the trailing `0` never reaches this loop
+        // — and a line break ends the statement because `Eol` is not a value
+        // start, so both keep working unchanged.
         loop {
+            let is_boundary = self.is_display_fold_statement_boundary();
             let (cat_line, cat_column) = match self.cursor.peek() {
-                Some(token) if Self::is_value_start(&token.token) => (token.line, token.column),
+                Some(token) if !is_boundary && Self::is_value_start(&token.token) => {
+                    (token.line, token.column)
+                }
                 _ => break,
             };
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2597,8 +2597,22 @@ fn test_display_folds_call_action() {
 fn parse_display(input: &str) -> Expression {
     let tokens = lex_wfl_with_positions(input);
     let mut parser = Parser::new(&tokens);
-    match parser.parse_statement() {
-        Ok(Statement::DisplayStatement { value, .. }) => value,
+    // Parse the whole program (not a single statement) so any trailing tokens
+    // the fold failed to consume surface as an extra statement and fail here,
+    // rather than being silently left on the cursor.
+    let program = parser
+        .parse()
+        .unwrap_or_else(|error| panic!("Failed to parse `{input}`: {error:?}"));
+    let mut statements = program.statements.into_iter();
+    let statement = statements
+        .next()
+        .unwrap_or_else(|| panic!("Expected a statement for `{input}`"));
+    assert!(
+        statements.next().is_none(),
+        "Expected exactly one statement for `{input}`"
+    );
+    match statement {
+        Statement::DisplayStatement { value, .. } => value,
         other => panic!("Expected a DisplayStatement for `{input}`, got: {other:?}"),
     }
 }
@@ -2642,7 +2656,7 @@ fn test_display_folds_keyword_not() {
 
 #[test]
 fn test_display_folds_keyword_pattern() {
-    assert_display_folds(r#"display "p: " pattern "\d+""#, "p: ", |right| {
+    assert_display_folds(r#"display "p: " pattern "abc""#, "p: ", |right| {
         assert!(
             matches!(right, Expression::Literal(Literal::Pattern(_), ..)),
             "expected a Pattern literal, got: {right:?}"
@@ -2707,7 +2721,7 @@ fn test_display_folds_keyword_process_running() {
 #[test]
 fn test_display_folds_keyword_header() {
     assert_display_folds(
-        r#"display "h: " header "Content-Type" of response"#,
+        r#"display "h: " header "Content-Type" of req"#,
         "h: ",
         |right| {
             assert!(

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2759,3 +2759,474 @@ fn test_display_folds_keyword_read_content() {
         },
     );
 }
+
+#[test]
+fn test_display_folds_keyword_back() {
+    // `back` is only reserved after `give` (`give back x`); as a fresh
+    // display value it is an unambiguous bare-variable reference, same as
+    // `not`/`pattern` above (see the `is_value_start` doc comment).
+    assert_display_folds(r#"display "b: " back"#, "b: ", |right| {
+        assert!(
+            matches!(right, Expression::Variable(name, ..) if name == "back"),
+            "expected the `back` variable, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_error() {
+    // `error` is only reserved inside `when error:` (a `try` clause header);
+    // as a fresh display value it is an unambiguous bare-variable reference.
+    assert_display_folds(r#"display "e: " error"#, "e: ", |right| {
+        assert!(
+            matches!(right, Expression::Variable(name, ..) if name == "error"),
+            "expected the `error` variable, got: {right:?}"
+        );
+    });
+}
+
+// --- Same-line statement boundaries: `count from ...` / `read output from process ...` ----
+//
+// `count` and `read` each fold as a bare value (the count-loop variable, and
+// `read content/binary/N bytes from ...`), but each also leads a longer,
+// statement-only form with no expression-position parse of its own:
+// `count from X to Y:` (a count loop) and `read output from process P as V`
+// (`parse_read_process_output_statement`). Both must still parse as their own
+// statement when they immediately follow a `display` on the same line,
+// exactly as they did before multi-value `display` existed, instead of being
+// partially folded into the display and stranding the rest as unparsable
+// leftover tokens. See `is_display_fold_statement_boundary` in
+// `parser/helpers.rs`.
+
+/// Parses `input` as a whole program and returns its statements, panicking
+/// with the parse error otherwise. Unlike `parse_display`, more than one
+/// statement is expected here — these tests are specifically about where one
+/// statement ends and the next begins.
+fn parse_program_statements(input: &str) -> Vec<Statement> {
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+    parser
+        .parse()
+        .unwrap_or_else(|error| panic!("Failed to parse `{input}`: {error:?}"))
+        .statements
+}
+
+#[test]
+fn count_from_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"display "start" count from 1 to 3:
+    display "n: " count
+end count
+"#,
+    );
+
+    assert_eq!(
+        statements.len(),
+        2,
+        "expected exactly 2 statements, got: {statements:?}"
+    );
+
+    match &statements[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `count`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+
+    assert!(
+        matches!(&statements[1], Statement::CountLoop { .. }),
+        "expected `count from ...` to open a count loop, got: {:?}",
+        statements[1]
+    );
+}
+
+#[test]
+fn read_output_from_process_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"display "start" read output from process proc as result
+display "result: " result
+"#,
+    );
+
+    assert_eq!(
+        statements.len(),
+        3,
+        "expected exactly 3 statements, got: {statements:?}"
+    );
+
+    match &statements[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `read`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+
+    assert!(
+        matches!(
+            &statements[1],
+            Statement::ReadProcessOutputStatement { variable_name, .. } if variable_name == "result"
+        ),
+        "expected `read output from process ... as result` to parse as its own statement, got: {:?}",
+        statements[1]
+    );
+
+    assert!(
+        matches!(&statements[2], Statement::DisplayStatement { .. }),
+        "expected the trailing `display \"result: \" result` to parse normally, got: {:?}",
+        statements[2]
+    );
+}
+
+// --- Same-line statement boundaries surfaced by centralizing `is_value_start` ----
+//
+// `create`, `change`, `push`, `parent`, `skip`, and `give` are all contextual
+// keywords (bare variables in expression position) that are *also* dedicated
+// arms of `parse_statement`'s top-level dispatch, with no expression-position
+// equivalent for their statement form (see the `is_value_start` doc comment
+// in `parser/helpers.rs`). Centralizing on `can_start_primary_expression`
+// surfaced these the same way it surfaced `count`/`read`, so each is excluded
+// from `is_value_start` outright; these tests lock that in.
+
+#[test]
+fn create_after_display_stays_a_separate_statement() {
+    let statements =
+        parse_program_statements("display \"start\" create directory at \"wfl-test-dir\"\n");
+
+    assert_eq!(
+        statements.len(),
+        2,
+        "expected exactly 2 statements, got: {statements:?}"
+    );
+    match &statements[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `create`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+    assert!(
+        matches!(&statements[1], Statement::CreateDirectoryStatement { .. }),
+        "expected `create directory at ...` to parse as its own statement, got: {:?}",
+        statements[1]
+    );
+}
+
+#[test]
+fn change_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"store n as 1
+display "start" change n to 2
+"#,
+    );
+
+    assert_eq!(
+        statements.len(),
+        3,
+        "expected exactly 3 statements, got: {statements:?}"
+    );
+    match &statements[1] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `change`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement second, got: {other:?}"),
+    }
+    assert!(
+        matches!(&statements[2], Statement::Assignment { .. }),
+        "expected `change n to 2` to parse as its own assignment statement, got: {:?}",
+        statements[2]
+    );
+}
+
+#[test]
+fn push_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"create list numbers:
+end list
+display "start" push with numbers and 5
+"#,
+    );
+
+    let display_index = statements.len() - 2;
+    match &statements[display_index] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `push`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement, got: {other:?}"),
+    }
+    assert!(
+        matches!(&statements[display_index + 1], Statement::PushStatement { .. }),
+        "expected `push with numbers and 5` to parse as its own statement, got: {:?}",
+        statements[display_index + 1]
+    );
+}
+
+#[test]
+fn parent_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"display "start" parent bump
+"#,
+    );
+
+    assert_eq!(
+        statements.len(),
+        2,
+        "expected exactly 2 statements, got: {statements:?}"
+    );
+    match &statements[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `parent`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+    assert!(
+        matches!(
+            &statements[1],
+            Statement::ParentMethodCall { method_name, .. } if method_name == "bump"
+        ),
+        "expected `parent bump` to parse as its own statement, got: {:?}",
+        statements[1]
+    );
+}
+
+#[test]
+fn skip_after_display_stays_a_continue_statement() {
+    // The sharpest case: as a bare statement, `skip` is `continue` — a
+    // control-flow *effect*, not a value — and both forms consume exactly one
+    // token, so a silent regression here would not even leave stray tokens
+    // behind; it would just quietly stop continuing the loop.
+    let statements = parse_program_statements(
+        r#"display "start" skip
+"#,
+    );
+
+    assert_eq!(
+        statements.len(),
+        2,
+        "expected exactly 2 statements, got: {statements:?}"
+    );
+    match &statements[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `skip`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+    assert!(
+        matches!(&statements[1], Statement::ContinueStatement { .. }),
+        "expected `skip` to still parse as its own ContinueStatement, got: {:?}",
+        statements[1]
+    );
+}
+
+#[test]
+fn give_back_after_display_stays_a_separate_statement() {
+    let statements = parse_program_statements(
+        r#"define action called f:
+    display "start" give back 5
+end action
+"#,
+    );
+
+    let Statement::ActionDefinition { body, .. } = &statements[0] else {
+        panic!("Expected an ActionDefinition, got: {:?}", statements[0]);
+    };
+
+    assert_eq!(
+        body.len(),
+        2,
+        "expected exactly 2 statements in the action body, got: {body:?}"
+    );
+    match &body[0] {
+        Statement::DisplayStatement { value, .. } => {
+            assert!(
+                matches!(value, Expression::Literal(Literal::String(s), ..) if s.as_ref() == "start"),
+                "expected the `display` to stop at the bare string, not fold `give`, got: {value:?}"
+            );
+        }
+        other => panic!("Expected a DisplayStatement first, got: {other:?}"),
+    }
+    assert!(
+        matches!(&body[1], Statement::ReturnStatement { .. }),
+        "expected `give back 5` to parse as its own return statement, got: {:?}",
+        body[1]
+    );
+}
+
+// --- Centralization: `is_value_start` cannot drift from `parse_primary_expression` ----
+
+/// Returns `true` if parsing `input` as a primary expression falls all the
+/// way through to `parse_primary_expression`'s final
+/// `_ => Err("Unexpected token in expression: ...")` arm — i.e. the leading
+/// token has *no* dedicated arm — as opposed to succeeding, or failing with a
+/// different, arm-specific error (e.g. an incomplete but recognized keyword
+/// form). This is a stronger signal than plain `Ok`/`Err`: several arms
+/// return a perfectly valid `Ok` for a bare keyword (`back`, `output`, ...),
+/// while others can still legitimately `Err` without having fallen through
+/// (e.g. `(` with nothing before `)`) — only the fallback's specific message
+/// means "no arm claimed this token".
+fn falls_through_to_primary_expression_fallback(input: &str) -> bool {
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+    match parser.parse_primary_expression() {
+        Ok(_) => false,
+        Err(error) => error.message.contains("Unexpected token in expression"),
+    }
+}
+
+#[test]
+fn can_start_primary_expression_matches_parse_primary_expression() {
+    // One representative snippet per case, covering every explicit
+    // keyword-led arm in `parse_primary_expression`, a broad sample of the
+    // contextual-keyword catch-all (`_ if token.is_contextual_keyword()`),
+    // and a broad sample of tokens with no primary-expression arm at all
+    // (structural keywords/punctuation that only mean something as a
+    // statement or as a continuation of a *preceding* expression). Not
+    // literally exhaustive over all ~190 `Token` variants — that would mostly
+    // test the lexer, not this coupling — but wide enough that adding or
+    // removing a `parse_primary_expression` arm for any of these tokens
+    // without updating `can_start_primary_expression` fails this test.
+    let cases: &[(&str, bool)] = &[
+        // Literals, identifiers, brackets: always a primary starter.
+        ("5", true),
+        ("5.0", true),
+        (r#""s""#, true),
+        ("yes", true),
+        ("nothing", true),
+        ("x", true),
+        ("(5)", true),
+        ("[5]", true),
+        // Explicit keyword-led arms.
+        ("call", true),
+        ("not yes", true),
+        ("-5", true),
+        ("with x", true),
+        ("count", true),
+        ("pattern", true),
+        ("loop", true),
+        ("output", true),
+        ("repeat", true),
+        ("exit", true),
+        ("back", true),
+        ("try", true),
+        ("when", true),
+        ("error", true),
+        ("file", true),
+        ("directory", true),
+        ("process", true),
+        ("header", true),
+        ("current", true),
+        ("list", true),
+        ("read", true),
+        ("find x in y", true),
+        ("replace x with y in z", true),
+        ("split x by y", true),
+        // A sample of the contextual-keyword catch-all: no dedicated arm
+        // above, but `token.is_contextual_keyword()` is true, so a bare
+        // keyword still resolves to a plain variable reference.
+        ("text", true),
+        ("map", true),
+        ("create", true),
+        ("new", true),
+        ("parent", true),
+        ("push", true),
+        ("skip", true),
+        ("give", true),
+        ("called", true),
+        ("needs", true),
+        ("change", true),
+        ("reversed", true),
+        ("at", true),
+        ("least", true),
+        ("most", true),
+        ("than", true),
+        ("zero", true),
+        ("any", true),
+        ("must", true),
+        ("defaults", true),
+        ("binary", true),
+        ("bytes", true),
+        ("that", true),
+        ("files", true),
+        ("extension", true),
+        ("extensions", true),
+        ("contains", true),
+        ("starts", true),
+        ("ends", true),
+        // Structural keywords and punctuation with no primary-expression arm:
+        // only meaningful as a statement starter or as a continuation
+        // consumed by an already-parsed left operand.
+        ("store", false),
+        ("display", false),
+        ("check", false),
+        ("if", false),
+        ("for", false),
+        ("define", false),
+        ("action", false),
+        ("end", false),
+        ("otherwise", false),
+        ("then", false),
+        ("as", false),
+        ("to", false),
+        ("from", false),
+        ("and", false),
+        ("or", false),
+        ("in", false),
+        ("while", false),
+        ("until", false),
+        ("forever", false),
+        ("break", false),
+        ("continue", false),
+        ("return", false),
+        (":", false),
+        (",", false),
+    ];
+
+    for (input, expected) in cases {
+        let tokens = lex_wfl_with_positions(input);
+        let leading_token = tokens
+            .first()
+            .unwrap_or_else(|| panic!("`{input}` lexed to no tokens"));
+        let predicted = Parser::can_start_primary_expression(&leading_token.token);
+        assert_eq!(
+            predicted, *expected,
+            "can_start_primary_expression(`{input}`) predicted {predicted}, expected {expected}"
+        );
+
+        if *expected {
+            assert!(
+                !falls_through_to_primary_expression_fallback(input),
+                "`{input}` is predicted to start a primary expression, but \
+                 parse_primary_expression fell through to its fallback arm — \
+                 can_start_primary_expression has drifted from \
+                 parse_primary_expression"
+            );
+        } else {
+            assert!(
+                falls_through_to_primary_expression_fallback(input),
+                "`{input}` is predicted NOT to start a primary expression, but \
+                 parse_primary_expression accepted it (or failed with a \
+                 different, arm-specific error) — can_start_primary_expression \
+                 has drifted from parse_primary_expression"
+            );
+        }
+    }
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2968,7 +2968,10 @@ display "start" push with numbers and 5
         other => panic!("Expected a DisplayStatement, got: {other:?}"),
     }
     assert!(
-        matches!(&statements[display_index + 1], Statement::PushStatement { .. }),
+        matches!(
+            &statements[display_index + 1],
+            Statement::PushStatement { .. }
+        ),
         "expected `push with numbers and 5` to parse as its own statement, got: {:?}",
         statements[display_index + 1]
     );
@@ -3072,6 +3075,15 @@ end action
 }
 
 // --- Centralization: `is_value_start` cannot drift from `parse_primary_expression` ----
+//
+// The primary enforcement is a pair of `debug_assert!`s inside
+// `parse_primary_expression` itself (`src/parser/expr/primary.rs`), which
+// compare `can_start_primary_expression`'s prediction against the real
+// dispatch on *every* primary-expression parse in every debug build — every
+// test below, every `TestPrograms/*.wfl` run, every program compiled without
+// `--release`. The test in this section is a curated, documented sample
+// kept for explicit coverage of each keyword-led arm, not the only thing
+// standing between the two staying in sync.
 
 /// Returns `true` if parsing `input` as a primary expression falls all the
 /// way through to `parse_primary_expression`'s final

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2298,8 +2298,11 @@ fn normal_pattern_quantifier_counts_remain_compatible() {
 // string literal, anything else is a variable/expression, and the values are
 // folded right-associatively into a single Concatenation — the same AST shape
 // (and therefore the same evaluation order and stringification order) as
-// joining them explicitly with `with` (`display a b c` parses identically to
-// `display a with b with c`). See parse_display_statement in stmt/io.rs.
+// joining them explicitly with `with` (`display "x" y "z"` parses identically
+// to `display "x" with y with "z"`; a run of bare words with no separator lexes
+// as one multi-word identifier, not several values, so an example needs a
+// non-identifier token to actually show the fold). See parse_display_statement
+// in stmt/io.rs.
 
 #[test]
 fn test_display_multiple_values_string_then_var() {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2291,3 +2291,203 @@ fn normal_pattern_quantifier_counts_remain_compatible() {
         assert_eq!(quantifier, expected_quantifier, "body: `{body}`");
     }
 }
+
+// --- Multi-value `display` (concatenation of space-separated values) ---
+//
+// `display` accepts more than one space-separated value: quoted text is a
+// string literal, anything else is a variable/expression, and the values are
+// folded into a single left-associative Concatenation (identical semantics to
+// joining them with `with`). See parse_display_statement in stmt/io.rs.
+
+#[test]
+fn test_display_multiple_values_string_then_var() {
+    let input = r#"display "user age is " user age"#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse multi-value display: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected Concatenation, got: {value:?}");
+    };
+    match *left {
+        Expression::Literal(Literal::String(ref s), ..) => {
+            assert_eq!(
+                s.as_ref(),
+                "user age is ",
+                "left should be the string literal"
+            )
+        }
+        other => panic!("Expected string literal on left, got: {other:?}"),
+    }
+    match *right {
+        Expression::Variable(ref name, ..) => {
+            assert_eq!(name, "user age", "right should be the variable 'user age'")
+        }
+        other => panic!("Expected variable on right, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_display_multiple_values_var_then_string() {
+    let input = r#"display user age " is the age""#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse multi-value display: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected Concatenation, got: {value:?}");
+    };
+    match *left {
+        Expression::Variable(ref name, ..) => {
+            assert_eq!(name, "user age", "left should be the variable 'user age'")
+        }
+        other => panic!("Expected variable on left, got: {other:?}"),
+    }
+    match *right {
+        Expression::Literal(Literal::String(ref s), ..) => {
+            assert_eq!(
+                s.as_ref(),
+                " is the age",
+                "right should be the string literal"
+            )
+        }
+        other => panic!("Expected string literal on right, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_display_three_values_left_associative() {
+    let input = r#"display "a" middle "b""#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse three-value display: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    // Left-associative: (("a" with middle) with "b")
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected outer Concatenation, got: {value:?}");
+    };
+    match *right {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "b"),
+        other => panic!("Expected string 'b' on outer right, got: {other:?}"),
+    }
+    let Expression::Concatenation {
+        left: inner_left,
+        right: inner_right,
+        ..
+    } = *left
+    else {
+        panic!("Expected inner Concatenation on left");
+    };
+    match *inner_left {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "a"),
+        other => panic!("Expected string 'a' on inner left, got: {other:?}"),
+    }
+    match *inner_right {
+        Expression::Variable(ref name, ..) => assert_eq!(name, "middle"),
+        other => panic!("Expected variable 'middle' on inner right, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_display_direct_index_not_concatenated() {
+    // Regression: `display numbers 0` must stay a single IndexAccess, NOT
+    // become a concatenation of `numbers` and `0`.
+    let input = r#"display numbers 0"#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse direct index display: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    assert!(
+        matches!(value, Expression::IndexAccess { .. }),
+        "Expected IndexAccess, got: {value:?}"
+    );
+}
+
+#[test]
+fn test_display_single_value_unchanged() {
+    // Regression: a single value is still a bare expression, not a Concatenation.
+    let input = r#"display user age"#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse single-value display: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    match value {
+        Expression::Variable(ref name, ..) => assert_eq!(name, "user age"),
+        other => panic!("Expected bare Variable, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_display_multiple_values_does_not_leak_into_next_statement() {
+    // The trailing value must be consumed by `display`, leaving the following
+    // statement (here `change`) to parse normally on the next line.
+    let input = "display \"user age is \" user age\nchange user age to 9";
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let program = parser
+        .parse()
+        .unwrap_or_else(|errors| panic!("Expected the program to parse: {errors:?}"));
+    assert_eq!(
+        program.statements.len(),
+        2,
+        "Expected exactly two statements, got: {:?}",
+        program.statements
+    );
+    assert!(
+        matches!(
+            program.statements[0],
+            Statement::DisplayStatement {
+                value: Expression::Concatenation { .. },
+                ..
+            }
+        ),
+        "Expected a Concatenation DisplayStatement, got: {:?}",
+        program.statements[0]
+    );
+    assert!(
+        matches!(program.statements[1], Statement::Assignment { .. }),
+        "Expected the following `change` to parse as an Assignment, got: {:?}",
+        program.statements[1]
+    );
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2491,3 +2491,64 @@ fn test_display_multiple_values_does_not_leak_into_next_statement() {
         program.statements[1]
     );
 }
+
+#[test]
+fn test_display_folds_count_variable() {
+    // Regression for the review finding: the count-loop variable `count` is a
+    // keyword, so it must still fold as a trailing display value instead of
+    // being mis-parsed as the start of a new count loop.
+    let input = r#"display "count is " count"#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse display with folded count: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected Concatenation, got: {value:?}");
+    };
+    match *left {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "count is "),
+        other => panic!("Expected string literal on left, got: {other:?}"),
+    }
+    match *right {
+        Expression::Variable(ref name, ..) => assert_eq!(name, "count"),
+        other => panic!("Expected the `count` variable on right, got: {other:?}"),
+    }
+}
+
+#[test]
+fn test_display_folds_call_action() {
+    // Regression for the review finding: `call <action>` is a keyword-led value
+    // and must fold as a trailing display value rather than being dropped.
+    let input = r#"display "n: " call doubled with 5"#;
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+
+    let result = parser.parse_statement();
+    assert!(
+        result.is_ok(),
+        "Failed to parse display with folded call: {result:?}"
+    );
+
+    let Ok(Statement::DisplayStatement { value, .. }) = result else {
+        panic!("Expected DisplayStatement, got: {result:?}");
+    };
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected Concatenation, got: {value:?}");
+    };
+    match *left {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "n: "),
+        other => panic!("Expected string literal on left, got: {other:?}"),
+    }
+    match *right {
+        Expression::ActionCall { ref name, .. } => assert_eq!(name, "doubled"),
+        other => panic!("Expected an ActionCall on right, got: {other:?}"),
+    }
+}

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2296,8 +2296,10 @@ fn normal_pattern_quantifier_counts_remain_compatible() {
 //
 // `display` accepts more than one space-separated value: quoted text is a
 // string literal, anything else is a variable/expression, and the values are
-// folded into a single left-associative Concatenation (identical semantics to
-// joining them with `with`). See parse_display_statement in stmt/io.rs.
+// folded right-associatively into a single Concatenation — the same AST shape
+// (and therefore the same evaluation order and stringification order) as
+// joining them explicitly with `with` (`display a b c` parses identically to
+// `display a with b with c`). See parse_display_statement in stmt/io.rs.
 
 #[test]
 fn test_display_multiple_values_string_then_var() {
@@ -2372,7 +2374,7 @@ fn test_display_multiple_values_var_then_string() {
 }
 
 #[test]
-fn test_display_three_values_left_associative() {
+fn test_display_three_values_right_associative_like_with() {
     let input = r#"display "a" middle "b""#;
     let tokens = lex_wfl_with_positions(input);
     let mut parser = Parser::new(&tokens);
@@ -2386,30 +2388,66 @@ fn test_display_three_values_left_associative() {
     let Ok(Statement::DisplayStatement { value, .. }) = result else {
         panic!("Expected DisplayStatement, got: {result:?}");
     };
-    // Left-associative: (("a" with middle) with "b")
+    // Right-associative, matching `"a" with middle with "b"`: ("a" with (middle with "b"))
     let Expression::Concatenation { left, right, .. } = value else {
         panic!("Expected outer Concatenation, got: {value:?}");
     };
-    match *right {
-        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "b"),
-        other => panic!("Expected string 'b' on outer right, got: {other:?}"),
+    match *left {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "a"),
+        other => panic!("Expected string 'a' on outer left, got: {other:?}"),
     }
     let Expression::Concatenation {
         left: inner_left,
         right: inner_right,
         ..
-    } = *left
+    } = *right
     else {
-        panic!("Expected inner Concatenation on left");
+        panic!("Expected inner Concatenation on right");
     };
     match *inner_left {
-        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "a"),
-        other => panic!("Expected string 'a' on inner left, got: {other:?}"),
+        Expression::Variable(ref name, ..) => assert_eq!(name, "middle"),
+        other => panic!("Expected variable 'middle' on inner left, got: {other:?}"),
     }
     match *inner_right {
-        Expression::Variable(ref name, ..) => assert_eq!(name, "middle"),
-        other => panic!("Expected variable 'middle' on inner right, got: {other:?}"),
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), "b"),
+        other => panic!("Expected string 'b' on inner right, got: {other:?}"),
     }
+}
+
+#[test]
+fn test_display_four_values_right_associative_nesting() {
+    // Four values must nest the same way a `with` chain does: right-associative,
+    // all the way down — (a with (b with (c with d))) — not just pairwise at
+    // the top level. This is what makes evaluation order (and therefore
+    // stringification order for mutating expressions) match `with` exactly.
+    // See the mutation-order regression in
+    // tests/display_multiple_values_stdout_test.rs for the runtime consequence.
+    fn as_str_literal(expr: &Expression) -> &str {
+        match expr {
+            Expression::Literal(Literal::String(s), ..) => s.as_ref(),
+            other => panic!("expected a string literal, got: {other:?}"),
+        }
+    }
+    fn as_concatenation(expr: &Expression) -> (&Expression, &Expression) {
+        match expr {
+            Expression::Concatenation { left, right, .. } => (&**left, &**right),
+            other => panic!("expected Concatenation, got: {other:?}"),
+        }
+    }
+
+    let tokens = lex_wfl_with_positions(r#"display "a" "b" "c" "d""#);
+    let mut parser = Parser::new(&tokens);
+    let Ok(Statement::DisplayStatement { value, .. }) = parser.parse_statement() else {
+        panic!("expected a DisplayStatement");
+    };
+
+    let (a, rest1) = as_concatenation(&value);
+    assert_eq!(as_str_literal(a), "a");
+    let (b, rest2) = as_concatenation(rest1);
+    assert_eq!(as_str_literal(b), "b");
+    let (c, d) = as_concatenation(rest2);
+    assert_eq!(as_str_literal(c), "c");
+    assert_eq!(as_str_literal(d), "d");
 }
 
 #[test]
@@ -2551,4 +2589,147 @@ fn test_display_folds_call_action() {
         Expression::ActionCall { ref name, .. } => assert_eq!(name, "doubled"),
         other => panic!("Expected an ActionCall on right, got: {other:?}"),
     }
+}
+
+/// Parses `input` as a single `display` statement and returns its value
+/// expression, panicking with the parse error (or the wrong statement kind)
+/// otherwise. Shared by the `test_display_folds_keyword_*` tests below.
+fn parse_display(input: &str) -> Expression {
+    let tokens = lex_wfl_with_positions(input);
+    let mut parser = Parser::new(&tokens);
+    match parser.parse_statement() {
+        Ok(Statement::DisplayStatement { value, .. }) => value,
+        other => panic!("Expected a DisplayStatement for `{input}`, got: {other:?}"),
+    }
+}
+
+/// Asserts `input` parses as `display "<label>" <trailing>` folded into a
+/// Concatenation whose left is the label string and whose right satisfies
+/// `check_right`.
+fn assert_display_folds(input: &str, label: &str, check_right: impl FnOnce(&Expression)) {
+    let value = parse_display(input);
+    let Expression::Concatenation { left, right, .. } = value else {
+        panic!("Expected Concatenation for `{input}`, got: {value:?}");
+    };
+    match *left {
+        Expression::Literal(Literal::String(ref s), ..) => assert_eq!(s.as_ref(), label),
+        other => panic!("Expected string literal '{label}' on left, got: {other:?}"),
+    }
+    check_right(&right);
+}
+
+// The following regression tests cover each keyword-led value added to
+// `is_value_start` beyond `call`/`count`/`current` (see the doc comment on
+// `is_value_start` in parser/helpers.rs for why each is safe): every one must
+// still fold into the display's Concatenation instead of being left as a
+// dangling, separately-parsed (and likely erroring) trailing statement.
+
+#[test]
+fn test_display_folds_keyword_not() {
+    assert_display_folds(r#"display "flag: " not yes"#, "flag: ", |right| {
+        assert!(
+            matches!(
+                right,
+                Expression::UnaryOperation {
+                    operator: UnaryOperator::Not,
+                    ..
+                }
+            ),
+            "expected a `not` UnaryOperation, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_pattern() {
+    assert_display_folds(r#"display "p: " pattern "\d+""#, "p: ", |right| {
+        assert!(
+            matches!(right, Expression::Literal(Literal::Pattern(_), ..)),
+            "expected a Pattern literal, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_output() {
+    // `output` is a contextual keyword: in expression position (not preceded
+    // by `read ... from process`) it is just the variable named `output`.
+    assert_display_folds(r#"display "o: " output"#, "o: ", |right| {
+        assert!(
+            matches!(right, Expression::Variable(name, ..) if name == "output"),
+            "expected the `output` variable, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_file_exists() {
+    assert_display_folds(r#"display "exists: " file exists at "x.txt""#, "exists: ", |right| {
+        assert!(
+            matches!(right, Expression::FileExists { .. }),
+            "expected a FileExists expression, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_directory_exists() {
+    assert_display_folds(
+        r#"display "exists: " directory exists at "x""#,
+        "exists: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::DirectoryExists { .. }),
+                "expected a DirectoryExists expression, got: {right:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_display_folds_keyword_process_running() {
+    assert_display_folds(r#"display "running: " process pid is running"#, "running: ", |right| {
+        assert!(
+            matches!(right, Expression::ProcessRunning { .. }),
+            "expected a ProcessRunning expression, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_header() {
+    assert_display_folds(
+        r#"display "h: " header "Content-Type" of response"#,
+        "h: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::HeaderAccess { .. }),
+                "expected a HeaderAccess expression, got: {right:?}"
+            );
+        },
+    );
+}
+
+#[test]
+fn test_display_folds_keyword_list_files() {
+    assert_display_folds(r#"display "files: " list files in ".""#, "files: ", |right| {
+        assert!(
+            matches!(right, Expression::ListFiles { .. }),
+            "expected a ListFiles expression, got: {right:?}"
+        );
+    });
+}
+
+#[test]
+fn test_display_folds_keyword_read_content() {
+    assert_display_folds(
+        r#"display "content: " read content from handle"#,
+        "content: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::ReadContent { .. }),
+                "expected a ReadContent expression, got: {right:?}"
+            );
+        },
+    );
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -2664,12 +2664,16 @@ fn test_display_folds_keyword_output() {
 
 #[test]
 fn test_display_folds_keyword_file_exists() {
-    assert_display_folds(r#"display "exists: " file exists at "x.txt""#, "exists: ", |right| {
-        assert!(
-            matches!(right, Expression::FileExists { .. }),
-            "expected a FileExists expression, got: {right:?}"
-        );
-    });
+    assert_display_folds(
+        r#"display "exists: " file exists at "x.txt""#,
+        "exists: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::FileExists { .. }),
+                "expected a FileExists expression, got: {right:?}"
+            );
+        },
+    );
 }
 
 #[test]
@@ -2688,12 +2692,16 @@ fn test_display_folds_keyword_directory_exists() {
 
 #[test]
 fn test_display_folds_keyword_process_running() {
-    assert_display_folds(r#"display "running: " process pid is running"#, "running: ", |right| {
-        assert!(
-            matches!(right, Expression::ProcessRunning { .. }),
-            "expected a ProcessRunning expression, got: {right:?}"
-        );
-    });
+    assert_display_folds(
+        r#"display "running: " process pid is running"#,
+        "running: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::ProcessRunning { .. }),
+                "expected a ProcessRunning expression, got: {right:?}"
+            );
+        },
+    );
 }
 
 #[test]
@@ -2712,12 +2720,16 @@ fn test_display_folds_keyword_header() {
 
 #[test]
 fn test_display_folds_keyword_list_files() {
-    assert_display_folds(r#"display "files: " list files in ".""#, "files: ", |right| {
-        assert!(
-            matches!(right, Expression::ListFiles { .. }),
-            "expected a ListFiles expression, got: {right:?}"
-        );
-    });
+    assert_display_folds(
+        r#"display "files: " list files in ".""#,
+        "files: ",
+        |right| {
+            assert!(
+                matches!(right, Expression::ListFiles { .. }),
+                "expected a ListFiles expression, got: {right:?}"
+            );
+        },
+    );
 }
 
 #[test]

--- a/tests/display_multiple_values_stdout_test.rs
+++ b/tests/display_multiple_values_stdout_test.rs
@@ -13,24 +13,16 @@
 //! `mutable_list_matches_with_byte_for_byte` below). These tests run the
 //! actual `wfl` binary end-to-end and assert exact stdout.
 
-use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
-
 mod test_helpers;
 
 /// Runs `program` as a temporary `.wfl` file and returns its stdout as a
 /// `String`, panicking with stderr if the process didn't exit successfully.
+///
+/// Delegates to `test_helpers::run_wfl_program`, which runs the `wfl` binary
+/// under a 30-second timeout (so a regression that stalls the interpreter fails
+/// the test instead of hanging CI) and cleans up the temporary script.
 fn run_wfl(program: &str) -> String {
-    let binary = test_helpers::get_wfl_binary_path();
-    let dir = tempfile::tempdir().expect("create temp dir");
-    let script: PathBuf = dir.path().join("program.wfl");
-    fs::write(&script, program).expect("write program");
-
-    let output = Command::new(binary)
-        .arg(&script)
-        .output()
-        .expect("run wfl binary");
+    let output = test_helpers::run_wfl_program(program, "display_multiple_values_stdout");
 
     assert!(
         output.status.success(),
@@ -141,7 +133,7 @@ create container Counter:
         change value to value plus 1
     end
 
-    action describe: Text
+    action summarize: Text
         return "Counter(" with value with ")"
     end
 end
@@ -151,7 +143,7 @@ create new Counter as c:
 end
 
 c.bump()
-display "instance: " c " value: " c.value " desc: " c.describe()
+display "instance: " c " value: " c.value " desc: " c.summarize()
 "#,
     );
     assert_eq!(

--- a/tests/display_multiple_values_stdout_test.rs
+++ b/tests/display_multiple_values_stdout_test.rs
@@ -227,18 +227,55 @@ display basket.items {connector} "" {connector} pop of basket.items
 
 #[test]
 fn keyword_led_values_fold_with_exact_output() {
-    let stdout = run_wfl(
+    // A unique absolute path under the OS temp dir, guaranteed not to exist
+    // (nothing ever creates it) and independent of the test's working
+    // directory or any files a developer happens to have lying around in the
+    // repo root.
+    let missing_path = test_helpers::get_unique_test_file_path(
+        "display_multiple_values_stdout_does_not_exist",
+    )
+    .with_extension("missing");
+    let missing_path = missing_path.to_str().expect("path should be valid UTF-8");
+
+    let stdout = run_wfl(&format!(
         r#"
 store is_admin as no
 display "is admin: " not is_admin
-display "exists: " file exists at "does-not-exist-for-sure.txt"
+display "exists: " file exists at "{missing_path}"
 count from 1 to 3:
     display "count is " count
 end count
-"#,
-    );
+"#
+    ));
     assert_eq!(
         stdout,
         "is admin: yes\nexists: no\ncount is 1\ncount is 2\ncount is 3\n"
     );
 }
+
+// --- Same-line statement boundaries: `count from ...` / `read output from process ...` ----
+
+#[test]
+fn count_from_after_display_on_same_line_stays_a_separate_statement() {
+    // `count` alone folds into `display` as the count-loop variable (see
+    // `keyword_led_values_fold_with_exact_output`), but `count from ...` on
+    // the *same line* as a preceding `display` must still open a count loop,
+    // exactly as it did before multi-value `display` existed — not get
+    // partially folded into the display and leave `from 1 to 3:` stranded.
+    let stdout = run_wfl(
+        r#"
+display "start" count from 1 to 3:
+    display "n: " count
+end count
+"#,
+    );
+    assert_eq!(stdout, "start\nn: 1\nn: 2\nn: 3\n");
+}
+
+// `read output from process ...` after a same-line `display` is covered as a
+// parser-level whole-program regression instead of here
+// (`read_output_from_process_after_display_stays_a_separate_statement` in
+// `src/parser/tests.rs`): it needs a real subprocess and a `wait for` to
+// exercise end-to-end, which would make this suite timing-dependent for a
+// case that's purely about statement *boundaries* — the AST shape settles the
+// question without needing to actually run a process.

--- a/tests/display_multiple_values_stdout_test.rs
+++ b/tests/display_multiple_values_stdout_test.rs
@@ -231,17 +231,24 @@ fn keyword_led_values_fold_with_exact_output() {
     // (nothing ever creates it) and independent of the test's working
     // directory or any files a developer happens to have lying around in the
     // repo root.
-    let missing_path = test_helpers::get_unique_test_file_path(
-        "display_multiple_values_stdout_does_not_exist",
-    )
-    .with_extension("missing");
+    let missing_path =
+        test_helpers::get_unique_test_file_path("display_multiple_values_stdout_does_not_exist")
+            .with_extension("missing");
     let missing_path = missing_path.to_str().expect("path should be valid UTF-8");
+    // WFL string literals only recognize `\n`, `\t`, `\r`, `\\`, `\0`, and `\"`
+    // as escapes (see `parse_string` in `src/lexer/token.rs`); anything else
+    // after a backslash is a lex error. On Windows, `missing_path` is an
+    // absolute path with `\`-separated components (e.g. `C:\Users\...\Temp\...`),
+    // so embedding it verbatim in a string literal below would frequently hit
+    // an invalid escape (`\U`, `\T`, ...) and fail to lex. Escape each `\` as
+    // `\\` so the embedded literal round-trips to the exact same path.
+    let missing_path_escaped = missing_path.replace('\\', "\\\\");
 
     let stdout = run_wfl(&format!(
         r#"
 store is_admin as no
 display "is admin: " not is_admin
-display "exists: " file exists at "{missing_path}"
+display "exists: " file exists at "{missing_path_escaped}"
 count from 1 to 3:
     display "count is " count
 end count

--- a/tests/display_multiple_values_stdout_test.rs
+++ b/tests/display_multiple_values_stdout_test.rs
@@ -1,0 +1,252 @@
+//! Exact-stdout regression coverage for multi-value `display` (space-separated
+//! values folded into a `Concatenation`, see `parse_display_statement` in
+//! `src/parser/stmt/io.rs`).
+//!
+//! Prior coverage for this feature only checked AST shape (parser unit tests
+//! in `src/parser/tests.rs`) or exit code (`TestPrograms/*.wfl` under the CI
+//! runner, which redirects stdout to `/dev/null`). Neither would have caught
+//! the mutation-order bug fixed alongside this file: the first cut folded
+//! space-separated `display` values left-associatively, while explicit `with`
+//! folds right-associatively, and `Concatenation` evaluates+stringifies left
+//! before right — so the two forms could observably diverge whenever a later
+//! value mutated something an earlier value referenced (see
+//! `mutable_list_matches_with_byte_for_byte` below). These tests run the
+//! actual `wfl` binary end-to-end and assert exact stdout.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+mod test_helpers;
+
+/// Runs `program` as a temporary `.wfl` file and returns its stdout as a
+/// `String`, panicking with stderr if the process didn't exit successfully.
+fn run_wfl(program: &str) -> String {
+    let binary = test_helpers::get_wfl_binary_path();
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let script: PathBuf = dir.path().join("program.wfl");
+    fs::write(&script, program).expect("write program");
+
+    let output = Command::new(binary)
+        .arg(&script)
+        .output()
+        .expect("run wfl binary");
+
+    assert!(
+        output.status.success(),
+        "program did not exit successfully.\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("stdout should be valid UTF-8")
+}
+
+// --- Documented happy paths -------------------------------------------------
+
+#[test]
+fn documented_happy_path_matches_hello_world_docs() {
+    // Docs/02-getting-started/hello-world.md, "Display Several Values at Once".
+    let stdout = run_wfl(
+        r#"
+store name as "Alice"
+display "Hello, " name "!"
+"#,
+    );
+    assert_eq!(stdout, "Hello, Alice!\n");
+}
+
+#[test]
+fn documented_spacing_examples_match_docs_exactly() {
+    // Same doc section: spacing comes only from inside the quotes.
+    let stdout = run_wfl(
+        r#"
+store age as 25
+display "I am " age " years old"
+display "I am" age "years old"
+"#,
+    );
+    assert_eq!(stdout, "I am 25 years old\nI am25years old\n");
+}
+
+#[test]
+fn original_bug_report_now_prints_every_value() {
+    // The report this feature fixes: trailing values were silently dropped.
+    let stdout = run_wfl(
+        r#"
+store user_age as 28
+display "user age is " user_age
+change user_age to 9
+display "user age is " user_age
+"#,
+    );
+    assert_eq!(stdout, "user age is 28\nuser age is 9\n");
+}
+
+// --- Action return values, arguments, and side effects ----------------------
+
+#[test]
+fn action_return_value_folds_into_display() {
+    let stdout = run_wfl(
+        r#"
+define action called doubled with n:
+    give back n times 2
+end action
+display "doubled: " call doubled with 21
+"#,
+    );
+    assert_eq!(stdout, "doubled: 42\n");
+}
+
+#[test]
+fn action_with_multiple_arguments_folds_into_display() {
+    let stdout = run_wfl(
+        r#"
+define action called greeting with parameters person_name and times_of_day:
+    give back "Good " with times_of_day with ", " with person_name
+end action
+display "greeting: " call greeting with "Bob" and "morning"
+"#,
+    );
+    assert_eq!(stdout, "greeting: Good morning, Bob\n");
+}
+
+#[test]
+fn action_with_side_effect_runs_in_display_order() {
+    // Each call must both mutate state and interpolate its return value in
+    // the order it appears, left to right across the whole display statement.
+    let stdout = run_wfl(
+        r#"
+store counter as 0
+define action called increment:
+    change counter to counter plus 1
+    give back counter
+end action
+display "first: " call increment " second: " call increment " third: " call increment
+"#,
+    );
+    assert_eq!(stdout, "first: 1 second: 2 third: 3\n");
+}
+
+// --- Containers: instance, property, and method -----------------------------
+
+#[test]
+fn container_instance_property_and_method_all_fold() {
+    let stdout = run_wfl(
+        r#"
+create container Counter:
+    property value: Number
+
+    action bump:
+        change value to value plus 1
+    end
+
+    action describe: Text
+        return "Counter(" with value with ")"
+    end
+end
+
+create new Counter as c:
+    value is 5
+end
+
+c.bump()
+display "instance: " c " value: " c.value " desc: " c.describe()
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "instance: Counter instance value: 6 desc: Counter(6)\n"
+    );
+}
+
+// --- Mutable list/container state: byte-for-byte equivalence with `with` ----
+
+#[test]
+fn mutable_list_matches_with_byte_for_byte() {
+    // This is the central regression: space-separated `display` and explicit
+    // `with` must be indistinguishable, including when a later value mutates
+    // something an earlier value references. `Concatenation` evaluates left,
+    // then right, then stringifies both — so association direction decides
+    // whether the list is stringified before or after the `pop` runs. Both
+    // forms below are now right-associative (`a with (b with c)`), so `pop`
+    // always runs first and both print the post-pop list.
+    let with_form = run_wfl(
+        r#"
+create list right_items:
+    add "before"
+    add "after"
+end list
+display right_items with "" with pop of right_items
+"#,
+    );
+    let space_separated_form = run_wfl(
+        r#"
+create list left_items:
+    add "before"
+    add "after"
+end list
+display left_items "" pop of left_items
+"#,
+    );
+
+    assert_eq!(with_form, "[before]after\n");
+    assert_eq!(
+        space_separated_form, with_form,
+        "space-separated display must byte-for-byte match the equivalent `with` chain"
+    );
+}
+
+#[test]
+fn mutable_container_property_matches_with_byte_for_byte() {
+    // Same evaluation-order guarantee as `mutable_list_matches_with_byte_for_byte`,
+    // exercised on a list held in a container *property* (accessed via
+    // `basket.items`) instead of a plain variable, since a container property
+    // is looked up through a separate code path (`Expression::PropertyAccess`
+    // in the interpreter) that also has to get the association direction
+    // right for its `Rc`-shared `Value::List` to alias correctly.
+    let program = |connector: &str| {
+        format!(
+            r#"
+create container Basket:
+    property items
+end
+
+create new Basket as basket:
+    items is ["before", "after"]
+end
+
+display basket.items {connector} "" {connector} pop of basket.items
+"#
+        )
+    };
+
+    let with_form = run_wfl(&program("with"));
+    let space_separated_form = run_wfl(&program(""));
+
+    assert_eq!(with_form, "[before]after\n");
+    assert_eq!(
+        space_separated_form, with_form,
+        "space-separated display must byte-for-byte match the equivalent `with` chain"
+    );
+}
+
+// --- Newly-supported keyword-led values --------------------------------------
+
+#[test]
+fn keyword_led_values_fold_with_exact_output() {
+    let stdout = run_wfl(
+        r#"
+store is_admin as no
+display "is admin: " not is_admin
+display "exists: " file exists at "does-not-exist-for-sure.txt"
+count from 1 to 3:
+    display "count is " count
+end count
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "is admin: yes\nexists: no\ncount is 1\ncount is 2\ncount is 3\n"
+    );
+}


### PR DESCRIPTION
## Summary

The `display` statement now accepts multiple space-separated values, folding them into a single left-associative concatenation. This resolves a usability issue where trailing values were silently dropped, and aligns with the natural-language principle that users expect `display "label" value` to work intuitively.

## Changes

### Parser (`src/parser/stmt/io.rs`)
- Refactored `parse_display_statement` to:
  - Anchor the statement at the `display` keyword itself (preserving line/column info)
  - Parse the first value with the full expression parser
  - Loop while the next token is a value-start (string/int/float/bool/nothing literals, identifiers, or `(`), folding each additional value into a left-associative `Concatenation`
  - Removed 163 lines of repetitive pattern-matching boilerplate that extracted line/column from every expression variant
- Added `Parser::is_value_start` helper (`src/parser/helpers.rs`) to identify tokens that begin a fresh value, ensuring:
  - Direct index access (`display numbers 0`) remains a single `IndexAccess` (the `0` is absorbed by the first expression)
  - Line breaks terminate the statement (`Eol` is not a value-start)
  - Single values are not wrapped in a `Concatenation`

### Backward Compatibility
- **No breaking changes:** Programs that previously worked continue to work identically
- **Silent bugs fixed:** Only programs that were already broken (silently dropping trailing values) have their behavior corrected
- Index access, line breaks, and single-value displays all remain unchanged

### Documentation & Examples
- **User guide** (`Docs/02-getting-started/hello-world.md`): Added "Display Several Values at Once" section with examples and a tip comparing space-separated and `with` forms
- **Test program** (`TestPrograms/display_multiple_values.wfl`): Comprehensive example covering the original report, `with` equivalence, mixed values, expressions, index access, and conditional blocks
- **Manifest-tracked example** (`TestPrograms/docs_examples/basic_syntax/display_multiple_01.wfl`): 5-layer validated backing the new docs section

### Tests
- **Parser unit tests** (`src/parser/tests.rs`): 5 new tests covering:
  - String then variable
  - Variable then string
  - Three-value left-associative fold
  - Index-access regression (ensures `display numbers 0` stays a single value)
  - Single-value regression (ensures no unnecessary `Concatenation` wrapper)
  - Statement boundary test (ensures the following statement parses correctly)

### Dev Diary
- Added `Dev diary/2026-07-18-display-multiple-values.md` documenting the bug report, root cause, implementation rationale, backward compatibility, spacing semantics, and test coverage

## Implementation Details

The fold uses the same semantics as `with` — values are joined directly with no separator inserted. Spaces come from the quotes: `display "I am " age " years old"` produces `I am 25 years old`. This upholds the **No-Unlearning Invariant**: the space-separated form and the `with` form are the same form, with nothing to unlearn.

The implementation is conservative: only tokens that clearly begin a value trigger the fold. Operators, keywords, and statement boundaries do not, preserving existing behavior for edge cases and keeping the language predictable.

https://claude.ai/code/session_01KUmoGX1Eyt6H1BcXKg34Vu
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `display` now accepts multiple space-separated values in one statement, desugaring like chained `with` (including keyword-led value forms such as `call`, `count from`, `not`, and file/directory/process/header/list/read constructs) with right-associative folding.
* **Bug Fixes**
  * Fixed same-line parsing so trailing values aren’t dropped; statement/line boundaries are respected, and direct index access (e.g., `scores 0`) remains a single value.
  * Prevents `display ... count/read ...` patterns from being incorrectly folded.
* **Documentation**
  * Added getting-started guidance and executable examples for multi-value `display` and spacing rules (no added spaces; spaces come from quoted text).
* **Tests**
  * Added parser and exact-stdout regression coverage (including `display` vs `with` equivalence) plus a new test program.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->