### PR TITLE
Fix concurrent handler isolation for #642 (capture, modules, streams, depth)

### DIFF
--- a/Dev diary/2026-07-25-issue-642-remaining-blockers.md
+++ b/Dev diary/2026-07-25-issue-642-remaining-blockers.md
@@ -1,0 +1,124 @@
+# Issue #642 — remaining lifecycle, concurrency, and compatibility blockers
+
+**Date:** 2026-07-25
+**Scope:** the items left open by the #642 re-review of the merged #641 head
+(`690be0af`, merged as `62a1b30`): four release-blockers for concurrent web
+serving plus the follow-up correctness/compatibility list.
+
+Every behavioral change below landed as a Red test-only commit (asserting the
+defect at base `62a1b30`) followed by its Green fix, per the root testing
+policy (§6.2 evidence path 1). Red/Green pairs are noted inline.
+
+> Note: the branch history was rewritten once before push (committer-identity
+> fix only; file contents unchanged, Red→Green ordering preserved). The hashes
+> in THIS document are the pushed, post-rewrite hashes — commit messages that
+> say "red at <hash>" still carry the pre-rewrite value; map them through the
+> pairs listed here.
+
+## Release blockers (concurrent web serving)
+
+### 1. `execute file ... and read output` capture is now handler-local
+The io_capture stack is a thread-local; interleaved concurrent handlers shared
+it, so a handler awaiting mid-capture absorbed sibling `display` output and
+lost its own lines to a sibling's buffer, with LIFO guard pops mismatching on
+out-of-order completion. The capture stack is now part of the per-handler
+`RunState` swap (handlers inherit a clone of the ambient stack, so output
+still reaches an enclosing capture), and `CaptureGuard` removes its buffer by
+`Rc` identity instead of popping blindly.
+Red `91ffee1` → Green `952e270` (`tests/concurrent_execute_capture_test.rs`).
+
+### 2. `wait for request` timeout expressions no longer stall siblings
+The timeout clause is an arbitrary WFL expression and was evaluated while
+holding the receiver mutex shared by every handler — one slow expression
+parked the whole server. It is now evaluated before locking.
+Red `01ee863` → Green `4556a65` (`tests/concurrent_timeout_eval_lock_test.rs`).
+
+### 3. Module/include loading context is now handler-local
+`current_source_file` and `loading_stack` were interpreter-global: concurrent
+loads falsely reported circular dependencies, resolved relative paths against
+a sibling's module directory, inflated import depth, and guards popped each
+other's entries. Both moved into the `RunState` swap (initialized from the
+enclosing context, so true cycles through it are still detected), and
+`ModuleLoadGuard` restores/removes by identity.
+Red `822778d` → Green `cfd3440` (`tests/concurrent_module_loading_test.rs`).
+
+### 4. Response streams are handler-owned
+`write`/`flush`/`close` acted on the global stream map with no ownership
+check, so a handler holding a sibling's handle (via a shared global) could
+inject bytes into, flush, or truncate the sibling's response — and because the
+write path clones the channel sender before awaiting, a sibling's `close`
+didn't even stop an in-flight write. The three verbs now require the handle to
+be in the current handler's open-stream list; a live stream owned by another
+handler reports ownership, a missing one keeps the closed-stream error, and
+re-closing one's own closed stream stays a no-op. With ownership enforced,
+write and close can no longer race across handlers (a handler is sequential
+within itself). Docs: web-servers.md "Ownership" note.
+Red `3ba71e7` → Green `1f71935` (`tests/concurrent_stream_ownership_test.rs`).
+
+## Follow-up correctness/compatibility
+
+### 5. Concurrent handlers preserve live recursion depth
+Handlers seeded `call_depth` from `base_call_depth` (run entry) instead of the
+live depth at loop entry, so a loop nested in user actions granted every
+handler a full `max_call_depth` on top of uncounted real frames — an early
+variant of the regression test aborted with a genuine native stack overflow on
+a 2 MB thread. Handlers now seed from the live depth (mirroring
+`execute file`'s child seeding). `IsolatedHandler::drop` also drops the
+handler future with the handler's own run state swapped in, so RAII guards in
+a future dropped mid-suspend (call-depth, capture, module-load) unwind against
+their own state rather than the ambient context.
+Red `bd183ad` → Green `0320d24` (`tests/concurrent_recursion_depth_test.rs`).
+
+### 6. Classic `write line|chunk` continuations for `starts`, `ends`, `:`
+The bare-marker guard enumerated continuation tokens by hand and was missing
+`KeywordStarts`, `KeywordEnds`, and `Colon` relative to
+`parse_binary_continuation_inner`, so `write line starts with "/" to f`
+silently mis-parsed into the streaming branch and `write line : to f`
+parse-failed. The guard now includes them and documents the binary parser as
+the authoritative set.
+Red `dff4f3b` → Green `c4f74bc` (`tests/write_web_postfix_test.rs`).
+
+### 7. Exact `flush (…)` / `flush call …` legacy side effects
+Pre-streaming these were two statements — the bare `flush` expression
+statement plus the operand expression statement. The fallback evaluated only
+`Variable("flush")`, dropping the operand's side effects. Runtime now executes
+both in the original order when the bare `flush` binding exists (exact form
+only; merged forms' fallback already spans the operand), and the analyzer and
+typechecker validate the operand the same way.
+Red `cd7bef4` → Green `daca8c7` (`tests/flush_action_backcompat_test.rs`).
+
+### 8. Typechecker alignment: repeat-until order/backedge, WebSocket binding
+- `RepeatUntilLoop` checked the condition before the body (runtime runs the
+  body first, in the same scope) with no backedge fixed point. It now checks
+  the body under the same fixed point as `while`, then the condition against
+  the POST-body state (`check_loop_body_fixed_point_post_body` — repeat-until
+  always runs the body before the condition, so the header-state restore used
+  for `while` would hide body retypings).
+- `WebSocketHandlerStatement` pushed a checker scope but never defined the
+  binding symbol, so handler bodies were checked against an outer same-named
+  symbol's concrete type (false errors on runtime-valid programs). The binding
+  is now recreated (Type::Unknown) in the scope, shadowing like runtime
+  `define_direct`.
+Red `f2e28d9` → Green `59a71cd`
+(`tests/typechecker_repeat_until_backedge_test.rs`,
+`tests/typechecker_websocket_binding_scope_test.rs`).
+
+### Deferred: try/finally error-alias scope
+The re-review also lists "align try/finally error-alias scope". At runtime the
+error alias (`error_message` and the `when` clause name) is defined in the
+shared try child-env and stays live through `finally`; statically both the
+analyzer and typechecker deliberately exclude the alias from promotion so
+`finally` resolves the outer binding — and that static contract is locked in
+by `tests/typechecker_try_finally_join_test.rs` (`:112`, `:211`). Aligning
+either direction is a breaking decision: making the runtime clause-local
+breaks programs that read `error_message` in `finally`; making the static
+passes runtime-faithful reverses deliberate, tested behavior from #641. Left
+for a maintainer ruling rather than changed unilaterally here.
+
+## Not changed
+- The consecutive-failure breaker threshold is still a private const
+  (`MAX_CONSECUTIVE_HANDLER_FAILURES = 256`); the classifier fixes from the
+  original #642 body were already on the merged head.
+- The serial `main loop`, plain `write`/`flush` forms, and all pre-existing
+  `TestPrograms/` behavior are unchanged (backward-compat gate run against the
+  release build).

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -545,11 +545,13 @@ close out
 - `close <out>` — end the response body. Writing after `close` is an error.
 
 **Ownership:** a response stream belongs to the handler that started it. Under
-`main loop concurrently:`, `write`, `flush`, and `close` on a stream handle that
-another handler owns (for example one shared through a global variable) fail
-with a catchable error instead of injecting into — or truncating — the owner's
-response. Re-`close`-ing a stream you own that is already closed stays a silent
-no-op.
+`main loop concurrently:`, `write`, `flush`, and `close` on a **live** stream
+handle that another handler owns (for example one shared through a global
+variable) fail with a catchable error instead of injecting into — or
+truncating — the owner's response. Once a stream is closed there is no live
+response left to protect: `write` and `flush` still fail with the
+closed-stream error, while `close` is an idempotent no-op for any handler
+holding the stale handle.
 
 **Lifecycle & backpressure:** the body channel is bounded, so a slow client
 slows your `write` calls (backpressure) instead of buffering without bound. If

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -111,7 +111,10 @@ bound work (the common web case), not CPU-bound loops.
 - A slow handler does not block its siblings. This includes the `wait for
   request ... with timeout <expr>` timeout expression itself: it is evaluated
   before the handler contends for the next request, so a slow expression in one
-  handler never stalls the others.
+  handler never stalls the others. Note that under `concurrently` each handler
+  slot evaluates its own timeout expression when its iteration starts (up to
+  the handler limit at once on an idle server), so keep timeout expressions
+  side-effect free — a literal or a cheap pure action.
 - Each request handler is isolated: its own scope, plus handler-local run
   state — count-loop counters, recursion-depth accounting (which continues from
   the depth at loop entry, so enclosing action frames stay counted),

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -108,8 +108,17 @@ bound work (the common web case), not CPU-bound loops.
 
 **What you get with `concurrently`:**
 
-- A slow handler does not block its siblings.
-- Each request handler is isolated (its own scope).
+- A slow handler does not block its siblings. This includes the `wait for
+  request ... with timeout <expr>` timeout expression itself: it is evaluated
+  before the handler contends for the next request, so a slow expression in one
+  handler never stalls the others.
+- Each request handler is isolated: its own scope, plus handler-local run
+  state — count-loop counters, recursion-depth accounting (which continues from
+  the depth at loop entry, so enclosing action frames stay counted),
+  `execute file ... and read output` capture, and module loading (`include` /
+  `load module` relative paths resolve against the handler's own context, and
+  one handler's in-flight load is never misreported as another's circular
+  dependency).
 - A handler that errors or panics is contained: that request fails on its own and
   the server keeps serving everyone else. How the client sees the failure depends
   on how far the handler got: if it had **not** sent a response yet, the client
@@ -534,6 +543,13 @@ close out
 - `flush <out>` — advisory: yield so queued bytes are handed to the socket.
   (Chunks are already forwarded as you write them; hyper writes as it receives.)
 - `close <out>` — end the response body. Writing after `close` is an error.
+
+**Ownership:** a response stream belongs to the handler that started it. Under
+`main loop concurrently:`, `write`, `flush`, and `close` on a stream handle that
+another handler owns (for example one shared through a global variable) fail
+with a catchable error instead of injecting into — or truncating — the owner's
+response. Re-`close`-ing a stream you own that is already closed stays a silent
+no-op.
 
 **Lifecycle & backpressure:** the body channel is bounded, so a slow client
 slows your `write` calls (backpressure) instead of buffering without bound. If

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1720,6 +1720,14 @@ impl Analyzer {
                     if let Some(fb) = action_fallback {
                         self.analyze_expression(fb);
                     }
+                    // Exact `flush (…)` / `flush call …`: pre-streaming the
+                    // operand was its own expression statement, and the runtime
+                    // still evaluates it after the `flush` fallback — analyze it
+                    // so its names are validated like any statement (#642).
+                    // (Merged forms' fallback already spans the operand tokens.)
+                    if legacy_binding.as_deref() == Some("flush") {
+                        self.analyze_expression(target);
+                    }
                 } else {
                     self.analyze_expression(target);
                 }

--- a/src/interpreter/io_capture.rs
+++ b/src/interpreter/io_capture.rs
@@ -2,11 +2,19 @@
 //!
 //! `display` and `print` are plain fn pointers (`NativeFunction`) with no
 //! access to interpreter state, so capture is routed through a thread-local
-//! stack instead of an `Interpreter` field. This is sound because the
-//! interpreter — including nested child interpreters started by
-//! `execute file` — runs on a single thread, and the parent is suspended
-//! while a child runs. Only output produced on the interpreter thread is
-//! captured, which is true for all program-output sites today.
+//! stack instead of an `Interpreter` field. This is sound for serial
+//! execution because the interpreter — including nested child interpreters
+//! started by `execute file` — runs on a single thread, and the parent is
+//! suspended while a child runs. Only output produced on the interpreter
+//! thread is captured, which is true for all program-output sites today.
+//!
+//! Concurrent handlers (`main loop concurrently:`) interleave on that one
+//! thread instead of suspending each other, so the stack is part of the
+//! per-handler `RunState` swap: `swap_stack` installs a handler's own stack
+//! for the duration of each poll (#642). Guards remove their buffer by
+//! identity rather than popping blindly, so a guard that drops while its
+//! handler's stack is parked (handler future dropped mid-suspend) or after
+//! out-of-order completion cannot remove another capture's buffer.
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -15,14 +23,17 @@ thread_local! {
     static CAPTURE_STACK: RefCell<Vec<Rc<RefCell<String>>>> = const { RefCell::new(Vec::new()) };
 }
 
-/// RAII guard that pops the capture buffer when dropped, so capture ends
+/// RAII guard that removes its capture buffer when dropped, so capture ends
 /// correctly even when execution unwinds through `?`.
-pub(crate) struct CaptureGuard(());
+pub(crate) struct CaptureGuard(Rc<RefCell<String>>);
 
 impl Drop for CaptureGuard {
     fn drop(&mut self) {
         CAPTURE_STACK.with(|stack| {
-            stack.borrow_mut().pop();
+            let mut stack = stack.borrow_mut();
+            if let Some(pos) = stack.iter().rposition(|b| Rc::ptr_eq(b, &self.0)) {
+                stack.remove(pos);
+            }
         });
     }
 }
@@ -31,8 +42,22 @@ impl Drop for CaptureGuard {
 /// returned guard is dropped. Buffers nest: only the innermost one receives
 /// output, giving correct semantics when a captured file itself captures.
 pub(crate) fn push_capture(buffer: Rc<RefCell<String>>) -> CaptureGuard {
-    CAPTURE_STACK.with(|stack| stack.borrow_mut().push(buffer));
-    CaptureGuard(())
+    CAPTURE_STACK.with(|stack| stack.borrow_mut().push(Rc::clone(&buffer)));
+    CaptureGuard(buffer)
+}
+
+/// Swap this thread's capture stack with `other`. Used by the concurrent
+/// handler `RunState` swap so each handler sees only its own capture stack
+/// while polled, with the ambient stack parked (and restored) around it.
+pub(crate) fn swap_stack(other: &mut Vec<Rc<RefCell<String>>>) {
+    CAPTURE_STACK.with(|stack| std::mem::swap(&mut *stack.borrow_mut(), other));
+}
+
+/// Clone of the current capture stack: the initial capture context a new
+/// concurrent handler inherits, so handler output still reaches an enclosing
+/// `execute file` capture (the buffers are shared, the stack itself is not).
+pub(crate) fn snapshot_stack() -> Vec<Rc<RefCell<String>>> {
+    CAPTURE_STACK.with(|stack| stack.borrow().clone())
 }
 
 /// Emit one line of program output: to the innermost active capture buffer on

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4681,10 +4681,14 @@ impl Interpreter {
 
     /// Whether the current execution context owns response stream `handle_id`:
     /// it appears in the currently-installed per-handler open list (the
-    /// interpreter's own list under serial execution). Stream verbs
-    /// (`write`/`flush`/`close`) require ownership, so a handler holding a
-    /// sibling's stream handle (e.g. through a shared global) cannot inject
-    /// into, flush, or truncate the sibling's response (#642).
+    /// interpreter's own list under serial execution). Stream verbs require
+    /// ownership while the stream is LIVE, so a handler holding a sibling's
+    /// stream handle (e.g. through a shared global) cannot inject into, flush,
+    /// or truncate the sibling's response (#642). Once a stream is closed
+    /// (removed from the map and every open list) ownership is no longer
+    /// determinable — write/flush then fail with the closed-stream error,
+    /// while `close` is an idempotent no-op for any holder of the stale
+    /// handle (there is no live response left to protect).
     fn owns_response_stream(&self, handle_id: &str) -> bool {
         self.open_response_streams
             .borrow()
@@ -7097,11 +7101,13 @@ impl Interpreter {
                             self.untrack_http_stream(&id);
                             Ok((Value::Null, ControlFlow::None))
                         } else if let Some(id) = server_id {
-                            // Only the owning handler may end the response body.
-                            // A sibling holding this handle must not be able to
-                            // truncate the owner's in-flight response (#642).
-                            // Re-closing an already-closed own stream stays a
-                            // silent no-op (the live-elsewhere case errors).
+                            // Only the owning handler may end a LIVE response
+                            // body: a sibling holding this handle must not be
+                            // able to truncate the owner's in-flight response
+                            // (#642). An already-closed stream has no owner
+                            // (and nothing left to protect), so `close` on a
+                            // stale handle is an idempotent no-op for any
+                            // handler.
                             if !self.owns_response_stream(&id)
                                 && self.server_response_streams.borrow().contains_key(&id)
                             {

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -871,20 +871,18 @@ struct RunState {
     /// buffer (#642). Starts as a clone of the ambient stack so handler output
     /// still reaches an enclosing capture.
     capture_stack: Vec<Rc<RefCell<String>>>,
-}
-
-impl RunState {
-    /// A fresh run state for a handler starting from `base_call_depth` (0 for a
-    /// top-level run; the parent's live depth for an `execute file` child).
-    /// Inherits the calling context's capture stack (cloned) so the handler's
-    /// uncaptured output keeps flowing to any enclosing `execute file` capture.
-    fn fresh(base_call_depth: usize) -> Self {
-        RunState {
-            call_depth: base_call_depth,
-            capture_stack: io_capture::snapshot_stack(),
-            ..RunState::default()
-        }
-    }
+    /// This handler's module-resolution base (`current_source_file`). Swapped
+    /// per poll so a sibling parked mid-`include` cannot make this handler
+    /// resolve relative module paths against the sibling's module directory
+    /// (#642). Starts as the calling context's source file.
+    current_source_file: Option<PathBuf>,
+    /// This handler's in-flight module-load stack (circular-dependency
+    /// detection and import-depth accounting). Swapped per poll so a sibling's
+    /// in-flight load of the same module is not misreported as a cycle (#642).
+    /// Starts as a clone of the calling context's stack, so a handler
+    /// re-including a module the enclosing context is still loading is still
+    /// (correctly) a cycle.
+    loading_stack: Vec<PathBuf>,
 }
 
 /// Wraps a handler future so its [`RunState`] is swapped into the interpreter
@@ -1019,9 +1017,17 @@ impl Drop for OutboundStreamCleanup {
 }
 
 /// RAII guard that ensures module loading context is restored on scope exit.
-/// Automatically pops loading_stack and restores current_source_file when dropped.
+/// Automatically removes its loading_stack entry and restores
+/// current_source_file when dropped.
+///
+/// Restoration is identity-checked rather than a blind pop/overwrite: under
+/// `main loop concurrently:` the loading context is handler-local (swapped per
+/// poll), so a guard that drops while its handler's context is parked (the
+/// handler future was dropped mid-suspend) sees the *ambient* context and must
+/// not clobber it (#642).
 struct ModuleLoadGuard<'a> {
     interpreter: &'a Interpreter,
+    module_path: PathBuf,
     previous_source: Option<PathBuf>,
     should_restore: bool,
 }
@@ -1036,10 +1042,11 @@ impl<'a> ModuleLoadGuard<'a> {
             .loading_stack
             .borrow_mut()
             .push(module_path.clone());
-        *interpreter.current_source_file.borrow_mut() = Some(module_path);
+        *interpreter.current_source_file.borrow_mut() = Some(module_path.clone());
 
         Self {
             interpreter,
+            module_path,
             previous_source,
             should_restore: true,
         }
@@ -1059,8 +1066,16 @@ impl<'a> ModuleLoadGuard<'a> {
 impl<'a> Drop for ModuleLoadGuard<'a> {
     fn drop(&mut self) {
         if self.should_restore {
-            *self.interpreter.current_source_file.borrow_mut() = self.previous_source.clone();
-            self.interpreter.loading_stack.borrow_mut().pop();
+            {
+                let mut current = self.interpreter.current_source_file.borrow_mut();
+                if current.as_ref() == Some(&self.module_path) {
+                    *current = self.previous_source.clone();
+                }
+            }
+            let mut stack = self.interpreter.loading_stack.borrow_mut();
+            if let Some(pos) = stack.iter().rposition(|p| p == &self.module_path) {
+                stack.remove(pos);
+            }
         }
     }
 }
@@ -4682,6 +4697,29 @@ impl Interpreter {
         let accepted = self.accepted_request.replace(state.accepted_request);
         state.accepted_request = accepted;
         io_capture::swap_stack(&mut state.capture_stack);
+        std::mem::swap(
+            &mut *self.current_source_file.borrow_mut(),
+            &mut state.current_source_file,
+        );
+        std::mem::swap(
+            &mut *self.loading_stack.borrow_mut(),
+            &mut state.loading_stack,
+        );
+    }
+
+    /// Build the initial [`RunState`] for a new concurrent handler: recursion
+    /// accounting starts at this run's base depth, and the handler inherits
+    /// (clones of) the calling context's capture stack and module-loading
+    /// context so captures, relative module paths, and cycle/import-depth
+    /// checks behave as they would in the enclosing context.
+    fn fresh_handler_run_state(&self) -> RunState {
+        RunState {
+            call_depth: self.base_call_depth,
+            capture_stack: io_capture::snapshot_stack(),
+            current_source_file: self.current_source_file.borrow().clone(),
+            loading_stack: self.loading_stack.borrow().clone(),
+            ..RunState::default()
+        }
     }
 
     /// Drop each outbound streaming handle whose id is in `ids` from
@@ -5293,7 +5331,7 @@ impl Interpreter {
                     std::panic::AssertUnwindSafe(self.execute_block(body, scope)).catch_unwind();
                 futs.push(IsolatedHandler {
                     interp: self,
-                    state: RunState::fresh(self.base_call_depth),
+                    state: self.fresh_handler_run_state(),
                     inner: Box::pin(handler),
                 });
             }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -4660,6 +4660,48 @@ impl Interpreter {
         }
     }
 
+    /// Whether the current execution context owns response stream `handle_id`:
+    /// it appears in the currently-installed per-handler open list (the
+    /// interpreter's own list under serial execution). Stream verbs
+    /// (`write`/`flush`/`close`) require ownership, so a handler holding a
+    /// sibling's stream handle (e.g. through a shared global) cannot inject
+    /// into, flush, or truncate the sibling's response (#642).
+    fn owns_response_stream(&self, handle_id: &str) -> bool {
+        self.open_response_streams
+            .borrow()
+            .iter()
+            .any(|s| s == handle_id)
+    }
+
+    /// The ownership-failure error for a stream verb: distinguishes a stream
+    /// that is live but owned by another handler from one that is simply no
+    /// longer open (closed earlier, or its owner exited).
+    fn response_stream_ownership_error(
+        &self,
+        verb: &str,
+        handle_id: &str,
+        line: usize,
+        column: usize,
+    ) -> RuntimeError {
+        if self
+            .server_response_streams
+            .borrow()
+            .contains_key(handle_id)
+        {
+            RuntimeError::new(
+                format!("Cannot {verb} a response stream owned by another handler"),
+                line,
+                column,
+            )
+        } else {
+            RuntimeError::new(
+                format!("Cannot {verb} a closed response stream"),
+                line,
+                column,
+            )
+        }
+    }
+
     /// Swap the interpreter's per-execution run-state fields with `state`.
     ///
     /// Used by [`IsolatedHandler`] to make the run state poll-local under
@@ -7034,6 +7076,18 @@ impl Interpreter {
                             self.untrack_http_stream(&id);
                             Ok((Value::Null, ControlFlow::None))
                         } else if let Some(id) = server_id {
+                            // Only the owning handler may end the response body.
+                            // A sibling holding this handle must not be able to
+                            // truncate the owner's in-flight response (#642).
+                            // Re-closing an already-closed own stream stays a
+                            // silent no-op (the live-elsewhere case errors).
+                            if !self.owns_response_stream(&id)
+                                && self.server_response_streams.borrow().contains_key(&id)
+                            {
+                                return Err(self.response_stream_ownership_error(
+                                    "close", &id, *line, *column,
+                                ));
+                            }
                             // Dropping the sender ends the response body stream.
                             self.server_response_streams.borrow_mut().remove(&id);
                             // Drop it from the handler's auto-close tracking so
@@ -10743,6 +10797,10 @@ impl Interpreter {
                         ));
                     }
                 };
+                if !self.owns_response_stream(&handle_id) {
+                    return Err(self
+                        .response_stream_ownership_error("write to", &handle_id, *line, *column));
+                }
                 let val = self.evaluate_expression(value, Rc::clone(&env)).await?;
                 let newline = usize::from(*is_line);
                 // Compute the outgoing byte length WITHOUT cloning a large
@@ -10912,6 +10970,11 @@ impl Interpreter {
                 let handle_id = self
                     .resolve_server_stream_handle(target, &env, *line, *column)
                     .await?;
+                if !self.owns_response_stream(&handle_id) {
+                    return Err(
+                        self.response_stream_ownership_error("flush", &handle_id, *line, *column)
+                    );
+                }
                 let exists = self
                     .server_response_streams
                     .borrow()

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -902,7 +902,10 @@ struct RunState {
 struct IsolatedHandler<'a, T> {
     interp: &'a Interpreter,
     state: RunState,
-    inner: std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>,
+    /// `Some` until `Drop` takes it: the handler future must be dropped with
+    /// this handler's run state installed (see `Drop`), which plain field
+    /// drop order cannot provide.
+    inner: Option<std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>>,
 }
 
 impl<'a, T> std::future::Future for IsolatedHandler<'a, T> {
@@ -916,7 +919,12 @@ impl<'a, T> std::future::Future for IsolatedHandler<'a, T> {
         // wrapper itself is `Unpin` and `get_mut` is sound.
         let this = self.get_mut();
         this.interp.swap_run_state(&mut this.state);
-        let result = this.inner.as_mut().poll(cx);
+        let result = this
+            .inner
+            .as_mut()
+            .expect("IsolatedHandler polled after drop")
+            .as_mut()
+            .poll(cx);
         this.interp.swap_run_state(&mut this.state);
         match result {
             std::task::Poll::Ready(value) => {
@@ -929,9 +937,20 @@ impl<'a, T> std::future::Future for IsolatedHandler<'a, T> {
 
 impl<'a, T> Drop for IsolatedHandler<'a, T> {
     fn drop(&mut self) {
+        // Drop the handler future FIRST, with this handler's run state
+        // installed: a future dropped while suspended still runs the `Drop`
+        // of every live RAII guard inside it (call-depth, capture,
+        // module-load), and those guards must unwind against the handler's
+        // own state — not the ambient context that happens to be installed
+        // at teardown (#642).
+        if let Some(inner) = self.inner.take() {
+            self.interp.swap_run_state(&mut self.state);
+            drop(inner);
+            self.interp.swap_run_state(&mut self.state);
+        }
         // The handler is finished (normal return, error, panic contained by
         // `catch_unwind`, or cancellation as the loop tears down). After the
-        // final poll's swap-out, `state` holds any streams it opened but never
+        // final swap-out, `state` holds any streams it opened but never
         // closed and any requests it dequeued but never answered. Close the
         // streams (finalizing the client's body) and 500 the unanswered requests,
         // so every exit path resolves the client instead of leaving it hanging.
@@ -4750,13 +4769,15 @@ impl Interpreter {
     }
 
     /// Build the initial [`RunState`] for a new concurrent handler: recursion
-    /// accounting starts at this run's base depth, and the handler inherits
+    /// accounting starts at the LIVE depth at loop entry — the enclosing
+    /// action frames beneath a nested `main loop concurrently:` stay counted,
+    /// mirroring `execute file`'s child seeding — and the handler inherits
     /// (clones of) the calling context's capture stack and module-loading
     /// context so captures, relative module paths, and cycle/import-depth
-    /// checks behave as they would in the enclosing context.
+    /// checks behave as they would in the enclosing context (#642).
     fn fresh_handler_run_state(&self) -> RunState {
         RunState {
-            call_depth: self.base_call_depth,
+            call_depth: self.call_depth.get(),
             capture_stack: io_capture::snapshot_stack(),
             current_source_file: self.current_source_file.borrow().clone(),
             loading_stack: self.loading_stack.borrow().clone(),
@@ -5374,7 +5395,7 @@ impl Interpreter {
                 futs.push(IsolatedHandler {
                     interp: self,
                     state: self.fresh_handler_run_state(),
-                    inner: Box::pin(handler),
+                    inner: Some(Box::pin(handler)),
                 });
             }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -9942,43 +9942,48 @@ impl Interpreter {
                     }
                 };
 
+                // Evaluate the timeout expression BEFORE locking the shared
+                // receiver. The timeout clause is an arbitrary WFL expression
+                // and evaluating it can await (a user action that sleeps, does
+                // I/O, ...). The receiver mutex is shared by every concurrent
+                // handler, so evaluating under it would let one handler's slow
+                // timeout expression stall the whole server (#642).
+                let timeout_duration = if let Some(timeout_expr) = timeout {
+                    let timeout_val = self
+                        .evaluate_expression(timeout_expr, Rc::clone(&env))
+                        .await?;
+                    match timeout_val {
+                        // Reject fractional values that would truncate to 0 ms
+                        // (e.g. 0.5) and hot-spin forever with zero-duration
+                        // timeouts. Require at least 1 millisecond.
+                        Value::Number(ms) if ms >= 1.0 => {
+                            Some(std::time::Duration::from_millis(ms as u64))
+                        }
+                        Value::Number(ms) if ms > 0.0 => {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Timeout must be at least 1 millisecond (got {ms} ms); \
+                                     fractional values below 1 would truncate to zero and spin"
+                                ),
+                                *line,
+                                *column,
+                            ));
+                        }
+                        _ => {
+                            return Err(RuntimeError::new(
+                                "Timeout must be a positive number (milliseconds)".to_string(),
+                                *line,
+                                *column,
+                            ));
+                        }
+                    }
+                } else {
+                    None
+                };
+
                 // Wait for a request to come in (with optional timeout)
                 let request = {
                     let mut receiver = request_receiver.lock().await;
-
-                    // Evaluate timeout if provided
-                    let timeout_duration = if let Some(timeout_expr) = timeout {
-                        let timeout_val = self
-                            .evaluate_expression(timeout_expr, Rc::clone(&env))
-                            .await?;
-                        match timeout_val {
-                            // Reject fractional values that would truncate to 0 ms
-                            // (e.g. 0.5) and hot-spin forever with zero-duration
-                            // timeouts. Require at least 1 millisecond.
-                            Value::Number(ms) if ms >= 1.0 => {
-                                Some(std::time::Duration::from_millis(ms as u64))
-                            }
-                            Value::Number(ms) if ms > 0.0 => {
-                                return Err(RuntimeError::new(
-                                    format!(
-                                        "Timeout must be at least 1 millisecond (got {ms} ms); \
-                                         fractional values below 1 would truncate to zero and spin"
-                                    ),
-                                    *line,
-                                    *column,
-                                ));
-                            }
-                            _ => {
-                                return Err(RuntimeError::new(
-                                    "Timeout must be a positive number (milliseconds)".to_string(),
-                                    *line,
-                                    *column,
-                                ));
-                            }
-                        }
-                    } else {
-                        None
-                    };
 
                     // Wait for request with or without timeout. Loop so a request
                     // whose client already gave up (its oneshot receiver dropped

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -863,14 +863,25 @@ struct RunState {
     /// from request-local outcomes (must never tear the server down because one
     /// accepted request failed). Survives respond clearing `open_pending_requests`.
     accepted_request: bool,
+    /// This handler's `execute file ... and read output` capture stack. The
+    /// capture routing itself is a thread-local (see `io_capture`), so it is
+    /// swapped — not just saved — per poll: while this handler runs, the
+    /// thread-local holds this stack; while it is suspended, the ambient stack
+    /// is restored so a sibling's output cannot land in this handler's capture
+    /// buffer (#642). Starts as a clone of the ambient stack so handler output
+    /// still reaches an enclosing capture.
+    capture_stack: Vec<Rc<RefCell<String>>>,
 }
 
 impl RunState {
     /// A fresh run state for a handler starting from `base_call_depth` (0 for a
     /// top-level run; the parent's live depth for an `execute file` child).
+    /// Inherits the calling context's capture stack (cloned) so the handler's
+    /// uncaptured output keeps flowing to any enclosing `execute file` capture.
     fn fresh(base_call_depth: usize) -> Self {
         RunState {
             call_depth: base_call_depth,
+            capture_stack: io_capture::snapshot_stack(),
             ..RunState::default()
         }
     }
@@ -4670,6 +4681,7 @@ impl Interpreter {
         );
         let accepted = self.accepted_request.replace(state.accepted_request);
         state.accepted_request = accepted;
+        io_capture::swap_stack(&mut state.capture_stack);
     }
 
     /// Drop each outbound streaming handle whose id is in `ids` from

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -10976,7 +10976,7 @@ impl Interpreter {
                     if root_bound {
                         // Reuse ExpressionStatement semantics by dispatching a
                         // synthetic statement.
-                        return self
+                        let flush_result = self
                             .execute_statement(
                                 &Statement::ExpressionStatement {
                                     expression: fallback_expr.clone(),
@@ -10985,7 +10985,26 @@ impl Interpreter {
                                 },
                                 Rc::clone(&env),
                             )
-                            .await;
+                            .await?;
+                        // Exact `flush (…)` / `flush call …` (legacy binding is
+                        // the bare word `flush`; merged forms always carry the
+                        // operand in the phrase): pre-streaming these were TWO
+                        // statements — bare `flush`, then the operand as its own
+                        // expression statement. Keep the operand's side effects
+                        // by evaluating it too, in the original order (#642).
+                        if legacy_binding.as_deref() == Some("flush") {
+                            return self
+                                .execute_statement(
+                                    &Statement::ExpressionStatement {
+                                        expression: target.clone(),
+                                        line: *line,
+                                        column: *column,
+                                    },
+                                    Rc::clone(&env),
+                                )
+                                .await;
+                        }
+                        return Ok(flush_result);
                     }
                 }
                 let handle_id = self

--- a/src/parser/stmt/io.rs
+++ b/src/parser/stmt/io.rs
@@ -948,6 +948,13 @@ impl<'a> IoParser<'a> for Parser<'a> {
         // value (`write line with "!" to file`, `write line[0] to file`, ...),
         // not a streaming marker with a missing operand. This is common in
         // line-by-line file code and predates response streaming.
+        //
+        // This token set must cover every continuation the ordinary expression
+        // grammar accepts after a variable: the postfix/`of` starters plus every
+        // operator arm of `parse_binary_continuation_inner` (expr/binary.rs) —
+        // including `starts`/`ends` (`starts with` comparisons) and the silently
+        // absorbed `:`. A missing entry silently re-reads a classic program as a
+        // stream write (#642).
         let bare_marker_before_classic_continuation = matches!(
             self.cursor.peek(),
             Some(t) if matches!(&t.token, Token::Identifier(id) if id == "line" || id == "chunk")
@@ -979,6 +986,9 @@ impl<'a> IoParser<'a> for Parser<'a> {
                     | Token::KeywordFind
                     | Token::KeywordReplace
                     | Token::KeywordSplit
+                    | Token::KeywordStarts
+                    | Token::KeywordEnds
+                    | Token::Colon
             )
         );
 

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -329,11 +329,12 @@ impl TypeChecker {
     }
 
     /// Whether executing `body` can leave its enclosing loop without reaching
-    /// the loop's own condition: a `break`, `exit`, or `return` anywhere in
-    /// the statement subtree. Deliberately conservative — a `break` inside a
-    /// NESTED loop only exits that inner loop, but treating it as early exit
-    /// merely softens condition checking back to the joined state, it never
-    /// rejects a valid program.
+    /// the loop's own condition. A `break` counts only at this loop's own
+    /// level — a `break` inside a NESTED loop exits that inner loop and the
+    /// outer body still falls through to its condition. `exit loop` and
+    /// `return` propagate out of every enclosing loop (`ControlFlow::Exit` /
+    /// `Return` are re-raised by each loop's dispatch), so they count from
+    /// any nesting depth.
     fn body_may_exit_loop_early(body: &[Statement]) -> bool {
         body.iter().any(Self::statement_may_exit_loop_early)
     }
@@ -363,13 +364,14 @@ impl TypeChecker {
                         .as_deref()
                         .is_some_and(Self::statement_may_exit_loop_early)
             }
+            // A nested loop consumes `break`; only `exit`/`return` escape it.
             Statement::ForEachLoop { body, .. }
             | Statement::CountLoop { body, .. }
             | Statement::WhileLoop { body, .. }
             | Statement::RepeatWhileLoop { body, .. }
             | Statement::RepeatUntilLoop { body, .. }
             | Statement::ForeverLoop { body, .. }
-            | Statement::MainLoop { body, .. } => Self::body_may_exit_loop_early(body),
+            | Statement::MainLoop { body, .. } => Self::body_escapes_enclosing_loop(body),
             Statement::TryStatement {
                 body,
                 when_clauses,
@@ -387,6 +389,66 @@ impl TypeChecker {
                     || finally_block
                         .as_ref()
                         .is_some_and(|b| Self::body_may_exit_loop_early(b))
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether `body` contains a control transfer that escapes EVERY enclosing
+    /// loop: `exit loop` or `return`. `break` never qualifies (the nearest
+    /// loop absorbs it), so nested loops are descended into freely.
+    fn body_escapes_enclosing_loop(body: &[Statement]) -> bool {
+        body.iter().any(Self::statement_escapes_enclosing_loop)
+    }
+
+    fn statement_escapes_enclosing_loop(stmt: &Statement) -> bool {
+        match stmt {
+            Statement::ExitStatement { .. } | Statement::ReturnStatement { .. } => true,
+            Statement::BreakStatement { .. } => false,
+            Statement::IfStatement {
+                then_block,
+                else_block,
+                ..
+            } => {
+                Self::body_escapes_enclosing_loop(then_block)
+                    || else_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_escapes_enclosing_loop(b))
+            }
+            Statement::SingleLineIf {
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                Self::statement_escapes_enclosing_loop(then_stmt)
+                    || else_stmt
+                        .as_deref()
+                        .is_some_and(Self::statement_escapes_enclosing_loop)
+            }
+            Statement::ForEachLoop { body, .. }
+            | Statement::CountLoop { body, .. }
+            | Statement::WhileLoop { body, .. }
+            | Statement::RepeatWhileLoop { body, .. }
+            | Statement::RepeatUntilLoop { body, .. }
+            | Statement::ForeverLoop { body, .. }
+            | Statement::MainLoop { body, .. } => Self::body_escapes_enclosing_loop(body),
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                finally_block,
+                ..
+            } => {
+                Self::body_escapes_enclosing_loop(body)
+                    || when_clauses
+                        .iter()
+                        .any(|c| Self::body_escapes_enclosing_loop(&c.body))
+                    || otherwise_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_escapes_enclosing_loop(b))
+                    || finally_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_escapes_enclosing_loop(b))
             }
             _ => false,
         }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -289,7 +289,16 @@ impl TypeChecker {
     /// always runs the body at least once, so the condition — and everything
     /// after the loop — sees the body's final type state, not the header
     /// join (#642).
-    fn check_loop_body_fixed_point_post_body(&mut self, body: &[Statement]) {
+    ///
+    /// When the body can exit early (`break`/`exit`/`return` anywhere in its
+    /// subtree), the condition is NOT necessarily reached from the fall-through
+    /// state — runtime skips it entirely on a break path — so the caller must
+    /// soften the installed state with the returned header join (see
+    /// `RepeatUntilLoop`). Returns the stabilized header snapshot for that.
+    fn check_loop_body_fixed_point_post_body(
+        &mut self,
+        body: &[Statement],
+    ) -> Vec<HashMap<String, Option<Type>>> {
         let entry = self.analyzer.snapshot_symbol_types();
         let mut header = entry.clone();
 
@@ -300,7 +309,7 @@ impl TypeChecker {
                 self.check_statement_types(statement);
             }
             if self.budget_error.is_some() {
-                return;
+                return header;
             }
             self.errors.truncate(error_count);
 
@@ -312,9 +321,74 @@ impl TypeChecker {
             header = next;
         }
 
-        self.analyzer.restore_symbol_types(header);
+        self.analyzer.restore_symbol_types(header.clone());
         for statement in body {
             self.check_statement_types(statement);
+        }
+        header
+    }
+
+    /// Whether executing `body` can leave its enclosing loop without reaching
+    /// the loop's own condition: a `break`, `exit`, or `return` anywhere in
+    /// the statement subtree. Deliberately conservative — a `break` inside a
+    /// NESTED loop only exits that inner loop, but treating it as early exit
+    /// merely softens condition checking back to the joined state, it never
+    /// rejects a valid program.
+    fn body_may_exit_loop_early(body: &[Statement]) -> bool {
+        body.iter().any(Self::statement_may_exit_loop_early)
+    }
+
+    fn statement_may_exit_loop_early(stmt: &Statement) -> bool {
+        match stmt {
+            Statement::BreakStatement { .. }
+            | Statement::ExitStatement { .. }
+            | Statement::ReturnStatement { .. } => true,
+            Statement::IfStatement {
+                then_block,
+                else_block,
+                ..
+            } => {
+                Self::body_may_exit_loop_early(then_block)
+                    || else_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_may_exit_loop_early(b))
+            }
+            Statement::SingleLineIf {
+                then_stmt,
+                else_stmt,
+                ..
+            } => {
+                Self::statement_may_exit_loop_early(then_stmt)
+                    || else_stmt
+                        .as_deref()
+                        .is_some_and(Self::statement_may_exit_loop_early)
+            }
+            Statement::ForEachLoop { body, .. }
+            | Statement::CountLoop { body, .. }
+            | Statement::WhileLoop { body, .. }
+            | Statement::RepeatWhileLoop { body, .. }
+            | Statement::RepeatUntilLoop { body, .. }
+            | Statement::ForeverLoop { body, .. }
+            | Statement::MainLoop { body, .. } => Self::body_may_exit_loop_early(body),
+            Statement::TryStatement {
+                body,
+                when_clauses,
+                otherwise_block,
+                finally_block,
+                ..
+            } => {
+                Self::body_may_exit_loop_early(body)
+                    || when_clauses
+                        .iter()
+                        .any(|c| Self::body_may_exit_loop_early(&c.body))
+                    || otherwise_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_may_exit_loop_early(b))
+                    || finally_block
+                        .as_ref()
+                        .is_some_and(|b| Self::body_may_exit_loop_early(b))
+            }
+            _ => false,
         }
     }
 
@@ -1835,9 +1909,20 @@ impl TypeChecker {
                 // same backedge fixed point as `while`/`repeat while`, but
                 // keeping the post-body state) so body retypings are visible
                 // to the condition (#642).
-                self.check_loop_body_fixed_point_post_body(body);
+                let header = self.check_loop_body_fixed_point_post_body(body);
                 if self.budget_error.is_some() {
                     return;
+                }
+                // A body that can `break`/`exit`/`return` skips the condition
+                // on that path at runtime, so the strict post-body state would
+                // falsely reject retype-then-break bodies (fatal inside
+                // `load module`). Soften to the join of header and post-body
+                // for the condition — and for code after the loop, which such
+                // a path also reaches with pre-break state.
+                if Self::body_may_exit_loop_early(body) {
+                    let post_body = self.analyzer.snapshot_symbol_types();
+                    self.analyzer
+                        .restore_symbol_types(Self::join_type_snapshots(&[header, post_body]));
                 }
 
                 let condition_type = self.infer_expression_type(condition);

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -283,6 +283,41 @@ impl TypeChecker {
         self.analyzer.restore_symbol_types(header);
     }
 
+    /// Like [`check_loop_body_fixed_point`], but leaves the POST-BODY type
+    /// state installed instead of restoring the loop-header state.
+    /// `repeat until` evaluates its condition after each body execution and
+    /// always runs the body at least once, so the condition — and everything
+    /// after the loop — sees the body's final type state, not the header
+    /// join (#642).
+    fn check_loop_body_fixed_point_post_body(&mut self, body: &[Statement]) {
+        let entry = self.analyzer.snapshot_symbol_types();
+        let mut header = entry.clone();
+
+        loop {
+            self.analyzer.restore_symbol_types(header.clone());
+            let error_count = self.errors.len();
+            for statement in body {
+                self.check_statement_types(statement);
+            }
+            if self.budget_error.is_some() {
+                return;
+            }
+            self.errors.truncate(error_count);
+
+            let backedge = self.analyzer.snapshot_symbol_types();
+            let next = Self::join_type_snapshots(&[entry.clone(), header.clone(), backedge]);
+            if next == header {
+                break;
+            }
+            header = next;
+        }
+
+        self.analyzer.restore_symbol_types(header);
+        for statement in body {
+            self.check_statement_types(statement);
+        }
+    }
+
     /// Get the return type for builtin functions
     fn get_builtin_function_type(&self, name: &str, _arg_count: usize) -> Type {
         match name {
@@ -1795,6 +1830,16 @@ impl TypeChecker {
                 line: _line,
                 column: _column,
             } => {
+                // Runtime order: the body ALWAYS runs before the condition is
+                // evaluated, in the same scope. Check in that order (with the
+                // same backedge fixed point as `while`/`repeat while`, but
+                // keeping the post-body state) so body retypings are visible
+                // to the condition (#642).
+                self.check_loop_body_fixed_point_post_body(body);
+                if self.budget_error.is_some() {
+                    return;
+                }
+
                 let condition_type = self.infer_expression_type(condition);
                 if condition_type != Type::Boolean
                     && condition_type != Type::Unknown
@@ -1807,10 +1852,6 @@ impl TypeChecker {
                         *_line,
                         *_column,
                     );
-                }
-
-                for stmt in body {
-                    self.check_statement_types(stmt);
                 }
             }
             Statement::ForeverLoop { body, .. } => {
@@ -2943,6 +2984,7 @@ impl TypeChecker {
             }
             Statement::WebSocketHandlerStatement {
                 server,
+                binding,
                 body,
                 line,
                 column,
@@ -2954,6 +2996,19 @@ impl TypeChecker {
                 self.check_server_expression_type(server, *line, *column);
                 self.analyzer.push_scope();
                 let outer_type_snapshot = self.analyzer.snapshot_symbol_types();
+                // Runtime binds the event object with `define_direct`,
+                // deliberately shadowing an outer same-named variable. Analyzer
+                // body scopes are discarded before this pass, so recreate the
+                // binding here — typed Unknown, keeping event-object access
+                // permissive instead of checking the body against the outer
+                // symbol's concrete type (#642).
+                self.analyzer.define_or_replace_symbol(Symbol {
+                    name: binding.clone(),
+                    kind: SymbolKind::Variable { mutable: true },
+                    symbol_type: Some(Type::Unknown),
+                    line: *line,
+                    column: *column,
+                });
                 for stmt in body {
                     self.check_statement_types(stmt);
                 }

--- a/src/typechecker/mod.rs
+++ b/src/typechecker/mod.rs
@@ -1301,6 +1301,13 @@ impl TypeChecker {
                     if let Some(fb) = action_fallback {
                         let _ = self.infer_expression_type(fb);
                     }
+                    // Exact `flush (…)` / `flush call …`: the runtime also
+                    // evaluates the operand as its own legacy expression
+                    // statement, so typecheck it as an ordinary expression —
+                    // no response-stream requirement (#642).
+                    if legacy_binding.as_deref() == Some("flush") {
+                        let _ = self.infer_expression_type(target);
+                    }
                 } else {
                     let target_type = self.infer_expression_type(target);
                     if !self.is_response_stream_target_type(&target_type) {

--- a/tests/concurrent_execute_capture_test.rs
+++ b/tests/concurrent_execute_capture_test.rs
@@ -1,0 +1,221 @@
+// Red→Green regression for issue #642: `execute file ... and read output`
+// capture must be handler-local under `main loop concurrently:`.
+//
+// The capture stack that routes `display` output into the reading variable is
+// a single thread-local shared by every handler on the interpreter thread. A
+// handler that awaits mid-capture (the child file yields) leaves its buffer on
+// top of that shared stack, so an interleaved sibling's output — its own
+// captured child, or a plain `display` — lands in the wrong handler's buffer,
+// and the LIFO guard pops mismatch when handlers finish out of push order.
+//
+// Two properties, each a separate test:
+//   1. Two handlers capturing concurrently each read exactly their own
+//      child's output.
+//   2. A sibling's plain `display` (no capture) must not leak into another
+//      handler's capture buffer.
+
+use std::fs;
+use std::time::Duration;
+use tempfile::TempDir;
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+mod common;
+
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("parse");
+            let mut interpreter = Interpreter::new();
+            if let Err(errors) = interpreter.interpret(&ast).await {
+                panic!("server interpreter failed: {errors:?}");
+            }
+        });
+    })
+}
+
+async fn wait_for_server(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..300 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on {addr} did not become ready in time");
+}
+
+async fn shutdown(port: u16, server: std::thread::JoinHandle<()>) {
+    let _ = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/shutdown"))
+        .send()
+        .await;
+    match tokio::task::spawn_blocking(move || server.join()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(join_err) => panic!("server join task failed: {join_err}"),
+    }
+}
+
+/// Write a child WFL file that displays `first`, yields for `wait_ms`, then
+/// displays `second` — the yield is what lets a sibling handler interleave
+/// inside the capture window. Returns a forward-slash path safe to embed in a
+/// WFL string literal on all platforms.
+fn write_child(dir: &TempDir, name: &str, first: &str, second: &str, wait_ms: u32) -> String {
+    let path = dir.path().join(name);
+    fs::write(
+        &path,
+        format!("display \"{first}\"\nwait for {wait_ms} milliseconds\ndisplay \"{second}\"\n"),
+    )
+    .expect("write child wfl file");
+    path.display().to_string().replace('\\', "/")
+}
+
+#[tokio::test]
+async fn test_concurrent_captures_do_not_cross_wire() {
+    let dir = TempDir::new().expect("tempdir");
+    let child_a = write_child(&dir, "child_a.wfl", "ALPHA-1", "ALPHA-2", 250);
+    let child_b = write_child(&dir, "child_b.wfl", "BRAVO-1", "BRAVO-2", 250);
+
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 20000
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                check if p is equal to "/a":
+                    execute wfl file at "{child_a}" and read output as child_output
+                    respond to req with child_output
+                otherwise:
+                    execute wfl file at "{child_b}" and read output as child_output
+                    respond to req with child_output
+                end check
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code);
+    wait_for_server(port).await;
+
+    // Start /a first so its capture window is open, then fire /b so both
+    // children are parked in their mid-file waits at the same time.
+    let a_url = format!("http://127.0.0.1:{port}/a");
+    let a = tokio::spawn(async move {
+        reqwest::Client::new()
+            .get(&a_url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    });
+    tokio::time::sleep(Duration::from_millis(80)).await;
+    let b_url = format!("http://127.0.0.1:{port}/b");
+    let b = tokio::spawn(async move {
+        reqwest::Client::new()
+            .get(&b_url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    });
+
+    let a_body = a.await.expect("/a task panicked");
+    let b_body = b.await.expect("/b task panicked");
+
+    assert!(
+        a_body.contains("ALPHA-1") && a_body.contains("ALPHA-2"),
+        "/a must capture its own child's full output, got: {a_body:?}"
+    );
+    assert!(
+        !a_body.contains("BRAVO"),
+        "/a captured a sibling handler's output (cross-wired capture): {a_body:?}"
+    );
+    assert!(
+        b_body.contains("BRAVO-1") && b_body.contains("BRAVO-2"),
+        "/b must capture its own child's full output, got: {b_body:?}"
+    );
+    assert!(
+        !b_body.contains("ALPHA"),
+        "/b captured a sibling handler's output (cross-wired capture): {b_body:?}"
+    );
+
+    shutdown(port, server).await;
+}
+
+#[tokio::test]
+async fn test_sibling_display_does_not_leak_into_capture() {
+    let dir = TempDir::new().expect("tempdir");
+    let child = write_child(&dir, "child.wfl", "CHILD-1", "CHILD-2", 600);
+
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 20000
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                check if p is equal to "/cap":
+                    execute wfl file at "{child}" and read output as child_output
+                    respond to req with child_output
+                otherwise:
+                    display "NOISE-FROM-SIBLING"
+                    respond to req with "noise-done"
+                end check
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code);
+    wait_for_server(port).await;
+
+    // Open the capture window, then have a sibling display while it is open.
+    let cap_url = format!("http://127.0.0.1:{port}/cap");
+    let cap = tokio::spawn(async move {
+        reqwest::Client::new()
+            .get(&cap_url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let noise = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/noise"))
+        .send()
+        .await
+        .expect("noise request failed");
+    assert_eq!(noise.text().await.unwrap(), "noise-done");
+
+    let cap_body = cap.await.expect("/cap task panicked");
+    assert!(
+        cap_body.contains("CHILD-1") && cap_body.contains("CHILD-2"),
+        "/cap must capture its child's full output, got: {cap_body:?}"
+    );
+    assert!(
+        !cap_body.contains("NOISE-FROM-SIBLING"),
+        "a sibling handler's display leaked into another handler's capture: {cap_body:?}"
+    );
+
+    shutdown(port, server).await;
+}

--- a/tests/concurrent_module_loading_test.rs
+++ b/tests/concurrent_module_loading_test.rs
@@ -1,0 +1,203 @@
+// Red→Green regression for issue #642: module/include loading context must be
+// handler-local under `main loop concurrently:`.
+//
+// `current_source_file` (relative-path resolution base) and `loading_stack`
+// (circular-dependency detection) are interpreter-global. A handler that
+// awaits mid-include leaves its module on the shared stack and its module's
+// path installed as the resolution base, so a concurrent sibling:
+//   1. including the same module falsely trips "Circular dependency detected";
+//   2. including its own (existing) module resolves the relative path against
+//      the *other* handler's module directory and fails with "not found".
+
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+use tempfile::TempDir;
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+mod common;
+
+fn start_server_thread(code: String, source_file: Option<PathBuf>) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("parse");
+            let mut interpreter = Interpreter::new();
+            if let Some(path) = source_file {
+                interpreter.set_source_file(path);
+            }
+            if let Err(errors) = interpreter.interpret(&ast).await {
+                panic!("server interpreter failed: {errors:?}");
+            }
+        });
+    })
+}
+
+async fn wait_for_server(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..300 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on {addr} did not become ready in time");
+}
+
+async fn shutdown(port: u16, server: std::thread::JoinHandle<()>) {
+    let _ = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/shutdown"))
+        .send()
+        .await;
+    match tokio::task::spawn_blocking(move || server.join()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(join_err) => panic!("server join task failed: {join_err}"),
+    }
+}
+
+fn wfl_path(path: &std::path::Path) -> String {
+    path.display().to_string().replace('\\', "/")
+}
+
+#[tokio::test]
+async fn test_concurrent_includes_of_same_module_do_not_false_cycle() {
+    let dir = TempDir::new().expect("tempdir");
+    // Top-level wait keeps the module load in flight so a sibling's include of
+    // the same module overlaps it.
+    let module = dir.path().join("shared_mod.wfl");
+    fs::write(
+        &module,
+        "wait for 400 milliseconds\nstore shared_value as \"included-ok\"\n",
+    )
+    .expect("write module");
+    let module_path = wfl_path(&module);
+
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 20000
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                include from "{module_path}"
+                respond to req with shared_value
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code, None);
+    wait_for_server(port).await;
+
+    // Overlap two loads of the same module.
+    let a_url = format!("http://127.0.0.1:{port}/a");
+    let a = tokio::spawn(async move { reqwest::Client::new().get(&a_url).send().await.unwrap() });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let b = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/b"))
+        .send()
+        .await
+        .expect("/b request failed");
+
+    let b_status = b.status().as_u16();
+    let b_body = b.text().await.unwrap();
+    assert_eq!(
+        (b_status, b_body.as_str()),
+        (200, "included-ok"),
+        "a sibling's in-flight include of the same module was misreported as \
+         a circular dependency"
+    );
+
+    let a_resp = a.await.expect("/a task panicked");
+    let a_status = a_resp.status().as_u16();
+    let a_body = a_resp.text().await.unwrap();
+    assert_eq!((a_status, a_body.as_str()), (200, "included-ok"));
+
+    shutdown(port, server).await;
+}
+
+#[tokio::test]
+async fn test_relative_include_resolves_against_own_handler_context() {
+    let dir = TempDir::new().expect("tempdir");
+    let main_file = dir.path().join("main.wfl");
+    fs::write(&main_file, "// server main\n").expect("write main");
+
+    // /a's module lives in a subdirectory and stays in flight (top-level wait),
+    // installing that subdirectory as the shared resolution base while parked.
+    let subdir = dir.path().join("subdir");
+    fs::create_dir(&subdir).expect("mkdir subdir");
+    fs::write(
+        subdir.join("slow_mod.wfl"),
+        "wait for 400 milliseconds\nstore slow_marker as \"slow-ok\"\n",
+    )
+    .expect("write slow module");
+
+    // /b's module lives next to main.wfl and is included by RELATIVE path, so
+    // it only resolves if the base is /b's own context (main.wfl's directory),
+    // not /a's parked module directory.
+    fs::write(
+        dir.path().join("sibling.wfl"),
+        "store sibling_value as \"sibling-ok\"\n",
+    )
+    .expect("write sibling module");
+
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 20000
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                check if p is equal to "/a":
+                    include from "subdir/slow_mod.wfl"
+                    respond to req with slow_marker
+                otherwise:
+                    include from "sibling.wfl"
+                    respond to req with sibling_value
+                end check
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code, Some(main_file));
+    wait_for_server(port).await;
+
+    let a_url = format!("http://127.0.0.1:{port}/a");
+    let a = tokio::spawn(async move { reqwest::Client::new().get(&a_url).send().await.unwrap() });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    let b = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/b"))
+        .send()
+        .await
+        .expect("/b request failed");
+
+    let b_status = b.status().as_u16();
+    let b_body = b.text().await.unwrap();
+    assert_eq!(
+        (b_status, b_body.as_str()),
+        (200, "sibling-ok"),
+        "/b's relative include resolved against a sibling handler's module \
+         directory instead of its own context"
+    );
+
+    let a_resp = a.await.expect("/a task panicked");
+    let a_status = a_resp.status().as_u16();
+    let a_body = a_resp.text().await.unwrap();
+    assert_eq!((a_status, a_body.as_str()), (200, "slow-ok"));
+
+    shutdown(port, server).await;
+}

--- a/tests/concurrent_recursion_depth_test.rs
+++ b/tests/concurrent_recursion_depth_test.rs
@@ -1,0 +1,136 @@
+// Red→Green regression for issue #642: concurrent handlers must inherit the
+// LIVE recursion depth at loop entry, not the run's base depth.
+//
+// `main loop concurrently:` can run nested inside user actions. Each handler's
+// run state previously seeded `call_depth` from `base_call_depth` (the run
+// entry, 0 for a top-level program), discarding the enclosing action frames
+// that are still live beneath the loop. With 256 handlers each granted a full
+// `max_call_depth` budget on top of uncounted real frames, the depth ceiling
+// no longer bounds the native stack — the exact overflow the limit exists to
+// prevent. (`execute file` already seeds its child with the parent's live
+// depth; this aligns the concurrent loop with it.)
+//
+// Setup: max_call_depth = 10; the loop runs 3 action frames deep
+// (level_a -> level_b -> serve); the handler recursion peaks at 9 frames of
+// its own. 9 < 10 passes standalone, but 3 + 9 = 12 must exceed the limit.
+
+use std::sync::Arc;
+use std::time::Duration;
+use wfl::Interpreter;
+use wfl::config::WflConfig;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+mod common;
+
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    // Generous native stack: WFL call levels are stack-hungry in debug builds,
+    // and on the BUGGY path the handler runs its full 9 recursion levels (the
+    // depth limit never fires). The test must reach its assertion and fail on
+    // content — not abort the process with a native stack overflow.
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || {
+            let rt = tokio::runtime::Runtime::new().expect("runtime");
+            rt.block_on(async {
+                let tokens = lex_wfl_with_positions(&code);
+                let mut parser = Parser::new(&tokens);
+                let ast = parser.parse().expect("parse");
+                let config = WflConfig {
+                    max_call_depth: 10,
+                    ..WflConfig::default()
+                };
+                let mut interpreter = Interpreter::with_config(Arc::new(config));
+                if let Err(errors) = interpreter.interpret(&ast).await {
+                    panic!("server interpreter failed: {errors:?}");
+                }
+            });
+        })
+        .expect("spawn server thread")
+}
+
+async fn wait_for_server(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..300 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on {addr} did not become ready in time");
+}
+
+async fn shutdown(port: u16, server: std::thread::JoinHandle<()>) {
+    let _ = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/shutdown"))
+        .send()
+        .await;
+    match tokio::task::spawn_blocking(move || server.join()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(join_err) => panic!("server join task failed: {join_err}"),
+    }
+}
+
+#[tokio::test]
+async fn test_handler_recursion_budget_includes_enclosing_action_frames() {
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        define action called recurse with parameters n:
+            check if n is greater than 0:
+                store unused as recurse of n minus 1
+            end check
+            give back n
+        end action
+
+        define action called serve:
+            main loop concurrently:
+                wait for request comes in on srv as req with timeout 20000
+                store p as req["path"]
+                check if p is equal to "/shutdown":
+                    respond to req with "bye"
+                    close server srv
+                    break
+                otherwise:
+                    store depth_outcome as "not-limited"
+                    try:
+                        store unused_r as recurse of 8
+                    when error:
+                        change depth_outcome to "depth-limited"
+                    end try
+                    respond to req with depth_outcome
+                end check
+            end loop
+        end action
+
+        define action called level_b:
+            store serve_result as call serve
+        end action
+
+        define action called level_a:
+            store level_b_result as call level_b
+        end action
+
+        listen on port {port} as srv
+        store run_result as call level_a
+    "#
+    );
+    let server = start_server_thread(code);
+    wait_for_server(port).await;
+
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/deep"))
+        .send()
+        .await
+        .expect("request failed");
+    let body = resp.text().await.unwrap();
+    assert_eq!(
+        body, "depth-limited",
+        "handler recursion accounting ignored the live action frames \
+         beneath the concurrent loop (expected 3 enclosing + 9 handler \
+         frames to exceed max_call_depth 10)"
+    );
+
+    shutdown(port, server).await;
+}

--- a/tests/concurrent_stream_ownership_test.rs
+++ b/tests/concurrent_stream_ownership_test.rs
@@ -1,0 +1,145 @@
+// Red→Green regression for issue #642: server response streams must be
+// handler-owned. A handler that obtains another handler's stream handle
+// (e.g. through a shared global) must not be able to write to, flush, or
+// close that stream — otherwise it can inject bytes into a sibling's
+// response body or truncate it by closing the stream mid-response.
+//
+// Scenario: /stream starts a streaming response, publishes its handle in a
+// global, writes one line, parks 500ms, writes a second line, closes. While
+// it is parked, /intrude grabs the global handle and attempts write + flush +
+// close, each in its own try block, reporting each outcome.
+//   - Fixed: all three attempts error (caught), and the streamed body is
+//     exactly the owner's two lines.
+//   - Buggy: the write injects "INTRUDER" into the owner's body and the close
+//     truncates it (the owner's second write then errors).
+
+use std::time::Duration;
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+mod common;
+
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("parse");
+            let mut interpreter = Interpreter::new();
+            if let Err(errors) = interpreter.interpret(&ast).await {
+                panic!("server interpreter failed: {errors:?}");
+            }
+        });
+    })
+}
+
+async fn wait_for_server(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..300 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on {addr} did not become ready in time");
+}
+
+async fn shutdown(port: u16, server: std::thread::JoinHandle<()>) {
+    let _ = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/shutdown"))
+        .send()
+        .await;
+    match tokio::task::spawn_blocking(move || server.join()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(join_err) => panic!("server join task failed: {join_err}"),
+    }
+}
+
+#[tokio::test]
+async fn test_sibling_handler_cannot_write_flush_or_close_anothers_stream() {
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        store shared_handle as ""
+
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 20000
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                check if p is equal to "/stream":
+                    start streaming response to req with status 200 as out
+                    change shared_handle to out
+                    write line "OWNER-1" to out
+                    wait for 500 milliseconds
+                    write line "OWNER-2" to out
+                    close out
+                otherwise:
+                    store write_outcome as "write:allowed"
+                    try:
+                        write line "INTRUDER" to shared_handle
+                    when error:
+                        change write_outcome to "write:denied"
+                    end try
+                    store flush_outcome as "flush:allowed"
+                    try:
+                        flush shared_handle
+                    when error:
+                        change flush_outcome to "flush:denied"
+                    end try
+                    store close_outcome as "close:allowed"
+                    try:
+                        close shared_handle
+                    when error:
+                        change close_outcome to "close:denied"
+                    end try
+                    store outcome_summary as write_outcome with " " with flush_outcome with " " with close_outcome
+                    respond to req with outcome_summary
+                end check
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code);
+    wait_for_server(port).await;
+
+    // Open the streaming response, then intrude while its handler is parked.
+    let stream_url = format!("http://127.0.0.1:{port}/stream");
+    let stream = tokio::spawn(async move {
+        reqwest::Client::new()
+            .get(&stream_url)
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap()
+    });
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let intrude = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/intrude"))
+        .send()
+        .await
+        .expect("/intrude request failed");
+    let intrude_body = intrude.text().await.unwrap();
+    assert_eq!(
+        intrude_body, "write:denied flush:denied close:denied",
+        "a sibling handler operated on a stream it does not own"
+    );
+
+    let stream_body = stream.await.expect("/stream task panicked");
+    assert_eq!(
+        stream_body, "OWNER-1\nOWNER-2\n",
+        "the owner's streamed body was corrupted or truncated by a sibling"
+    );
+
+    shutdown(port, server).await;
+}

--- a/tests/concurrent_timeout_eval_lock_test.rs
+++ b/tests/concurrent_timeout_eval_lock_test.rs
@@ -1,0 +1,120 @@
+// Red→Green regression for issue #642: `wait for request ... with timeout`
+// must evaluate the timeout expression BEFORE locking the shared request
+// receiver.
+//
+// The timeout clause takes an arbitrary WFL expression, and evaluating it can
+// await (a user action that sleeps, does I/O, ...). If that evaluation happens
+// while holding the receiver mutex shared by every concurrent handler, one
+// handler's slow timeout expression parks the whole server: no sibling can
+// dequeue a request until the expression finishes.
+//
+// Discriminating scenario: the first handler iteration to call `slow_timeout`
+// flips a global flag and then sleeps 2s inside the expression. Siblings see
+// the flipped flag and evaluate instantly.
+//   - Buggy order (lock, then evaluate): the sleeping handler holds the
+//     receiver lock, so a request sent during the sleep waits ~2s.
+//   - Fixed order (evaluate, then lock): the sleeping handler holds no lock,
+//     a sibling dequeues the request promptly (< 1s).
+
+use std::time::{Duration, Instant};
+use wfl::Interpreter;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+mod common;
+
+fn start_server_thread(code: String) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let mut parser = Parser::new(&tokens);
+            let ast = parser.parse().expect("parse");
+            let mut interpreter = Interpreter::new();
+            // Surface an unexpected interpreter error as a thread panic so
+            // `shutdown` re-raises it instead of the test silently passing.
+            if let Err(errors) = interpreter.interpret(&ast).await {
+                panic!("server interpreter failed: {errors:?}");
+            }
+        });
+    })
+}
+
+/// Wait until the WFL server has actually bound `port` and is accepting
+/// connections (bare TCP connect; warp accepts and closes it without
+/// delivering an HTTP request to a handler).
+async fn wait_for_server(port: u16) {
+    let addr = format!("127.0.0.1:{port}");
+    for _ in 0..300 {
+        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server on {addr} did not become ready in time");
+}
+
+/// Send `/shutdown` so the server closes and its loop breaks, then join.
+async fn shutdown(port: u16, server: std::thread::JoinHandle<()>) {
+    let _ = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/shutdown"))
+        .send()
+        .await;
+    match tokio::task::spawn_blocking(move || server.join()).await {
+        Ok(Ok(())) => {}
+        Ok(Err(panic)) => std::panic::resume_unwind(panic),
+        Err(join_err) => panic!("server join task failed: {join_err}"),
+    }
+}
+
+#[tokio::test]
+async fn test_slow_timeout_expression_does_not_stall_sibling_handlers() {
+    let port = common::free_tcp_port();
+    let code = format!(
+        r#"
+        store first as yes
+        define action called slow_timeout:
+            check if first is yes:
+                change first to no
+                wait for 2000 milliseconds
+            end check
+            give back 30000
+        end action
+
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout call slow_timeout
+            store p as req["path"]
+            check if p is equal to "/shutdown":
+                respond to req with "bye"
+                close server srv
+                break
+            otherwise:
+                respond to req with "ok"
+            end check
+        end loop
+    "#
+    );
+    let server = start_server_thread(code);
+    wait_for_server(port).await;
+
+    // Let the first handler iteration reach (and start sleeping inside) the
+    // slow timeout expression before the request goes out.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let t0 = Instant::now();
+    let resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/ok"))
+        .send()
+        .await
+        .expect("request failed");
+    let elapsed = t0.elapsed();
+    assert_eq!(resp.text().await.unwrap(), "ok");
+    assert!(
+        elapsed < Duration::from_millis(1000),
+        "request was stalled behind a sibling's timeout-expression evaluation \
+         holding the shared receiver lock ({elapsed:?})"
+    );
+
+    shutdown(port, server).await;
+}

--- a/tests/flush_action_backcompat_test.rs
+++ b/tests/flush_action_backcompat_test.rs
@@ -118,6 +118,87 @@ fn explicit_call_flush_target_keeps_the_exact_zero_argument_action_fallback() {
     );
 }
 
+// Issue #642: before streaming, the exact forms `flush (…)` / `flush call …`
+// were TWO statements — the bare `flush` expression statement (auto-calling a
+// zero-argument `flush` action, or evaluating a plain binding) followed by the
+// operand as its own expression statement. Preserving only the `flush` half
+// silently drops the operand's side effects.
+
+#[test]
+fn parenthesized_flush_target_still_evaluates_the_operand_expression() {
+    let src = "define action called flush:\n\
+               \x20\x20\x20\x20display \"FLUSH_RAN\"\n\
+               end action\n\
+               define action called bump:\n\
+               \x20\x20\x20\x20display \"BUMP_RAN\"\n\
+               \x20\x20\x20\x20give back 1\n\
+               end action\n\
+               flush (call bump)\n";
+    let (out, code) = run_src(src);
+    assert_eq!(
+        code,
+        Some(0),
+        "`flush (call bump)` must keep both legacy statements; output:\n{out}"
+    );
+    assert!(
+        out.contains("FLUSH_RAN"),
+        "the exact zero-argument `flush` action must run; output:\n{out}"
+    );
+    assert!(
+        out.contains("BUMP_RAN"),
+        "the parenthesized operand was a separate legacy expression statement \
+         and its side effects must still fire; output:\n{out}"
+    );
+}
+
+#[test]
+fn explicit_call_flush_target_still_evaluates_the_operand_expression() {
+    let src = "define action called flush:\n\
+               \x20\x20\x20\x20display \"FLUSH_RAN\"\n\
+               end action\n\
+               define action called acquire stream:\n\
+               \x20\x20\x20\x20display \"ACQUIRE_RAN\"\n\
+               \x20\x20\x20\x20give back 1\n\
+               end action\n\
+               flush call acquire stream\n";
+    let (out, code) = run_src(src);
+    assert_eq!(
+        code,
+        Some(0),
+        "`flush call ...` must keep both legacy statements; output:\n{out}"
+    );
+    assert!(
+        out.contains("FLUSH_RAN"),
+        "the exact zero-argument `flush` action must run; output:\n{out}"
+    );
+    assert!(
+        out.contains("ACQUIRE_RAN"),
+        "the `call ...` operand was a separate legacy expression statement \
+         and its side effects must still fire; output:\n{out}"
+    );
+}
+
+#[test]
+fn non_callable_flush_binding_still_evaluates_the_paren_operand() {
+    let src = "store flush as 1\n\
+               define action called bump:\n\
+               \x20\x20\x20\x20display \"BUMP_RAN\"\n\
+               \x20\x20\x20\x20give back 1\n\
+               end action\n\
+               flush (call bump)\n";
+    let (out, code) = run_src(src);
+    assert_eq!(
+        code,
+        Some(0),
+        "`flush (call bump)` with a plain `flush` binding must stay legal; output:\n{out}"
+    );
+    assert!(
+        out.contains("BUMP_RAN"),
+        "the parenthesized operand must still be evaluated when `flush` is a \
+         non-callable binding; output:\n{out}"
+    );
+}
+
 #[test]
 fn truly_bare_flush_still_evaluates_a_non_callable_legacy_variable() {
     let src = "store flush as 1\n\

--- a/tests/typechecker_repeat_until_backedge_test.rs
+++ b/tests/typechecker_repeat_until_backedge_test.rs
@@ -1,0 +1,55 @@
+//! Red→Green regression for issue #642: the type checker must walk a
+//! `repeat until` loop the way the runtime executes it — body FIRST, then the
+//! condition, in the same scope — mirroring the `while`/`repeat while`
+//! fixed-point treatment added in #641.
+//!
+//! Runtime (`Statement::RepeatUntilLoop`) always runs the body once before
+//! evaluating the condition, and evaluates the condition in the same
+//! environment. Checking the condition first leaves body-introduced bindings
+//! `Unknown` in the condition, silently missing real type errors.
+
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::typechecker::TypeChecker;
+
+fn typecheck(code: &str) -> Result<(), String> {
+    let tokens = lex_wfl_with_positions(code);
+    let program = Parser::new(&tokens).parse().expect("parse");
+    TypeChecker::new()
+        .check_types(&program)
+        .map_err(|errors| format!("{errors:?}"))
+}
+
+#[test]
+fn repeat_until_condition_sees_body_retyped_binding() {
+    // The body ALWAYS runs before the condition, and the body retypes `out`
+    // from Number to a response stream — so the condition's numeric
+    // comparison is a guaranteed runtime type error the checker must
+    // surface. Checking the condition first sees the stale outer Number and
+    // misses it.
+    let code = "store out as 5\n\
+                repeat until out is greater than 3:\n\
+                \x20\x20\x20\x20start streaming response to \"req\" with status 200 as out\n\
+                end repeat\n";
+    assert!(
+        typecheck(code).is_err(),
+        "the condition must be checked AFTER the body (runtime order), so the \
+         body's retyping of `out` to a response stream is visible to the \
+         numeric comparison"
+    );
+}
+
+#[test]
+fn repeat_until_with_consistent_types_still_checks_cleanly() {
+    // The happy path must stay green under body-first checking.
+    let code = "store counter as 0\n\
+                repeat until counter is greater than 3:\n\
+                \x20\x20\x20\x20change counter to counter plus 1\n\
+                end repeat\n\
+                display counter\n";
+    assert!(
+        typecheck(code).is_ok(),
+        "a well-typed repeat-until loop must not be rejected: {:?}",
+        typecheck(code)
+    );
+}

--- a/tests/typechecker_repeat_until_backedge_test.rs
+++ b/tests/typechecker_repeat_until_backedge_test.rs
@@ -47,9 +47,29 @@ fn repeat_until_with_consistent_types_still_checks_cleanly() {
                 \x20\x20\x20\x20change counter to counter plus 1\n\
                 end repeat\n\
                 display counter\n";
+    let result = typecheck(code);
     assert!(
-        typecheck(code).is_ok(),
-        "a well-typed repeat-until loop must not be rejected: {:?}",
-        typecheck(code)
+        result.is_ok(),
+        "a well-typed repeat-until loop must not be rejected: {result:?}"
+    );
+}
+
+#[test]
+fn repeat_until_break_path_does_not_force_post_body_condition_types() {
+    // Runtime exits at `break` WITHOUT evaluating the condition, so a body
+    // that retypes a binding and then always breaks is runtime-valid even if
+    // the condition would mistype against the retyped binding. The checker
+    // must not reject it — type errors are fatal inside `load module`, so a
+    // false positive here breaks working modules (PR #643 review).
+    let code = "store out as 5\n\
+                repeat until out is greater than 3:\n\
+                \x20\x20\x20\x20start streaming response to \"req\" with status 200 as out\n\
+                \x20\x20\x20\x20break\n\
+                end repeat\n";
+    let result = typecheck(code);
+    assert!(
+        result.is_ok(),
+        "a retype-then-break body never reaches the condition at runtime and \
+         must not be reported against post-body types: {result:?}"
     );
 }

--- a/tests/typechecker_repeat_until_backedge_test.rs
+++ b/tests/typechecker_repeat_until_backedge_test.rs
@@ -55,6 +55,48 @@ fn repeat_until_with_consistent_types_still_checks_cleanly() {
 }
 
 #[test]
+fn nested_loop_break_does_not_soften_repeat_until_condition() {
+    // A `break` inside a NESTED loop only exits that inner loop — the outer
+    // repeat-until body still falls through to its condition, so the
+    // condition must keep the precise post-body check and flag the retyped
+    // binding (PR #643 review: over-broad softening would hide this real
+    // runtime type error).
+    let code = "store out as 5\n\
+                repeat until out is greater than 3:\n\
+                \x20\x20\x20\x20start streaming response to \"req\" with status 200 as out\n\
+                \x20\x20\x20\x20count from 1 to 3:\n\
+                \x20\x20\x20\x20\x20\x20\x20\x20break\n\
+                \x20\x20\x20\x20end count\n\
+                end repeat\n";
+    let result = typecheck(code);
+    assert!(
+        result.is_err(),
+        "a nested loop's break does not skip the outer condition at runtime, \
+         so the retyped binding must still be reported: {result:?}"
+    );
+}
+
+#[test]
+fn nested_exit_loop_still_softens_repeat_until_condition() {
+    // `exit loop` propagates out of every enclosing loop (unlike `break`),
+    // so even from a nested loop it skips the outer condition — the softened
+    // joined state applies and the retype-then-exit body stays legal.
+    let code = "store out as 5\n\
+                repeat until out is greater than 3:\n\
+                \x20\x20\x20\x20start streaming response to \"req\" with status 200 as out\n\
+                \x20\x20\x20\x20count from 1 to 3:\n\
+                \x20\x20\x20\x20\x20\x20\x20\x20exit loop\n\
+                \x20\x20\x20\x20end count\n\
+                end repeat\n";
+    let result = typecheck(code);
+    assert!(
+        result.is_ok(),
+        "exit loop escapes the outer loop too, so the condition must be \
+         checked against the softened joined state: {result:?}"
+    );
+}
+
+#[test]
 fn repeat_until_break_path_does_not_force_post_body_condition_types() {
     // Runtime exits at `break` WITHOUT evaluating the condition, so a body
     // that retypes a binding and then always breaks is runtime-valid even if

--- a/tests/typechecker_websocket_binding_scope_test.rs
+++ b/tests/typechecker_websocket_binding_scope_test.rs
@@ -1,0 +1,42 @@
+//! Red→Green regression for issue #642: the WebSocket handler binding must be
+//! recreated (and shadow any outer same-named symbol) in the type checker's
+//! handler scope.
+//!
+//! Runtime binds the event object with `define_direct`, deliberately
+//! shadowing an outer variable of the same name. The #641 typechecker pass
+//! added the handler scope but never defined the binding symbol in it, so the
+//! binding resolved to the OUTER symbol's concrete type and the checker
+//! reasoned over the wrong type inside the handler — false errors on
+//! runtime-valid programs (analyzer body scopes are discarded before this
+//! pass; compare the `OpenFileStatement` symbol recreation).
+
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+use wfl::typechecker::TypeChecker;
+
+fn typecheck(code: &str) -> Result<(), String> {
+    let tokens = lex_wfl_with_positions(code);
+    let program = Parser::new(&tokens).parse().expect("parse");
+    TypeChecker::new()
+        .check_types(&program)
+        .map_err(|errors| format!("{errors:?}"))
+}
+
+#[test]
+fn websocket_binding_shadows_outer_symbol_inside_handler_body() {
+    // `conn` is a Number outside the handler; inside, it is the event object,
+    // and indexing it is runtime-valid. The checker must not flag the body
+    // against the outer Number type.
+    let code = "store conn as 5\n\
+                listen for websockets on port 8080 as srv\n\
+                on websocket connect to srv as conn:\n\
+                \x20\x20\x20\x20store cid as conn[\"id\"]\n\
+                end on\n\
+                store next_conn as conn plus 1\n";
+    let result = typecheck(code);
+    assert!(
+        result.is_ok(),
+        "the handler binding must shadow the outer `conn` (Number) inside the \
+         handler body, and the outer type must be restored after it: {result:?}"
+    );
+}

--- a/tests/write_web_postfix_test.rs
+++ b/tests/write_web_postfix_test.rs
@@ -1038,6 +1038,42 @@ fn bare_line_binding_keeps_direct_integer_index_as_classic_fallback() {
     assert_eq!(written, "first");
 }
 
+// Issue #642: the bare-marker guard must recognize every classic expression
+// continuation the ordinary binary parser accepts — `starts with`/`ends with`
+// (comparison operators since #566) and a silently absorbed `:` were missing,
+// so these pre-streaming programs mis-parsed into the streaming branch
+// (`starts`/`ends`) or parse-failed outright (`:`).
+
+#[test]
+fn bare_line_binding_keeps_starts_with_continuation_in_classic_file_write() {
+    let written =
+        run_file_write_with_line_binding("write line starts with \"/\"", "store line as \"/api\"");
+    assert_eq!(written, "yes");
+}
+
+#[test]
+fn bare_line_binding_keeps_ends_with_continuation_in_classic_file_write() {
+    let written =
+        run_file_write_with_line_binding("write line ends with \"!\"", "store line as \"wow!\"");
+    assert_eq!(written, "yes");
+}
+
+#[test]
+fn bare_chunk_binding_keeps_starts_with_continuation_in_classic_file_write() {
+    let written =
+        run_file_write_with_line_binding("write chunk starts with \"w\"", "store chunk as \"wow\"");
+    assert_eq!(written, "yes");
+}
+
+#[test]
+fn bare_line_binding_keeps_absorbed_colon_in_classic_file_write() {
+    // The binary continuation loop silently absorbs a `:` (see
+    // `parse_binary_continuation_inner`), so `write v : to "out"` writes `v`.
+    // The same program with the variable named `line` must not change meaning.
+    let written = run_file_write_with_line_binding("write line :", "store line as \"hello\"");
+    assert_eq!(written, "hello");
+}
+
 #[test]
 fn display_property_followed_by_spaced_list_keeps_legacy_statement_split() {
     let program = parse("display alice.name [1, 2]\n");


### PR DESCRIPTION
## Summary

Completes the remaining work from issue #642 (re-review of the merged #641 streaming/concurrency head): four release-blockers for concurrent web serving, the follow-up correctness/compatibility items, and the PR-review feedback rounds. Every behavioral change landed as a **Red test-only commit that is an ancestor of its Green fix** (testing.md §6.2 path 1); pairs are listed under Test evidence below.

## Key Changes

### Runtime isolation (concurrent handler safety)

1. **Handler-local output capture** (`src/interpreter/io_capture.rs`, `src/interpreter/mod.rs`) — the `execute file ... and read output` capture stack joins the per-handler `RunState` swap; handlers inherit a clone of the ambient stack so output still reaches an enclosing capture; `CaptureGuard` removes its buffer by `Rc` identity instead of a blind pop. Regression: `tests/concurrent_execute_capture_test.rs`.
2. **Handler-local module loading** (`src/interpreter/mod.rs`) — `current_source_file` and `loading_stack` join the `RunState` swap, so relative `include`/`load module` paths resolve against the handler's own context and a sibling's in-flight load is never misreported as a cycle; `ModuleLoadGuard` restores/removes by identity. Regression: `tests/concurrent_module_loading_test.rs`.
3. **Response-stream ownership** (`src/interpreter/mod.rs`) — `write`/`flush`/`close` on a **live** stream require it to be in the current handler's open list, so a handler holding a sibling's handle (e.g. via a shared global) cannot inject into, flush, or truncate the sibling's response. A closed stream keeps the closed-stream error for write/flush; `close` on a stale handle stays an idempotent no-op (nothing live left to protect). Regression: `tests/concurrent_stream_ownership_test.rs`.
4. **Timeout evaluation ordering** (`src/interpreter/mod.rs`) — `wait for request ... with timeout <expr>` evaluates the expression **before** locking the shared receiver, so one handler's awaiting expression no longer stalls every sibling's dequeue. Each concurrent slot evaluates its own operand at iteration start (documented). Regression: `tests/concurrent_timeout_eval_lock_test.rs`.
5. **Live recursion depth** (`src/interpreter/mod.rs`) — handlers seed `call_depth` from the live depth at loop entry (mirroring `execute file` child seeding), so enclosing action frames stay counted; an early test variant reproduced a real native stack overflow. `IsolatedHandler::drop` now drops the handler future with the handler's own run state installed, so RAII guards in a future dropped mid-suspend unwind against the right context. Regression: `tests/concurrent_recursion_depth_test.rs`.

### Parser/typechecker/analyzer compatibility

6. **Classic `write line|chunk` continuations** (`src/parser/stmt/io.rs`) — the bare-marker guard now includes `starts`/`ends`/`:` (the arms it was missing relative to `parse_binary_continuation_inner`), so `write line starts with "/" to f` and `write line : to f` keep their pre-streaming file-write meaning. Regression: `tests/write_web_postfix_test.rs`.
7. **Exact `flush (…)` / `flush call …`** (`src/interpreter/mod.rs`, `src/analyzer/mod.rs`, `src/typechecker/mod.rs`) — these were two legacy statements (bare `flush` + the operand); the fallback now evaluates both in order when the bare `flush` binding exists, and all three passes validate the operand. Regression: `tests/flush_action_backcompat_test.rs`.
8. **`repeat until` runtime-order typechecking** (`src/typechecker/mod.rs`) — body checked first under a backedge fixed point, then the condition against post-body state; bodies containing an early exit (`break`/`exit`/`return`) soften the condition to the header⊔post-body join, since runtime skips the condition on those paths and type errors are fatal in `load module`. Regressions: `tests/typechecker_repeat_until_backedge_test.rs`.
9. **WebSocket handler binding** (`src/typechecker/mod.rs`) — the binding symbol is recreated (Type::Unknown) in the handler's checker scope, shadowing an outer same-named symbol the way runtime `define_direct` does. Regression: `tests/typechecker_websocket_binding_scope_test.rs`.

### Docs & process

- `Docs/04-advanced-features/web-servers.md`: what `concurrently` isolates per handler; response-stream ownership semantics (including exact close-after-close behavior); per-slot timeout-expression evaluation guidance.
- `Dev diary/2026-07-25-issue-642-remaining-blockers.md`: full Red→Green map and rationale.
- **Deferred (maintainer ruling requested):** try/finally error-alias scope. Runtime keeps the alias live through `finally`; analyzer/typechecker deliberately resolve the outer binding there, and each direction is locked in by existing tests — aligning either way is a breaking decision (details in the Dev Diary).

## Test evidence

- **Risk class:** R3 (concurrency, lifecycle, streaming, backward compatibility).
- **Red evidence (§6.2 path 1)** — test-only Red commit → Green fix, all on this branch (base `62a1b30`):
  - timeout/lock ordering `01ee863` → `4556a65`
  - execute-file capture `91ffee1` → `952e270`
  - module loading `822778d` → `cfd3440`
  - stream ownership `3ba71e7` → `1f71935`
  - recursion depth `bd183ad` → `0320d24`
  - write continuations `dff4f3b` → `c4f74bc`
  - flush legacy forms `cd7bef4` → `daca8c7`
  - repeat-until + ws binding `f2e28d9` → `59a71cd`
  - repeat-until break-path (review round) `c6e719c` → `7553a6a`
  - (History was rewritten once pre-push for committer identity only; commit messages cite pre-rewrite red hashes — the Dev Diary maps them.)
- **Layers run locally (Linux x86-64):** `cargo fmt --all -- --check`; `cargo clippy --all-targets --all-features -- -D warnings`; `cargo test --workspace` (all green); `./scripts/run_integration_tests.sh` — TestPrograms walk **111 passed / 0 failed / 24 documented skips** (backward-compat gate §11.6); `./scripts/run_web_tests.sh` — 3/3; `python scripts/validate_docs_examples.py --force` — 18/18.
- **Platforms:** Linux locally; Windows via this PR's CI matrix.
- **Not applicable:** transpiler changes (streaming statements already rejected with a clear error); benches.
- **Residual risk:** per-slot timeout-expression evaluation is burstier on idle servers than the old lock-serialized accident (documented; eval-once caching offered as follow-up if preferred). Test-harness duplication across the five new concurrency tests follows the existing per-file convention (a shared `tests/common` helper would emit dead-code warnings in the other suites that include `common`).
- **Rollback:** revert this branch's commits; no schema/config/persisted-state changes.

https://claude.ai/code/session_01DPs45HiGQ4RQzDdihoti4K

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/643" rel="nofollow noreferrer noopener" target="_blank">``&lt;img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review"&gt;``</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved concurrent web-server handling with isolated request contexts, non-blocking timeout evaluation, and safer module loading.
  * Added ownership protection for streaming responses; unauthorized handlers can no longer write, flush, or close another handler’s stream.
* **Bug Fixes**
  * Preserved legacy `flush` behavior and improved classic write syntax compatibility.
  * Corrected loop type checking, WebSocket handler scoping, recursion limits, and concurrent output capture.
* **Documentation**
  * Expanded guidance on concurrent request handling and streaming response ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->