### PR TITLE
fix(ci): raise nightly Windows build timeout to 180m (nightly red since 26.7.49)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,7 +123,19 @@ jobs:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.should_build == 'true'
     runs-on: windows-latest
-    timeout-minutes: 90
+    # `cargo test --release` here compiles EVERY integration test binary in
+    # tests/ (112 of them as of 26.7.49) against the full dependency graph, in
+    # release mode with `[profile.release] debug = true` — so each one also links
+    # a large PDB on the MSVC target. PRs #641/#643 added 26 new test files,
+    # which pushed this single step from ~27 min (26.7.47, run 29805777509) to
+    # over 70 min without finishing, and the job hit the previous 90-minute cap
+    # (run 30190411454, cancelled mid-compile). Because a cancelled job never
+    # runs its cache-save post step, the enlarged test binaries never landed in
+    # the Swatinem/rust-cache entry, so every following nightly restarted from
+    # the same cold state and timed out again. 180 min gives the first post-#641
+    # nightly room to finish and repopulate the cache; warm runs stay far below
+    # it. Previous bump was 60 -> 90 in PR #618 for the same class of growth.
+    timeout-minutes: 180
     env:
       TARGET: x86_64-pc-windows-msvc
     steps:


### PR DESCRIPTION
## What was broken

The **Nightly Build is red.** Run [30190411454](https://github.com/WebFirstLanguage/wfl/actions/runs/30190411454) (2026-07-26 06:03 UTC, sha `8d6aaed2` = v26.7.49) was **cancelled**, not failed: the `Build WFL for Windows` job hit its `timeout-minutes: 90` cap at 07:34:05 and GitHub killed it. `Run tests` was cancelled mid-step; `Run LSP Tests`, the VS Code extension build, the WiX MSI and the whole `release` job were skipped, so **no nightly release was published for 2026-07-26**.

This was the first *full* nightly after PRs #641 and #643 merged. The 07-22 → 07-25 nightlies were all no-change skips on `9a8e0cca`, so the cost increase was invisible until today.

## Root cause

The `Run tests` step runs `cargo test --release --locked`, which compiles **every** integration test binary in `tests/` against the full dependency graph — in release mode, and with `[profile.release] debug = true`, so each binary also links a large PDB on `x86_64-pc-windows-msvc`.

PRs #641/#643 added **26 new test files** (`tests/` is now 112 targets) plus new deps (`tokio-tungstenite` 0.30, `rcgen`, `yasna`, `pem`). Measured against the last full nightly:

| | run 29805777509 (v26.7.47, 07-21) | run 30190411454 (v26.7.49, 07-26) |
|---|---|---|
| `Run tests` | 06:15:05 → 06:42:14 = **27 min**, success | 06:23:57 → cancelled 07:34 = **>70 min**, never reached `Finished` |
| job total | ~47 min | 90 min (capped) |

**Nothing is hung.** The final log line is an ordinary `Compiling tokio-tungstenite v0.30.0` at 06:26:00, and no `Finished`/`Running` line for the test profile ever appears — the step was still in codegen/link when the cap fired.

Worth flagging: **the failure is self-perpetuating.** A cancelled job does not run its cache-save post step (`Post Cache Cargo registry + target dir` is `skipped` in this run), so the enlarged release test binaries never entered the `Swatinem/rust-cache` entry. Every subsequent nightly restarts from the same pre-#641 cache and times out at the same point. The nightly will stay red until the cap is raised once and the cache repopulates.

## The fix

One line plus a rationale comment: `timeout-minutes: 90` → `180` on the `build` job. This mirrors PR #618, which raised the same cap 60 → 90 for the same class of growth.

180 min gives the first post-#641 nightly room to finish and save its cache; warm runs should return to well under an hour once it does.

## Verification

- YAML parses and the value is applied (`jobs.build.timeout-minutes == 180`).
- No source, dependency, `Cargo.lock`, or `.build_meta.json` change — CI-config only, so there is no language-behavior surface and no `TestPrograms/` impact. Backward compatibility is untouched.
- **Honest limitation:** I could not reproduce locally. The failure is specific to release-mode MSVC codegen on `windows-latest`, and this triage environment is aarch64 Linux with no Rust toolchain. The diagnosis rests on the run logs and the step-level timing comparison above, which are unambiguous about *where* the time went. `ci.yml` will not validate this change either — its integration lanes compile the test binaries in **debug** (14 min on Windows today), which is exactly why `ci.yml` stayed green while the nightly went red.
- **Real validation is the next scheduled nightly** (or a `workflow_dispatch` run of `nightly.yml` from this branch) after merge.

## Recommended follow-ups (not in this PR)

1. **Structural:** 112 separate release test binaries is the actual cost driver, and it will grow again. Consolidating related integration tests into fewer harnesses, or splitting `Run tests` into its own parallel job, would cut wall-clock more durably than raising the cap a third time.
2. The nightly-only lint/test gap is still open — `ci.yml` never exercises release-mode Windows test compilation, so this class of regression can only ever surface at 06:00 UTC.

---

*Automated triage PR from the WFL repo warden — opened for a human to review and merge; I have not merged it.*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WebFirstLanguage/codesmith/wfl/pr/645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787648812&installation_model_id=429082&pr_number=645&repository=WebFirstLanguage%2Fwfl&return_to=https%3A%2F%2Fgithub.com%2FWebFirstLanguage%2Fwfl%2Fpull%2F645&signature=3b5c9b51fad75495d7bd97c339e3bf60ed8c6e1597e67c220a2ed9de01318778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the Windows nightly build time limit to reduce failures during longer test compilation and cache recovery.
  * Added workflow documentation explaining the extended timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->