### PR TITLE
Add regression tests for paced upstream streaming

### DIFF
--- a/tests/http_stream_paced_test.rs
+++ b/tests/http_stream_paced_test.rs
@@ -1,0 +1,166 @@
+// Regression tests for outbound response streaming against a *paced* upstream:
+// one that trickles chunks onto a kept-alive connection over time, the way a
+// real model endpoint streams SSE/NDJSON. The existing http_stream_test.rs
+// upstream writes its whole body in one shot with Content-Length and
+// `Connection: close`, so bytes are already buffered by the time the program
+// reads; these tests cover the complementary shape — data that arrives while
+// `wait for next line` is already parked — which is the entire point of
+// `stream response` (see Docs/04-advanced-features/interoperability.md,
+// "an upstream that emits output progressively").
+//
+// Risk class R3 (streaming/lifecycle, testing.md §11.3): proves ordering and
+// wakeups for parked reads, clean EOF via the chunked terminator (NOT via
+// connection close — the server holds the socket open afterwards, as a
+// keep-alive upstream does), and bounded wall-clock completion.
+
+use std::time::Duration;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+/// Spawn an upstream that answers 200 with `Transfer-Encoding: chunked`, then
+/// writes one chunk per line with `delay_ms` between chunks, sends the chunked
+/// terminator, and KEEPS THE CONNECTION OPEN (no `Connection: close`, no
+/// shutdown) so end-of-body is only observable from the chunked framing.
+async fn spawn_paced_chunked_server(lines: Vec<&'static str>, delay_ms: u64) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut tmp = [0u8; 4096];
+        // Drain the request head (single read is enough for a bodyless GET).
+        let _ = socket.read(&mut tmp).await;
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nTransfer-Encoding: chunked\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        socket.flush().await.unwrap();
+        for line in lines {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            let payload = format!("{line}\n");
+            let frame = format!("{:x}\r\n{}\r\n", payload.len(), payload);
+            socket.write_all(frame.as_bytes()).await.unwrap();
+            socket.flush().await.unwrap();
+        }
+        socket.write_all(b"0\r\n\r\n").await.unwrap();
+        socket.flush().await.unwrap();
+        // Keep-alive: hold the socket open long past the test window. The
+        // client must reach EOF from the zero-length chunk alone.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        drop(socket);
+    });
+    format!("http://{addr}")
+}
+
+async fn run_wfl(code: &str) -> Interpreter {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&program)
+        .await
+        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
+    interpreter
+}
+
+fn get_var(interpreter: &Interpreter, name: &str) -> Value {
+    interpreter
+        .global_env()
+        .borrow()
+        .get(name)
+        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
+}
+
+fn get_number(interpreter: &Interpreter, name: &str) -> f64 {
+    match get_var(interpreter, name) {
+        Value::Number(n) => n,
+        other => panic!("Expected '{name}' to be a number, got {other:?}"),
+    }
+}
+
+fn get_text(interpreter: &Interpreter, name: &str) -> String {
+    match get_var(interpreter, name) {
+        Value::Text(t) => t.to_string(),
+        other => panic!("Expected '{name}' to be text, got {other:?}"),
+    }
+}
+
+/// A single chunk that arrives ~200ms AFTER the program has parked in
+/// `wait for next line` must wake the read and be delivered.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_next_line_wakes_for_chunk_arriving_while_parked() {
+    let url = spawn_paced_chunked_server(vec!["late-arrival"], 200).await;
+    let code = format!(
+        r#"
+open url at "{url}" and stream response as up
+wait for next line from up as first_line
+store got as "" with first_line
+wait for next line from up as second_line
+check if second_line is nothing:
+    store eof_ok as "yes"
+otherwise:
+    store eof_ok as "no"
+end check
+close up
+"#
+    );
+
+    let interpreter = tokio::time::timeout(Duration::from_secs(10), run_wfl(&code))
+        .await
+        .expect("stream read stalled: chunk arriving while parked was never delivered");
+    assert_eq!(get_text(&interpreter, "got"), "late-arrival");
+    assert_eq!(get_text(&interpreter, "eof_ok"), "yes");
+}
+
+/// Many paced chunks (the real SSE shape: ~30ms cadence on one kept-alive
+/// connection) must ALL be delivered, in order, ending in a clean EOF.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_next_line_delivers_every_paced_chunk_then_eof() {
+    let lines: Vec<&'static str> = vec![
+        "data: one",
+        "data: two",
+        "data: three",
+        "data: four",
+        "data: five",
+        "data: six",
+        "data: seven",
+        "data: eight",
+        "data: nine",
+        "data: ten",
+    ];
+    let expected = lines.len() as f64;
+    let url = spawn_paced_chunked_server(lines, 30).await;
+    let code = format!(
+        r#"
+open url at "{url}" and stream response as up
+store line_count as 0
+store last_line as ""
+count from 1 to 1000:
+    wait for next line from up as l
+    check if l is nothing:
+        break
+    otherwise:
+        add 1 to line_count
+        change last_line to l
+    end check
+end count
+close up
+"#
+    );
+
+    let interpreter = tokio::time::timeout(Duration::from_secs(15), run_wfl(&code))
+        .await
+        .expect("stream read stalled mid-body: paced chunks were never delivered");
+    assert_eq!(get_number(&interpreter, "line_count"), expected);
+    assert_eq!(get_text(&interpreter, "last_line"), "data: ten");
+}

--- a/tests/http_stream_paced_test.rs
+++ b/tests/http_stream_paced_test.rs
@@ -23,41 +23,14 @@ use wfl::interpreter::value::Value;
 use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
 
-/// Spawn an upstream that answers 200 with `Transfer-Encoding: chunked`, then
-/// writes one chunk per line with `delay_ms` between chunks, sends the chunked
-/// terminator, and KEEPS THE CONNECTION OPEN (no `Connection: close`, no
-/// shutdown) so end-of-body is only observable from the chunked framing.
-async fn spawn_paced_chunked_server(lines: Vec<&'static str>, delay_ms: u64) -> String {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-    tokio::spawn(async move {
-        let (mut socket, _) = listener.accept().await.unwrap();
-        let mut tmp = [0u8; 4096];
-        // Drain the request head (single read is enough for a bodyless GET).
-        let _ = socket.read(&mut tmp).await;
-        socket
-            .write_all(
-                b"HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nTransfer-Encoding: chunked\r\n\r\n",
-            )
-            .await
-            .unwrap();
-        socket.flush().await.unwrap();
-        for line in lines {
-            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
-            let payload = format!("{line}\n");
-            let frame = format!("{:x}\r\n{}\r\n", payload.len(), payload);
-            socket.write_all(frame.as_bytes()).await.unwrap();
-            socket.flush().await.unwrap();
-        }
-        socket.write_all(b"0\r\n\r\n").await.unwrap();
-        socket.flush().await.unwrap();
-        // Keep-alive: hold the socket open long past the test window. The
-        // client must reach EOF from the zero-length chunk alone.
-        tokio::time::sleep(Duration::from_secs(60)).await;
-        drop(socket);
-    });
-    format!("http://{addr}")
+/// One chunked-encoding frame for `payload` + `\n`.
+fn chunk_frame(payload: &str) -> String {
+    let line = format!("{payload}\n");
+    format!("{:x}\r\n{}\r\n", line.len(), line)
 }
+
+const CHUNKED_HEAD: &[u8] =
+    b"HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nTransfer-Encoding: chunked\r\n\r\n";
 
 async fn run_wfl(code: &str) -> Interpreter {
     let tokens = lex_wfl_with_positions(code);
@@ -95,18 +68,77 @@ fn get_text(interpreter: &Interpreter, name: &str) -> String {
     }
 }
 
-/// A single chunk that arrives ~200ms AFTER the program has parked in
-/// `wait for next line` must wake the read and be delivered.
+/// A chunk that arrives strictly AFTER the program has consumed everything
+/// sent so far must wake the parked read and be delivered.
+///
+/// Synchronization (rather than a bare wall-clock delay racing interpreter
+/// startup): the upstream sends a `ready` line immediately, and holds the
+/// late chunk until the program — having consumed `ready` — signals progress
+/// by hitting the server's second endpoint (`/go`). Only then, after a fixed
+/// pause, is the late chunk written. The program also timestamps the parked
+/// read on both sides, and the test asserts it genuinely waited: if the late
+/// chunk had been buffered before the read began (broken-wakeup false pass),
+/// the read would return instantly and the parked-duration assertion would
+/// fail the test rather than let it pass vacuously.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_next_line_wakes_for_chunk_arriving_while_parked() {
-    let url = spawn_paced_chunked_server(vec!["late-arrival"], 200).await;
+    const LATE_DELAY_MS: u64 = 300;
+    // Generous slack under LATE_DELAY_MS: proves the read parked, without
+    // flaking on scheduling jitter.
+    const MIN_PARKED_MS: f64 = 150.0;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        // Connection A: the stream. Head + `ready` line immediately.
+        let (mut stream_sock, _) = listener.accept().await.unwrap();
+        let mut tmp = [0u8; 4096];
+        let _ = stream_sock.read(&mut tmp).await;
+        stream_sock.write_all(CHUNKED_HEAD).await.unwrap();
+        stream_sock
+            .write_all(chunk_frame("ready").as_bytes())
+            .await
+            .unwrap();
+        stream_sock.flush().await.unwrap();
+
+        // Connection B: `/go` — the program signals it has consumed `ready`
+        // and is about to park in the next read.
+        let (mut go_sock, _) = listener.accept().await.unwrap();
+        let _ = go_sock.read(&mut tmp).await;
+        go_sock
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+            .await
+            .unwrap();
+        go_sock.shutdown().await.ok();
+
+        // Now — and only now — pause, then deliver the late chunk and the
+        // chunked terminator. The socket stays open (keep-alive): EOF must
+        // come from the zero-length chunk alone.
+        tokio::time::sleep(Duration::from_millis(LATE_DELAY_MS)).await;
+        stream_sock
+            .write_all(chunk_frame("late-arrival").as_bytes())
+            .await
+            .unwrap();
+        stream_sock.write_all(b"0\r\n\r\n").await.unwrap();
+        stream_sock.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        drop(stream_sock);
+    });
+    let url = format!("http://{addr}");
+
     let code = format!(
         r#"
-open url at "{url}" and stream response as up
-wait for next line from up as first_line
-store got as "" with first_line
-wait for next line from up as second_line
-check if second_line is nothing:
+open url at "{url}/stream" and stream response as up
+wait for next line from up as ready_line
+store got_ready as "" with ready_line
+open url at "{url}/go" and read content as go_ack
+store parked_at as current time in milliseconds
+wait for next line from up as late_line
+store woke_at as current time in milliseconds
+store got_late as "" with late_line
+store parked_ms as woke_at minus parked_at
+wait for next line from up as eof_line
+check if eof_line is nothing:
     store eof_ok as "yes"
 otherwise:
     store eof_ok as "no"
@@ -118,12 +150,21 @@ close up
     let interpreter = tokio::time::timeout(Duration::from_secs(10), run_wfl(&code))
         .await
         .expect("stream read stalled: chunk arriving while parked was never delivered");
-    assert_eq!(get_text(&interpreter, "got"), "late-arrival");
+    assert_eq!(get_text(&interpreter, "got_ready"), "ready");
+    assert_eq!(get_text(&interpreter, "go_ack"), "ok");
+    assert_eq!(get_text(&interpreter, "got_late"), "late-arrival");
     assert_eq!(get_text(&interpreter, "eof_ok"), "yes");
+    let parked_ms = get_number(&interpreter, "parked_ms");
+    assert!(
+        parked_ms >= MIN_PARKED_MS,
+        "read returned after only {parked_ms}ms — the late chunk was already \
+         buffered, so this run never exercised a parked-read wakeup"
+    );
 }
 
 /// Many paced chunks (the real SSE shape: ~30ms cadence on one kept-alive
-/// connection) must ALL be delivered, in order, ending in a clean EOF.
+/// connection) must ALL be delivered — the exact sequence, in order — ending
+/// in a clean EOF from the chunked terminator.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_next_line_delivers_every_paced_chunk_then_eof() {
     let lines: Vec<&'static str> = vec![
@@ -138,20 +179,49 @@ async fn test_next_line_delivers_every_paced_chunk_then_eof() {
         "data: nine",
         "data: ten",
     ];
-    let expected = lines.len() as f64;
-    let url = spawn_paced_chunked_server(lines, 30).await;
+    let expected_count = lines.len() as f64;
+    let expected_sequence = lines
+        .iter()
+        .map(|l| format!("{l}|"))
+        .collect::<Vec<_>>()
+        .join("");
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut tmp = [0u8; 4096];
+        let _ = socket.read(&mut tmp).await;
+        socket.write_all(CHUNKED_HEAD).await.unwrap();
+        socket.flush().await.unwrap();
+        for line in lines {
+            tokio::time::sleep(Duration::from_millis(30)).await;
+            socket
+                .write_all(chunk_frame(line).as_bytes())
+                .await
+                .unwrap();
+            socket.flush().await.unwrap();
+        }
+        socket.write_all(b"0\r\n\r\n").await.unwrap();
+        socket.flush().await.unwrap();
+        // Keep-alive: hold the socket open long past the test window.
+        tokio::time::sleep(Duration::from_secs(60)).await;
+        drop(socket);
+    });
+    let url = format!("http://{addr}");
+
     let code = format!(
         r#"
 open url at "{url}" and stream response as up
 store line_count as 0
-store last_line as ""
+store all_lines as ""
 count from 1 to 1000:
     wait for next line from up as l
     check if l is nothing:
         break
     otherwise:
         add 1 to line_count
-        change last_line to l
+        change all_lines to all_lines with l with "|"
     end check
 end count
 close up
@@ -161,6 +231,6 @@ close up
     let interpreter = tokio::time::timeout(Duration::from_secs(15), run_wfl(&code))
         .await
         .expect("stream read stalled mid-body: paced chunks were never delivered");
-    assert_eq!(get_number(&interpreter, "line_count"), expected);
-    assert_eq!(get_text(&interpreter, "last_line"), "data: ten");
+    assert_eq!(get_number(&interpreter, "line_count"), expected_count);
+    assert_eq!(get_text(&interpreter, "all_lines"), expected_sequence);
 }


### PR DESCRIPTION
## Summary
Add comprehensive regression tests for outbound response streaming against a paced (time-delayed) upstream server. These tests validate the core streaming feature by exercising the scenario it was designed for: an upstream that emits data progressively over time on a kept-alive connection, rather than all at once.

## Key Changes
- **New test file**: `tests/http_stream_paced_test.rs` with two integration tests
  - `test_next_line_wakes_for_chunk_arriving_while_parked()`: Validates that `wait for next line` wakes for a chunk that arrives strictly after the read is parked, and detects EOF via the chunked terminator (not connection close). Synchronization is deterministic rather than a bare wall-clock race: the upstream sends a `ready` line, withholds the late chunk until the program consumes `ready` and hits a `/go` endpoint, and the test asserts the read genuinely parked (>= 150ms of a 300ms delay) so a pre-buffered chunk fails loudly instead of passing vacuously.
  - `test_next_line_delivers_every_paced_chunk_then_eof()`: Validates that many paced chunks (~30ms cadence, simulating real SSE/NDJSON) are delivered in order with clean EOF. It asserts the **complete ordered line sequence** (not just the count and final line), so a dropped, duplicated, substituted, or reordered intermediate line is caught.

- **Shared test helpers**: `chunk_frame()` builds one `Transfer-Encoding: chunked` frame for a line, and the `CHUNKED_HEAD` constant holds the chunked response head. Each test defines its own upstream inline because their shapes differ: the parked-read test needs a two-connection `/go` handshake for deterministic synchronization, while the paced-sequence test uses a simple timed chunk loop. Both hold the connection open after the terminator (no `Connection: close`) so EOF is proven from the chunked framing alone.

## Implementation Details
- Tests use `tokio::time::timeout()` to enforce bounded wall-clock completion and catch stalled reads
- Each server holds its socket open for 60 seconds post-terminator to prove the client doesn't rely on connection close for EOF
- Risk class R3 (streaming/lifecycle per `testing.md` §11.3): proves ordering, wakeups for parked reads, clean EOF via chunked framing, and bounded completion
- Complements existing `http_stream_test.rs` which tests the simpler case (whole body buffered, `Connection: close`)

https://claude.ai/code/session_0141poBiWyVCasUHBttCuHq9
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WebFirstLanguage/codesmith/wfl/pr/650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
