### PR TITLE
ci: build Linux (static musl) in CI and publish artifacts to DO Spaces

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,17 @@
+# actionlint configuration.
+#
+# Every job in this repository runs on a Blacksmith runner rather than a
+# GitHub-hosted one. actionlint only knows the GitHub-hosted label set, so it
+# reports each `runs-on:` value here as `label "..." is unknown` unless the
+# labels are declared. Declaring them is what makes `actionlint` usable on this
+# repo at all - locally, in an editor, or in any review tool that runs it.
+#
+# Keep this list in sync with the `runs-on:` values in .github/workflows/.
+self-hosted-runner:
+  labels:
+    - blacksmith-2vcpu-ubuntu-2404-arm
+    - blacksmith-4vcpu-ubuntu-2404
+    - blacksmith-4vcpu-ubuntu-2404-arm
+    - blacksmith-8vcpu-ubuntu-2404
+    - blacksmith-4vcpu-windows-2025
+    - blacksmith-8vcpu-windows-2025

--- a/.github/workflows/auto-fmt.yml
+++ b/.github/workflows/auto-fmt.yml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   auto-format:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # runs cargo fmt and commits the result - no parallelism to
+    # exploit and no x86 artifact produced, so the smallest ARM runner
+    # does the same work for a third of the price.
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,19 @@ on:
   pull_request:
     branches: [ main ]
 
+# Without this, every push to a branch leaves the previous run compiling a
+# commit whose result nobody will ever read. A superseded clippy-and-test run
+# can burn its full 30-minute budget for nothing.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
+  # Incremental artifacts are pure overhead in CI: the target dir is restored
+  # from cache and never reused across edits, so incremental only bloats what
+  # gets saved back. nightly.yml already sets this.
+  CARGO_INCREMENTAL: 0
 
 # Default to least-privilege; jobs that need more (e.g. bump-version) opt in.
 permissions:
@@ -16,7 +27,10 @@ permissions:
 jobs:
   fmt:
     name: Check formatting
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # `cargo fmt --check` parses and prints. It is setup- and I/O-bound and
+    # never saturates one core, let alone four. Smallest ARM runner:
+    # $0.0025/min against the $0.008 it costs today.
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -31,7 +45,9 @@ jobs:
   # API on stable (libFuzzer/nightly is only needed to actually *run* them).
   fuzz-check:
     name: Fuzz targets compile
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # `cargo check` only - no codegen, and it produces no shipped artifact,
+    # so architecture is irrelevant and ARM is 37.5% cheaper per vCPU.
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     needs: fmt
     steps:
       - uses: actions/checkout@v4
@@ -554,7 +570,10 @@ jobs:
   # so API drift that breaks the fuzz targets blocks the post-merge version bump.
   bump-version:
     name: Bump Version
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Runs the same bump_version.py --update-all as versioning.yml, which shells
+    # out to a locked `cargo check` on the fuzz crate - so this compiles and
+    # needs the same 4 cores as fuzz-check. ARM: no x86 artifact produced.
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     needs: [fmt, fuzz-check, clippy-and-test, integration-tests, database-tests, run-wfl-programs]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
 # Without this, every push to a branch leaves the previous run compiling a
 # commit whose result nobody will ever read. A superseded clippy-and-test run
 # can burn its full 30-minute budget for nothing.
+#
+# Cancellation is deliberately OFF on main: the post-merge `bump-version` job
+# commits, pushes, and *then* tags. Cancelling it between those two writes would
+# leave main carrying an untagged version bump, which is a state no later run
+# repairs. Wasted compute on main is cheap; a missing release tag is not.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -527,16 +527,6 @@ jobs:
             echo "  $b: no PT_INTERP segment - statically linked"
           done
 
-      # The real boundary test, not a proxy for it: run the binaries we are
-      # about to ship on the oldest distro we claim to support. Debian 12 is
-      # exactly where the glibc build failed in issue #616.
-      - name: Prove portability on Debian 12 (wfl#616 regression gate)
-        run: |
-          docker run --rm \
-            -v "$PWD/target/$TARGET/release/wfl:/usr/local/bin/wfl:ro" \
-            -v "$PWD/target/$TARGET/release/wfl-lsp:/usr/local/bin/wfl-lsp:ro" \
-            debian:12-slim sh -c 'wfl --version && wfl-lsp --version'
-
       - name: Smoke test
         run: |
           BIN="$PWD/target/$TARGET/release/wfl"
@@ -572,6 +562,37 @@ jobs:
           EOF
           tar czf "dist/${DIR}-${SHORT_SHA}.tar.gz" -C dist "$DIR"
           ls -la "dist/${DIR}-${SHORT_SHA}.tar.gz"
+
+      # The real boundary test, not a proxy for it, and it runs *after* packaging
+      # on purpose: the thing a user installs is the extracted tarball, not the
+      # build output it was copied from. Verifying the pre-package binaries would
+      # leave `strip` and the tar round-trip untested on the only distro this
+      # gate exists for. Debian 12 is exactly where the glibc build failed in
+      # issue #616.
+      #
+      # The full TestPrograms suite still runs on the host runner (ci.yml); what
+      # is unique here is the old-glibc distro, so this runs the same
+      # comprehensive program the host smoke test does, from the shipped tarball.
+      - name: Prove portability on Debian 12 (wfl#616 regression gate)
+        env:
+          VERSION:   ${{ needs.check-for-changes.outputs.version }}
+          SHORT_SHA: ${{ needs.check-for-changes.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -e TARBALL="wfl-${VERSION}-linux-x86_64-${SHORT_SHA}.tar.gz" \
+            -v "$PWD/dist:/dist:ro" \
+            -v "$PWD/TestPrograms:/TestPrograms:ro" \
+            debian:12-slim sh -euc '
+              cat /etc/debian_version
+              cd /tmp
+              tar xzf "/dist/$TARBALL"
+              cd wfl-*-linux-x86_64
+              ls -la
+              ./wfl --version
+              ./wfl-lsp --version
+              ./wfl /TestPrograms/basic_syntax_comprehensive.wfl
+            '
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -629,6 +629,34 @@ jobs:
             echo "::warning::No VSIX artifacts found in downloaded artifacts directory"
           fi
 
+      # Spaces is the canonical download location; the GitHub Release below is a
+      # mirror, so the canonical publish goes first.
+      #
+      # It also has to go first for retry reasons: the nightly tag and release
+      # ARE the success marker that check-for-changes reads. If the tag existed
+      # and this step failed, the next scheduled run would resolve that tag to
+      # the current commit, set should_build=false, and never retry the publish -
+      # the rolling downloads would stay stale until an unrelated code commit
+      # landed. Failing before the tag is written keeps the run retryable.
+      #
+      # publish_spaces.sh is itself ordered so a partial failure cannot leave the
+      # bucket describing a mixed release (immutable objects first, rolling
+      # pointers and metadata only after every upload succeeds).
+      - name: Publish artifacts to DigitalOcean Spaces
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.SPACES_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_KEY }}
+          SPACES_BUCKET:         wfl
+          SPACES_ENDPOINT:       https://nyc3.digitaloceanspaces.com
+          AWS_DEFAULT_REGION:    nyc3
+        run: |
+          ./scripts/publish_spaces.sh \
+            artifacts \
+            "${{ needs.check-for-changes.outputs.version }}" \
+            "${{ needs.check-for-changes.outputs.short_sha }}" \
+            "${{ github.sha }}" \
+            "${{ github.ref_name }}"
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"
@@ -716,21 +744,3 @@ jobs:
             $ASSET_FILES
 
           echo "Release created successfully: $TAG with $(echo $ASSET_FILES | wc -w) assets"
-
-      # Spaces is the canonical download location; the GitHub Release above is a
-      # mirror. This runs last so a failed upload cannot leave a half-written
-      # bucket sitting behind a release that claims the files are there.
-      - name: Publish artifacts to DigitalOcean Spaces
-        env:
-          AWS_ACCESS_KEY_ID:     ${{ secrets.SPACES_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_KEY }}
-          SPACES_BUCKET:         wfl
-          SPACES_ENDPOINT:       https://nyc3.digitaloceanspaces.com
-          AWS_DEFAULT_REGION:    nyc3
-        run: |
-          ./scripts/publish_spaces.sh \
-            artifacts \
-            "${{ needs.check-for-changes.outputs.version }}" \
-            "${{ needs.check-for-changes.outputs.short_sha }}" \
-            "${{ github.sha }}" \
-            "${{ github.ref_name }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -506,17 +506,25 @@ jobs:
 
       # A musl *target* does not guarantee a static *binary* - one stray dynamic
       # dependency silently reintroduces the libc floor while the job still goes
-      # green. Assert the property we actually promise, for BOTH binaries, and
-      # fail if it is absent.
+      # green. Assert the property we actually promise, for BOTH binaries.
+      #
+      # The authoritative test is the ABSENCE of a PT_INTERP program header: a
+      # binary that names no interpreter cannot be asking a loader for libc at
+      # startup. Do not match on `file` output - Rust's musl target emits a
+      # static-PIE, which `file` describes as "static-pie linked" rather than
+      # "statically linked", so grepping for the latter reports a perfectly
+      # static binary as broken.
       - name: Assert the binaries are statically linked
         run: |
           for b in wfl wfl-lsp; do
             BIN="target/$TARGET/release/$b"
             file "$BIN"
-            if ! file "$BIN" | grep -q "statically linked"; then
-              echo "::error::$BIN is not statically linked - wfl#616 would reappear"
+            if readelf -l "$BIN" | grep -q "Requesting program interpreter"; then
+              echo "::error::$BIN has a PT_INTERP segment - it is dynamically linked and wfl#616 would reappear"
+              readelf -l "$BIN" | grep -A1 INTERP
               exit 1
             fi
+            echo "  $b: no PT_INTERP segment - statically linked"
           done
 
       # The real boundary test, not a proxy for it: run the binaries we are

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,7 +122,15 @@ jobs:
     name: Build WFL for Windows
     needs: check-for-changes
     if: needs.check-for-changes.outputs.should_build == 'true'
-    runs-on: blacksmith-4vcpu-windows-2025
+    # 4 -> 8 vCPU. This job has died on its own timeout twice (runs
+    # 30190411454, and again after PRs #641/#643 added 26 test files), and a
+    # cancelled job never runs its cache-save post step - so each failure left
+    # the next nightly equally cold and it timed out again. Compiling 112
+    # release-mode test binaries is the one workload that genuinely scales
+    # with cores, so doubling them should more than halve wall-clock: ~70min
+    # at $0.016/min = $1.12 becomes ~30min at $0.032/min = $0.96. Cheaper AND
+    # it breaks the timeout death spiral.
+    runs-on: blacksmith-8vcpu-windows-2025
     # `cargo test --release` here compiles EVERY integration test binary in
     # tests/ (112 of them as of 26.7.49) against the full dependency graph, in
     # release mode with `[profile.release] debug = true` — so each one also links
@@ -281,6 +289,11 @@ jobs:
           name: vscode-wfl-${{ needs.check-for-changes.outputs.version }}.vsix
           path: vscode-extension/vscode-wfl-${{ needs.check-for-changes.outputs.version }}.vsix
           if-no-files-found: warn
+          # A hand-off to the release job, not an archive: Spaces and the
+          # GitHub Release are the durable copies. GitHub's 90-day default
+          # retains ~90 nightlies of MSIs and VSIXs on artifact storage, which
+          # GitHub bills separately from Blacksmith compute.
+          retention-days: 7
 
       # ---------- Initialize WiX Source Files ----------
       - name: Initialize WiX source files
@@ -433,12 +446,138 @@ jobs:
           name: wfl-${{ needs.check-for-changes.outputs.version }}.msi
           path: target/${{ env.TARGET }}/release/wfl-${{ needs.check-for-changes.outputs.version }}.msi
           if-no-files-found: error
+          retention-days: 7
+  # ------------------------------------------------------------
+  # BUILD JOB (Linux, statically linked against musl)
+  # ------------------------------------------------------------
+  # Runs in parallel with the Windows leg. This produces the artifact that until
+  # now was built by hand on the wflbuild.starnet droplet, with one deliberate
+  # change: the target is musl, not glibc. The old glibc build IS wfl#616 - it
+  # links against glibc 2.39 from Ubuntu 24.04 and refuses to run on Debian 12
+  # or Ubuntu 22.04. A static musl binary has no libc floor at all.
+  build-linux:
+    name: Build WFL for Linux (static musl)
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.should_build == 'true'
+    # Rust release codegen genuinely scales with cores, so this is one of the
+    # few places a bigger runner pays for itself instead of idling.
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 60
+    env:
+      TARGET: x86_64-unknown-linux-musl
+      CC_x86_64_unknown_linux_musl: musl-gcc
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
+      # Matches the BUILD_INFO the old wflbuild tarballs carried: no debug
+      # symbols in the shipped artifact. Also keeps target/ far below the ~30 GB
+      # ceiling CLAUDE.md warns about, so no disk-space dance is needed here.
+      CARGO_PROFILE_RELEASE_DEBUG: false
+    steps:
+      - uses: actions/checkout@v4
+
+      # cmake and clang are for aws-lc-sys, which reqwest 0.13 pulls in and
+      # which compiles C and assembly. It is the only dependency in the graph
+      # with a musl story to get wrong - there is no openssl-sys anywhere here
+      # (TLS is rustls end to end), so the usual musl blocker does not apply.
+      - name: Install musl toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools musl-dev cmake clang
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+
+      - name: Cache Cargo registry + target dir
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: x86_64-unknown-linux-musl
+          # Only main writes the cache, so PR runs cannot race each other to
+          # overwrite it with a partial target dir.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # Both binaries, matching the Windows MSI, which has always shipped wfl
+      # and wfl-lsp together. The Linux tarball previously carried only wfl, so
+      # editor support was Windows-only by accident of packaging.
+      - name: Build wfl and wfl-lsp
+        run: |
+          cargo build --release --locked --target "$TARGET" --bin wfl
+          cargo build --release --locked --target "$TARGET" -p wfl-lsp --bin wfl-lsp
+
+      # A musl *target* does not guarantee a static *binary* - one stray dynamic
+      # dependency silently reintroduces the libc floor while the job still goes
+      # green. Assert the property we actually promise, for BOTH binaries, and
+      # fail if it is absent.
+      - name: Assert the binaries are statically linked
+        run: |
+          for b in wfl wfl-lsp; do
+            BIN="target/$TARGET/release/$b"
+            file "$BIN"
+            if ! file "$BIN" | grep -q "statically linked"; then
+              echo "::error::$BIN is not statically linked - wfl#616 would reappear"
+              exit 1
+            fi
+          done
+
+      # The real boundary test, not a proxy for it: run the binaries we are
+      # about to ship on the oldest distro we claim to support. Debian 12 is
+      # exactly where the glibc build failed in issue #616.
+      - name: Prove portability on Debian 12 (wfl#616 regression gate)
+        run: |
+          docker run --rm \
+            -v "$PWD/target/$TARGET/release/wfl:/usr/local/bin/wfl:ro" \
+            -v "$PWD/target/$TARGET/release/wfl-lsp:/usr/local/bin/wfl-lsp:ro" \
+            debian:12-slim sh -c 'wfl --version && wfl-lsp --version'
+
+      - name: Smoke test
+        run: |
+          BIN="$PWD/target/$TARGET/release/wfl"
+          "$BIN" --version
+          "$PWD/target/$TARGET/release/wfl-lsp" --version
+          "$BIN" TestPrograms/basic_syntax_comprehensive.wfl
+
+      - name: Package tarball
+        env:
+          VERSION:   ${{ needs.check-for-changes.outputs.version }}
+          SHORT_SHA: ${{ needs.check-for-changes.outputs.short_sha }}
+        run: |
+          set -euo pipefail
+          # Superset of the tarballs already in the Spaces bucket: the existing
+          # wfl-<version>-linux-x86_64/{wfl,README.md,LICENSE,BUILD_INFO} layout
+          # is preserved exactly, with wfl-lsp added alongside. Anything already
+          # installing from that URL keeps working unchanged.
+          DIR="wfl-${VERSION}-linux-x86_64"
+          mkdir -p "dist/$DIR"
+          cp "target/$TARGET/release/wfl"     "dist/$DIR/wfl"
+          cp "target/$TARGET/release/wfl-lsp" "dist/$DIR/wfl-lsp"
+          strip "dist/$DIR/wfl" "dist/$DIR/wfl-lsp"
+          cp README.md LICENSE "dist/$DIR/"
+          cat > "dist/$DIR/BUILD_INFO" <<EOF
+          wfl ${VERSION}
+          commit:   ${{ github.sha }}
+          branch:   ${{ github.ref_name }}
+          built:    $(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          builder:  GitHub Actions / Blacksmith (x86_64-unknown-linux-musl)
+          rustc:    $(rustc --version)
+          contents: wfl, wfl-lsp
+          note:     statically linked against musl - no glibc floor (wfl#616)
+          EOF
+          tar czf "dist/${DIR}-${SHORT_SHA}.tar.gz" -C dist "$DIR"
+          ls -la "dist/${DIR}-${SHORT_SHA}.tar.gz"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wfl-${{ needs.check-for-changes.outputs.version }}-linux-x86_64.tar.gz
+          path: dist/wfl-${{ needs.check-for-changes.outputs.version }}-linux-x86_64-${{ needs.check-for-changes.outputs.short_sha }}.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
   # ------------------------------------------------------------
   # RELEASE JOB
   # ------------------------------------------------------------
   release:
     name: Create or Update Nightly Release
-    needs: [check-for-changes, build]
+    needs: [check-for-changes, build, build-linux]
     if: needs.check-for-changes.outputs.should_build == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -465,6 +604,13 @@ jobs:
           find artifacts -type f -name "*.msi" -exec ls -la {} \;
           echo "VSIX artifacts:"
           find artifacts -type f -name "*.vsix" -exec ls -la {} \;
+          echo "Linux tarballs:"
+          find artifacts -type f -name "*.tar.gz" -exec ls -la {} \;
+
+          if [ $(find artifacts -type f -name "*.tar.gz" | wc -l) -eq 0 ]; then
+            echo "::error::No Linux tarball found in downloaded artifacts directory"
+            exit 1
+          fi
 
           if [ $(find artifacts -type f -name "*.msi" | wc -l) -eq 0 ]; then
             echo "::error::No MSI artifacts found in downloaded artifacts directory"
@@ -523,10 +669,11 @@ jobs:
           # GitHub's immutable releases require assets to be attached during creation
           MSI_FILES=$(find artifacts -type f -name "*.msi")
           VSIX_FILES=$(find artifacts -type f -name "*.vsix")
+          TARBALL_FILES=$(find artifacts -type f -name "*.tar.gz")
 
           # Build the list of files to attach and validate them
           ASSET_FILES=""
-          for f in $MSI_FILES $VSIX_FILES; do
+          for f in $MSI_FILES $VSIX_FILES $TARBALL_FILES; do
             if [ ! -s "$f" ]; then
               echo "::error::Empty or corrupted file: $f"
               exit 1
@@ -553,9 +700,29 @@ jobs:
 
           ## Downloads
           - **wfl-${VERSION}.msi** - Windows MSI installer (includes WFL, WFL-LSP, and VS Code extension)
-          - **vscode-wfl-${VERSION}.vsix** - VS Code extension (standalone installation)" \
+          - **wfl-${VERSION}-linux-x86_64-${SHORT_SHA}.tar.gz** - Linux x86_64 (includes WFL and WFL-LSP), statically linked against musl so it has no glibc requirement
+          - **vscode-wfl-${VERSION}.vsix** - VS Code extension (standalone installation)
+
+          Canonical, CDN-backed downloads: <https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/>" \
             --prerelease \
             $ASSET_FILES
 
           echo "Release created successfully: $TAG with $(echo $ASSET_FILES | wc -w) assets"
 
+      # Spaces is the canonical download location; the GitHub Release above is a
+      # mirror. This runs last so a failed upload cannot leave a half-written
+      # bucket sitting behind a release that claims the files are there.
+      - name: Publish artifacts to DigitalOcean Spaces
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.SPACES_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_KEY }}
+          SPACES_BUCKET:         wfl
+          SPACES_ENDPOINT:       https://nyc3.digitaloceanspaces.com
+          AWS_DEFAULT_REGION:    nyc3
+        run: |
+          ./scripts/publish_spaces.sh \
+            artifacts \
+            "${{ needs.check-for-changes.outputs.version }}" \
+            "${{ needs.check-for-changes.outputs.short_sha }}" \
+            "${{ github.sha }}" \
+            "${{ github.ref_name }}"

--- a/.github/workflows/update-security-doc.yml
+++ b/.github/workflows/update-security-doc.yml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   update-security:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # regenerates a Markdown document - no parallelism to
+    # exploit and no x86 artifact produced, so the smallest ARM runner
+    # does the same work for a third of the price.
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -5,7 +5,10 @@ on:
 
 jobs:
   bump-version:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # bump_version.py --update-all shells out to `cargo update` and a locked
+    # `cargo check` on the fuzz crate, so this compiles - keep 4 cores, and
+    # match the fuzz-check job it mirrors. ARM is 37.5% cheaper per vCPU.
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     permissions:
       contents: write
     steps:

--- a/.github/workflows/wfl-config-lint.yml
+++ b/.github/workflows/wfl-config-lint.yml
@@ -11,7 +11,10 @@ permissions:
 
 jobs:
   config-lint:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # Does a full `cargo build` plus three `cargo run` invocations, so this is a
+    # real compile, not a lint - keep 4 cores. ARM is still 37.5% cheaper at
+    # the same core count, and nothing here produces an x86 artifact.
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     
     steps:
     - uses: actions/checkout@v4

--- a/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
+++ b/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
@@ -31,7 +31,13 @@ Two gates enforce this, because a musl *target* does not by itself guarantee a
 static *binary* — one dependency that links dynamically silently reintroduces
 the floor while CI still reports success:
 
-- `file` must report `statically linked` for **both** binaries, or the job fails.
+- **Both** binaries must have no `PT_INTERP` program header, per `readelf`, or
+  the job fails: a binary that names no interpreter cannot be asking a loader
+  for libc at startup. The first version of this gate grepped `file` output for
+  `statically linked` and failed the whole nightly on a perfectly static
+  binary, because Rust's musl target emits a static PIE, which `file` describes
+  as `static-pie linked`. The ELF fact is the property being claimed; `file`'s
+  phrasing is not.
 - Both binaries are then executed inside `debian:12-slim` — the exact
   distro where the glibc build failed. This is the real boundary, not a proxy
   for it.
@@ -86,8 +92,27 @@ Three things this script gets right that are easy to get wrong:
   `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` is set for this reason. This
   is the single most common cause of "the same command works against S3."
 
-The publish step runs *last* in the release job, so a failed upload cannot leave
-a half-written bucket sitting behind a release that claims the files are there.
+### Failure ordering
+
+Two orderings matter, and the obvious choice for each is the wrong one.
+
+**Within the script**, all immutable objects upload first; the rolling pointers,
+`SHA256SUMS`, and `status.json` are written only once every one of them has
+succeeded. Writing each rolling pointer next to its immutable counterpart reads
+more naturally, but under `set -e` a later failure would then leave
+`wfl-latest-linux-x86_64.tar.gz` pointing at the new build while the Windows
+pointer, the checksums, and `status.json` still described the previous one: a
+mixed release that consumers could observe indefinitely.
+
+**Within the release job**, the Spaces publish runs *before* the nightly tag and
+GitHub Release are created. Publishing last looks safer, but the tag and release
+*are* the success marker `check-for-changes` reads: it resolves the newest
+`nightly-*` tag to a commit and sets `should_build=false` when that matches HEAD.
+A publish failure behind an already-pushed tag therefore would not be retried on
+the next scheduled run, and the rolling downloads would stay stale until an
+unrelated code commit happened to land. Failing before the tag is written keeps
+the run retryable, and the canonical location being written before its mirror is
+the right order anyway.
 
 ## Runner sizing
 
@@ -145,6 +170,11 @@ roughly 70 min at $0.016/min ($1.12) becomes roughly 30 min at $0.032/min
   the CI pipeline green, and it is reversible until then.
 - **#616 should be verifiable as closed** once the first nightly publishes: the
   Debian 12 gate proves the property the issue is about.
-- Docs that point at a download URL should point at
+- Docs ship with the change. `Docs/02-getting-started/installation.md` gains a
+  *Linux x86_64 Tarball* section pointing at
   `https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/wfl-latest-linux-x86_64.tar.gz`,
-  which is now always current and no longer requires a glibc check first.
+  which is now always current and no longer requires a glibc check first, and
+  `Docs/reference/supported-platforms.md` no longer claims static-musl Linux has
+  "no CI lane" and is unverified. Static musl stays **Tier 2**: the new lane is
+  post-merge only and does not run the integration or `TestPrograms` suites, and
+  the promotion policy in that document requires both.

--- a/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
+++ b/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
@@ -11,6 +11,59 @@ Three things, in one change because they only make sense together:
 3. **Runners were right-sized**, including a fix for the Windows nightly's
    timeout spiral.
 
+## Risk class and verification (R3)
+
+**R3: backward compatibility.** The artifact layout and the download URLs are
+user-facing, and #616 is a compatibility defect. No WFL language behaviour
+changes here; the runtime is the same interpreter compiled for a different target,
+so the language-level gates are the existing suites, unchanged.
+
+| Acceptance criterion | Gate that proves it | Layer |
+|---|---|---|
+| The shipped binaries start on the oldest distro we claim to support | *Prove portability on Debian 12*: extracts the published tarball inside `debian:12-slim` and runs `wfl --version`, `wfl-lsp --version`, and `TestPrograms/basic_syntax_comprehensive.wfl` from it | E2E, in-CI, on the packaged artifact |
+| No libc floor is reintroduced by a dependency | *Assert the binaries are statically linked*: fails on a `PT_INTERP` program header in either binary | Artifact property, in-CI |
+| The tarball stays a superset of the layout already published | `dist/wfl-<version>-linux-x86_64/` keeps `wfl`, `README.md`, `LICENSE`, `BUILD_INFO` and adds `wfl-lsp`; existing paths unchanged | Packaging, reviewed diff |
+| Published artifacts are readable *and* byte-identical through the CDN | `publish_spaces.sh` re-downloads every immutable object through the CDN and compares SHA-256 against the local file; rolling keys are checked for a 200 | Integration, in-CI |
+| A partial publish cannot be observed as a release | Two-phase upload: immutable objects first, rolling pointers and metadata only after all of them succeed | Integration, by construction + the ordering test below |
+| `status.json` is always parseable | Built with `jq -n --arg`, so quotes and newlines in `VERSION`/`BRANCH`/artifact names are escaped | Unit, script-level |
+| Language behaviour is unchanged | Existing `cargo test`, integration, and `TestPrograms` suites in `ci.yml` | Unit/integration/E2E |
+
+**Red evidence.**
+
+- *#616 itself is the Red.* The `main` artifact fails the Debian 12 gate by
+  construction: a glibc-2.39-linked binary cannot start there. This change is the
+  Green.
+- *Static-linkage gate.* The first implementation grepped `file` output for
+  `statically linked` and failed the nightly on a perfectly static binary
+  (Rust's musl target emits a static PIE, which `file` calls `static-pie
+  linked`). Observed Red in CI, fixed in `e9e045d`, green after.
+- *`status.json` escaping.* Reproduced with the previous here-doc: a branch name
+  containing `"` produced `"branch": "main"quote"`, which `jq` rejects as invalid
+  JSON. The `jq -n` version emits `"main\"quote"` and parses.
+- *CDN byte verification.* Exercised the script against stub `aws`/`curl` shims:
+  tampering with an already-published object makes the new check exit non-zero
+  with a want/got hash mismatch, where the previous status-code-only check passed.
+- *Region derivation.* With `SPACES_ENDPOINT=https://ams3.digitaloceanspaces.com`
+  the old hardcoded `nyc3` CDN host failed a correct publish; the derived host now
+  follows the endpoint.
+
+**Layers executed.** Workflow lint (`actionlint`, clean apart from two
+pre-existing action-version warnings), `bash -n` and a stubbed end-to-end run of
+`publish_spaces.sh`, and the nightly's own in-CI gates listed above. The Rust
+suites are untouched by this change and run as usual in `ci.yml`.
+
+**Residual risk.**
+
+- The Debian 12 gate is post-merge (nightly), not per-PR, so a portability
+  regression is caught within a day rather than at review time. Static musl stays
+  **Tier 2** in `Docs/reference/supported-platforms.md` for exactly this reason.
+- The publish path cannot be fully exercised without live Spaces credentials, so
+  the ordering and verification logic is proven against shims plus the first real
+  nightly. Until that nightly is green, `wflbuild.starnet` stays in place as the
+  fallback.
+- `aws-lc-sys` compiles C and assembly for musl; if it ever breaks, the escape
+  hatch is pinning reqwest to `rustls-tls-ring`, which belongs in its own change.
+
 ## Why musl and not glibc
 
 Until now the project shipped a Windows MSI nightly and no Linux artifact from

--- a/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
+++ b/Dev diary/2026-07-28-linux-musl-build-and-spaces-publishing.md
@@ -1,0 +1,150 @@
+# 2026-07-28 — Linux builds move into CI (static musl) and artifacts publish to DigitalOcean Spaces
+
+## What changed
+
+Three things, in one change because they only make sense together:
+
+1. **CI now builds Linux.** A new `build-linux` job in `nightly.yml` produces
+   `wfl` and `wfl-lsp` for `x86_64-unknown-linux-musl`, statically linked.
+2. **Artifacts publish to DigitalOcean Spaces**, which becomes the canonical
+   download location. The GitHub Release remains, as a mirror.
+3. **Runners were right-sized**, including a fix for the Windows nightly's
+   timeout spiral.
+
+## Why musl and not glibc
+
+Until now the project shipped a Windows MSI nightly and no Linux artifact from
+CI at all. The Linux tarballs that exist were built by hand on an out-of-band
+host (`wflbuild`), on Ubuntu 24.04, against glibc.
+
+That is issue **#616**: a binary linked against glibc 2.39 will not start on
+Debian 12 or Ubuntu 22.04. It surfaced when the wfl binary refused to run in an
+older sandbox, and again when Scriptorium needed a runtime on an older base
+image.
+
+Lowering the floor by building on Ubuntu 22.04 would have moved the problem
+rather than removed it — there would still be *a* floor, and the next older
+distro would hit it. A statically linked musl binary has no libc floor at all,
+so the class of bug is closed rather than deferred.
+
+Two gates enforce this, because a musl *target* does not by itself guarantee a
+static *binary* — one dependency that links dynamically silently reintroduces
+the floor while CI still reports success:
+
+- `file` must report `statically linked` for **both** binaries, or the job fails.
+- Both binaries are then executed inside `debian:12-slim` — the exact
+  distro where the glibc build failed. This is the real boundary, not a proxy
+  for it.
+
+The dependency graph cooperates: TLS is rustls end to end (`ring` via sqlx,
+`aws-lc-rs` via reqwest), so there is **no `openssl-sys`** anywhere — the usual
+musl blocker does not apply. `aws-lc-sys` does compile C and assembly, which is
+why the job installs `musl-tools`, `musl-dev`, `cmake`, and `clang`.
+
+### wfl-lsp is now in the Linux tarball
+
+The MSI has always shipped `wfl` and `wfl-lsp` together; the Linux tarball
+carried only `wfl`. That made editor support Windows-only by accident of
+packaging rather than by decision. The tarball layout is otherwise unchanged and
+remains a strict superset of what is already published, so existing installers
+keep working:
+
+```
+wfl-<version>-linux-x86_64/
+  wfl
+  wfl-lsp      <- new
+  README.md
+  LICENSE
+  BUILD_INFO
+```
+
+## Publishing
+
+`scripts/publish_spaces.sh` is the only writer to the bucket, so the layout is
+defined in one place:
+
+```
+releases/wfl-<version>-linux-x86_64-<sha>.tar.gz   immutable
+releases/wfl-<version>.msi                         immutable
+releases/vscode-wfl-<version>.vsix                 immutable
+releases/wfl-latest-linux-x86_64.tar.gz            rolling
+releases/wfl-latest-windows-x86_64.msi             rolling
+releases/SHA256SUMS                                checksums for this publish
+status.json                                        last-publish record
+```
+
+Three things this script gets right that are easy to get wrong:
+
+- **Objects are uploaded `public-read`.** The bucket's contents were private —
+  the CDN returned `AccessDenied` for every key — so nothing could actually
+  install from the published URL. The script ends by fetching two keys back
+  *through the CDN* and failing the job on anything but a 200, so an ACL
+  regression can never hide behind a green run.
+- **Rolling pointers get `max-age=60`, not the CDN's 1-hour default.** Otherwise
+  an installer can fetch a stale "latest" for an hour after a successful publish.
+- **AWS CLI v2.23+ sends CRC32 integrity headers that Spaces rejects with a 400.**
+  `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` is set for this reason. This
+  is the single most common cause of "the same command works against S3."
+
+The publish step runs *last* in the release job, so a failed upload cannot leave
+a half-written bucket sitting behind a release that claims the files are there.
+
+## Runner sizing
+
+Cost on Blacksmith is strictly linear in vCPU, so a larger runner only saves
+money if wall-clock time drops proportionally. Each job was classified by what
+dominates its runtime rather than given a blanket size.
+
+| Job | Before | After | Reasoning |
+|---|---|---|---|
+| nightly `build` (Windows) | `4vcpu-windows-2025` | `8vcpu-windows-2025` | See below |
+| nightly `build-linux` | *(new)* | `8vcpu-ubuntu-2404` | Release codegen genuinely scales with cores |
+| `fmt` | `4vcpu-ubuntu-2404` | `2vcpu-ubuntu-2404-arm` | `cargo fmt --check` never saturates one core |
+| `fuzz-check` | `4vcpu-ubuntu-2404` | `4vcpu-ubuntu-2404-arm` | `cargo check` only, no shipped artifact |
+| `bump-version` (both) | `4vcpu-ubuntu-2404` | `4vcpu-ubuntu-2404-arm` | Shells out to a locked `cargo check` on fuzz |
+| `config-lint` | `4vcpu-ubuntu-2404` | `4vcpu-ubuntu-2404-arm` | Full `cargo build` — a compile, not a lint |
+| `auto-fmt`, `update-security-doc` | `4vcpu-ubuntu-2404` | `2vcpu-ubuntu-2404-arm` | No compile at all |
+
+**`clippy-and-test`, `integration-tests`, `database-tests`, and
+`run-wfl-programs` deliberately stay on x64** even though nothing in them
+requires it. They are the gate on the x86_64 binary the project ships; moving
+them to ARM would mean testing an architecture that is not released. The ~38%
+saving is not worth that gap.
+
+### The Windows timeout spiral
+
+The Windows nightly had died on its own timeout more than once (run
+`30190411454`, and again after #641/#643 added 26 test files). The failure was
+self-perpetuating: a cancelled job never runs its cache-save post step, so the
+enlarged test binaries never landed in the `rust-cache` entry, and the next
+nightly restarted from the same cold state and timed out identically. Raising
+the timeout treated the symptom.
+
+`cargo test --release` here compiles 112 integration test binaries, which
+parallelizes well, so doubling the cores should more than halve wall-clock:
+roughly 70 min at $0.016/min ($1.12) becomes roughly 30 min at $0.032/min
+($0.96). Cheaper *and* it breaks the loop.
+
+## Other CI hygiene in this change
+
+- **`concurrency: cancel-in-progress`** on `ci.yml`. Without it, every push to a
+  branch leaves the previous run compiling a commit whose result nobody will
+  read — up to a full 30-minute `clippy-and-test` budget, per superseded push.
+- **`CARGO_INCREMENTAL: 0`** in `ci.yml`, matching `nightly.yml`. The target dir
+  is restored from cache and never reused across edits, so incremental artifacts
+  only bloat what gets saved back.
+- **`retention-days: 7`** on the artifact uploads. The 90-day default was
+  retaining ~90 nightlies of MSIs and VSIXs on artifact storage, which GitHub
+  bills separately from Blacksmith compute — so it shows up on a different
+  invoice than people expect.
+
+## Consequences
+
+- `wflbuild.starnet` no longer has a job. Its decommission is deliberately *not*
+  part of this change; it should happen only after several nightlies have proven
+  the CI pipeline green, and it is reversible until then.
+- **#616 should be verifiable as closed** once the first nightly publishes: the
+  Debian 12 gate proves the property the issue is about.
+- Docs that point at a download URL should point at
+  `https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/wfl-latest-linux-x86_64.tar.gz`,
+  which is now always current and no longer requires a glibc check first.

--- a/Docs/02-getting-started/installation.md
+++ b/Docs/02-getting-started/installation.md
@@ -5,6 +5,7 @@ Get WFL running on your system in just a few minutes. Choose the installation me
 ## Installation Methods
 
 - **[Windows MSI Installer](#windows-msi-installer)** - Easiest for Windows users
+- **[Linux x86_64 Tarball](#linux-x86_64-tarball)** - Prebuilt, no dependencies to install
 - **[From Source](#from-source)** - Cross-platform, latest features
 - **[Verify Installation](#verify-installation)** - Make sure it works
 
@@ -68,6 +69,89 @@ To update to a newer version:
 3. Choose "Upgrade" when prompted
 
 Your existing WFL code will continue to work (backward compatibility guarantee).
+
+---
+
+## Linux x86_64 Tarball
+
+**Recommended for Linux users on x86_64.** The tarball ships prebuilt `wfl` and
+`wfl-lsp` binaries, so there is nothing to compile and no runtime to install.
+
+The binaries are statically linked against musl, which means they have **no glibc
+requirement** and run on any x86_64 Linux distribution, including older ones like
+Debian 12 and Ubuntu 22.04. Every nightly build verifies this by running the
+binaries inside a `debian:12-slim` container before publishing them.
+
+### Step 1: Download and Verify
+
+The canonical, CDN-backed download location is
+<https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/>. The GitHub Release is a
+mirror of the same files.
+
+```bash
+BASE=https://wfl.nyc3.cdn.digitaloceanspaces.com/releases
+curl -fLO "$BASE/wfl-latest-linux-x86_64.tar.gz"
+curl -fLO "$BASE/SHA256SUMS"
+```
+
+`wfl-latest-linux-x86_64.tar.gz` always points at the most recent build. To pin a
+specific build instead, download the versioned name shown in `SHA256SUMS`
+(`wfl-<version>-linux-x86_64-<short-sha>.tar.gz`); those objects are immutable.
+
+Check the download against the published checksums:
+
+```bash
+# The rolling "latest" tarball is byte-identical to the versioned one it mirrors,
+# so compare its hash against the Linux entry in SHA256SUMS.
+sha256sum wfl-latest-linux-x86_64.tar.gz
+grep linux-x86_64 SHA256SUMS
+```
+
+The two hashes must match. If they do not, do not install the archive.
+
+### Step 2: Extract
+
+```bash
+tar xzf wfl-latest-linux-x86_64.tar.gz
+```
+
+This creates a `wfl-<version>-linux-x86_64/` directory containing:
+
+- `wfl` - the WFL compiler and runtime
+- `wfl-lsp` - the Language Server, for editor integration
+- `README.md`, `LICENSE`
+- `BUILD_INFO` - version, commit, build time, and target triple
+
+### Step 3: Install
+
+Install both binaries somewhere on your `PATH`:
+
+```bash
+sudo install -m 755 wfl-*-linux-x86_64/wfl     /usr/local/bin/wfl
+sudo install -m 755 wfl-*-linux-x86_64/wfl-lsp /usr/local/bin/wfl-lsp
+```
+
+Prefer a per-user install? Use `~/.local/bin` instead of `/usr/local/bin` and
+drop the `sudo` (make sure `~/.local/bin` is on your `PATH`).
+
+### Step 4: Verify Installation
+
+```bash
+wfl --version
+wfl-lsp --version
+```
+
+### Updating WFL
+
+Repeat Steps 1-3 with the current tarball; `install` overwrites the previous
+binaries in place. Your existing WFL code will continue to work (backward
+compatibility guarantee).
+
+> **Other platforms and architectures:** Linux on `aarch64`, macOS, and non-x86_64
+> musl targets have no prebuilt artifact yet - build [from
+> source](#from-source). See
+> [`supported-platforms.md`](../reference/supported-platforms.md) for the current
+> support tiers.
 
 ---
 

--- a/Docs/reference/supported-platforms.md
+++ b/Docs/reference/supported-platforms.md
@@ -30,7 +30,7 @@ exercises**, not by aspiration.
 | **Linux (glibc)** | `x86_64` | **Tier 1** | `ci.yml` builds + tests on `ubuntu-latest`: unit/integration tests, Clippy (`-D warnings`), database tests (PostgreSQL + MariaDB), and the `TestPrograms` runner. |
 | **Windows** | `x86_64` (`x86_64-pc-windows-msvc`) | **Tier 1** | `ci.yml` runs the integration + `TestPrograms` matrix on `windows-latest`. The MSI installer (`cargo-wix`) and its smoke test run in `nightly.yml` **after** merge, not on PRs. |
 | **macOS** | `x86_64`, `aarch64` (Apple Silicon) | **Tier 2** | Builds from source ([`installation.md`](../02-getting-started/installation.md) documents the flow) but is **not** in CI. Supported best-effort until a macOS CI lane is added. |
-| **Linux (musl / non-glibc)** | any | **Tier 2** | No CI lane; static-musl builds are expected to work but unverified. |
+| **Linux (musl, static)** | `x86_64` (`x86_64-unknown-linux-musl`) | **Tier 2** | `nightly.yml` (`build-linux`) builds `wfl` + `wfl-lsp`, asserts neither binary carries a program interpreter (`PT_INTERP`, i.e. no libc floor), runs them on `debian:12-slim`, and smoke-tests one `TestPrograms` program. That lane is post-merge only, **not** on PRs, and does not run the integration or full `TestPrograms` suites, so static musl stays Tier 2 under the promotion policy below. This is the artifact published to the canonical CDN (see [`installation.md`](../02-getting-started/installation.md#linux-x86_64-tarball)). Other musl architectures have no CI lane. |
 | **Linux / other Unix** | `aarch64`, others | **Tier 2** | Pure-Rust with a Tokio runtime; expected to build where the toolchain and dependencies do. Unverified. |
 | **32-bit targets** | `i686`, `armv7`, … | **Unsupported** | Not built or tested. The interpreter runs on a large (1 GiB) call stack thread and assumes 64-bit address space. |
 
@@ -98,8 +98,10 @@ testable, documented, and operable* for **supported language behaviour**:
   mandatory release gate that is **not yet met** — examples are validated
   locally via `scripts/validate_docs_examples.py` today.)
 - Release artifacts are produced by the nightly/release workflows (not from PR
-  CI) and installable via the documented paths; verifiable checksums are a
-  tracked Operations follow-up.
+  CI) and installable via the documented paths. Each publish writes a
+  `SHA256SUMS` file next to the artifacts at
+  <https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/>; signing the installers
+  remains a tracked Operations follow-up.
 
 Support **does not** extend to:
 

--- a/scripts/publish_spaces.sh
+++ b/scripts/publish_spaces.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Publish WFL release artifacts to the DigitalOcean Spaces bucket that backs
+# https://wfl.nyc3.cdn.digitaloceanspaces.com.
+#
+# Spaces is the CANONICAL download location; the GitHub Release is a mirror.
+# This script is the only writer, so the bucket layout is defined here:
+#
+#   releases/wfl-<version>-linux-x86_64-<sha>.tar.gz   immutable, versioned
+#   releases/wfl-<version>.msi                         immutable, versioned
+#   releases/vscode-wfl-<version>.vsix                 immutable, versioned
+#   releases/wfl-latest-linux-x86_64.tar.gz            rolling pointer
+#   releases/SHA256SUMS                                checksums for this publish
+#   status.json                                        last-publish record
+#
+# Usage: publish_spaces.sh <artifact-dir> <version> <short-sha> <commit-sha> <branch>
+#
+# Required env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# Optional env: SPACES_BUCKET (default wfl), SPACES_ENDPOINT (default nyc3)
+
+set -euo pipefail
+
+ARTIFACT_DIR="${1:?artifact dir required}"
+VERSION="${2:?version required}"
+SHORT_SHA="${3:?short sha required}"
+COMMIT_SHA="${4:?commit sha required}"
+BRANCH="${5:-main}"
+
+BUCKET="${SPACES_BUCKET:-wfl}"
+ENDPOINT="${SPACES_ENDPOINT:-https://nyc3.digitaloceanspaces.com}"
+
+# AWS CLI v2.23+ sends CRC32 integrity headers by default. DigitalOcean Spaces
+# rejects them with a 400, so every upload fails with an opaque error unless
+# these are relaxed. This is the single most common reason "aws s3 cp works
+# against S3 but not Spaces".
+export AWS_REQUEST_CHECKSUM_CALCULATION="${AWS_REQUEST_CHECKSUM_CALCULATION:-when_required}"
+export AWS_RESPONSE_CHECKSUM_VALIDATION="${AWS_RESPONSE_CHECKSUM_VALIDATION:-when_required}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-nyc3}"
+
+IMMUTABLE="public, max-age=31536000, immutable"
+# The rolling pointers must NOT inherit the CDN's 1-hour default TTL, or an
+# installer can fetch a stale "latest" for an hour after a successful publish.
+ROLLING="public, max-age=60, must-revalidate"
+
+put() { # put <local-file> <remote-key> <content-type> <cache-control>
+  aws s3 cp "$1" "s3://${BUCKET}/$2" \
+    --endpoint-url "$ENDPOINT" \
+    --acl public-read \
+    --content-type "$3" \
+    --cache-control "$4" \
+    --only-show-errors
+  echo "  -> s3://${BUCKET}/$2"
+}
+
+find_one() { find "$ARTIFACT_DIR" -type f -name "$1" | head -1; }
+
+TARBALL="$(find_one 'wfl-*-linux-x86_64-*.tar.gz')"
+MSI="$(find_one '*.msi')"
+VSIX="$(find_one '*.vsix')"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+: > "$WORK/SHA256SUMS"
+
+PUBLISHED=()
+
+if [ -n "$TARBALL" ]; then
+  echo "Linux tarball: $TARBALL"
+  put "$TARBALL" "releases/$(basename "$TARBALL")" application/gzip "$IMMUTABLE"
+  put "$TARBALL" "releases/wfl-latest-linux-x86_64.tar.gz" application/gzip "$ROLLING"
+  ( cd "$(dirname "$TARBALL")" && sha256sum "$(basename "$TARBALL")" ) >> "$WORK/SHA256SUMS"
+  PUBLISHED+=("$(basename "$TARBALL")")
+else
+  echo "::warning::no Linux tarball found in $ARTIFACT_DIR"
+fi
+
+if [ -n "$MSI" ]; then
+  echo "Windows MSI: $MSI"
+  put "$MSI" "releases/$(basename "$MSI")" application/x-msi "$IMMUTABLE"
+  put "$MSI" "releases/wfl-latest-windows-x86_64.msi" application/x-msi "$ROLLING"
+  ( cd "$(dirname "$MSI")" && sha256sum "$(basename "$MSI")" ) >> "$WORK/SHA256SUMS"
+  PUBLISHED+=("$(basename "$MSI")")
+else
+  echo "::warning::no MSI found in $ARTIFACT_DIR"
+fi
+
+if [ -n "$VSIX" ]; then
+  echo "VS Code extension: $VSIX"
+  put "$VSIX" "releases/$(basename "$VSIX")" application/octet-stream "$IMMUTABLE"
+  ( cd "$(dirname "$VSIX")" && sha256sum "$(basename "$VSIX")" ) >> "$WORK/SHA256SUMS"
+  PUBLISHED+=("$(basename "$VSIX")")
+fi
+
+if [ "${#PUBLISHED[@]}" -eq 0 ]; then
+  echo "::error::nothing was published - refusing to overwrite SHA256SUMS/status.json"
+  exit 1
+fi
+
+put "$WORK/SHA256SUMS" "releases/SHA256SUMS" text/plain "$ROLLING"
+
+cat > "$WORK/status.json" <<JSON
+{
+  "result":   "success",
+  "sha":      "${COMMIT_SHA}",
+  "version":  "${VERSION}",
+  "message":  "built and published ${PUBLISHED[*]}",
+  "branch":   "${BRANCH}",
+  "finished": "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)",
+  "host":     "github-actions/blacksmith"
+}
+JSON
+put "$WORK/status.json" "status.json" application/json "$ROLLING"
+
+# Prove the CDN actually serves what we just uploaded. The bucket was private
+# until this pipeline existed, so a silent ACL regression would break every
+# install while the workflow still reported success.
+CDN="https://${BUCKET}.nyc3.cdn.digitaloceanspaces.com"
+echo "Verifying public readability via CDN..."
+for key in "releases/SHA256SUMS" "status.json"; do
+  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "${CDN}/${key}")"
+  if [ "$code" != "200" ]; then
+    echo "::error::${CDN}/${key} returned HTTP ${code} - objects are not public-read"
+    exit 1
+  fi
+  echo "  200 ${CDN}/${key}"
+done
+
+echo "Published ${#PUBLISHED[@]} artifact(s) to s3://${BUCKET}/releases/"

--- a/scripts/publish_spaces.sh
+++ b/scripts/publish_spaces.sh
@@ -28,6 +28,10 @@ BRANCH="${5:-main}"
 BUCKET="${SPACES_BUCKET:-wfl}"
 ENDPOINT="${SPACES_ENDPOINT:-https://nyc3.digitaloceanspaces.com}"
 
+# `status.json` is serialized with jq rather than a here-doc, so fail loudly and
+# early if it is missing instead of halfway through a publish.
+command -v jq >/dev/null || { echo "::error::jq is required but not installed"; exit 1; }
+
 # AWS CLI v2.23+ sends CRC32 integrity headers by default. DigitalOcean Spaces
 # rejects them with a 400, so every upload fails with an opaque error unless
 # these are relaxed. This is the single most common reason "aws s3 cp works
@@ -35,6 +39,18 @@ ENDPOINT="${SPACES_ENDPOINT:-https://nyc3.digitaloceanspaces.com}"
 export AWS_REQUEST_CHECKSUM_CALCULATION="${AWS_REQUEST_CHECKSUM_CALCULATION:-when_required}"
 export AWS_RESPONSE_CHECKSUM_VALIDATION="${AWS_RESPONSE_CHECKSUM_VALIDATION:-when_required}"
 export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-nyc3}"
+
+# The CDN hostname is <bucket>.<region>.cdn.digitaloceanspaces.com, so the region
+# in it has to be the region we actually uploaded through. Hardcoding one would
+# make the verification below fetch a host the objects were never written to the
+# moment SPACES_ENDPOINT pointed elsewhere, failing a publish that succeeded.
+ENDPOINT_HOST="${ENDPOINT#*://}"
+ENDPOINT_HOST="${ENDPOINT_HOST%%/*}"
+case "$ENDPOINT_HOST" in
+  *.digitaloceanspaces.com) REGION="${ENDPOINT_HOST%%.*}" ;;
+  *)                        REGION="$AWS_DEFAULT_REGION" ;;
+esac
+CDN="https://${BUCKET}.${REGION}.cdn.digitaloceanspaces.com"
 
 IMMUTABLE="public, max-age=31536000, immutable"
 # The rolling pointers must NOT inherit the CDN's 1-hour default TTL, or an
@@ -51,6 +67,8 @@ put() { # put <local-file> <remote-key> <content-type> <cache-control>
   echo "  -> s3://${BUCKET}/$2"
 }
 
+sha256_of() { sha256sum "$1" | cut -d' ' -f1; }
+
 find_one() { find "$ARTIFACT_DIR" -type f -name "$1" | head -1; }
 
 TARBALL="$(find_one 'wfl-*-linux-x86_64-*.tar.gz')"
@@ -62,6 +80,9 @@ trap 'rm -rf "$WORK"' EXIT
 : > "$WORK/SHA256SUMS"
 
 PUBLISHED=()
+# Local paths of the immutable objects, parallel to PUBLISHED, so the CDN check
+# at the end can compare what the CDN serves against the bytes we uploaded.
+PUBLISHED_PATHS=()
 
 # ---------------------------------------------------------------------------
 # Phase 1: immutable, versioned objects.
@@ -77,6 +98,7 @@ if [ -n "$TARBALL" ]; then
   put "$TARBALL" "releases/$(basename "$TARBALL")" application/gzip "$IMMUTABLE"
   ( cd "$(dirname "$TARBALL")" && sha256sum "$(basename "$TARBALL")" ) >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$(basename "$TARBALL")")
+  PUBLISHED_PATHS+=("$TARBALL")
 else
   echo "::warning::no Linux tarball found in $ARTIFACT_DIR"
 fi
@@ -86,6 +108,7 @@ if [ -n "$MSI" ]; then
   put "$MSI" "releases/$(basename "$MSI")" application/x-msi "$IMMUTABLE"
   ( cd "$(dirname "$MSI")" && sha256sum "$(basename "$MSI")" ) >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$(basename "$MSI")")
+  PUBLISHED_PATHS+=("$MSI")
 else
   echo "::warning::no MSI found in $ARTIFACT_DIR"
 fi
@@ -95,6 +118,7 @@ if [ -n "$VSIX" ]; then
   put "$VSIX" "releases/$(basename "$VSIX")" application/octet-stream "$IMMUTABLE"
   ( cd "$(dirname "$VSIX")" && sha256sum "$(basename "$VSIX")" ) >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$(basename "$VSIX")")
+  PUBLISHED_PATHS+=("$VSIX")
 fi
 
 if [ "${#PUBLISHED[@]}" -eq 0 ]; then
@@ -122,24 +146,53 @@ fi
 
 put "$WORK/SHA256SUMS" "releases/SHA256SUMS" text/plain "$ROLLING"
 
-cat > "$WORK/status.json" <<JSON
-{
-  "result":   "success",
-  "sha":      "${COMMIT_SHA}",
-  "version":  "${VERSION}",
-  "message":  "built and published ${PUBLISHED[*]}",
-  "branch":   "${BRANCH}",
-  "finished": "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)",
-  "host":     "github-actions/blacksmith"
-}
-JSON
+# Serialized with jq, not a here-doc: VERSION, BRANCH and the artifact names are
+# interpolated values, and a quote or newline in any of them would silently
+# publish a status.json that no consumer can parse. jq escapes them.
+jq -n \
+  --arg sha      "$COMMIT_SHA" \
+  --arg version  "$VERSION" \
+  --arg message  "built and published ${PUBLISHED[*]}" \
+  --arg branch   "$BRANCH" \
+  --arg finished "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)" \
+  '{
+     result:   "success",
+     sha:      $sha,
+     version:  $version,
+     message:  $message,
+     branch:   $branch,
+     finished: $finished,
+     host:     "github-actions/blacksmith"
+   }' > "$WORK/status.json"
 put "$WORK/status.json" "status.json" application/json "$ROLLING"
 
 # Prove the CDN actually serves what we just uploaded. The bucket was private
 # until this pipeline existed, so a silent ACL regression would break every
 # install while the workflow still reported success.
-CDN="https://${BUCKET}.nyc3.cdn.digitaloceanspaces.com"
 echo "Verifying public readability via CDN..."
+
+# For the artifacts, a 200 is not enough - it proves a key exists, not that the
+# bytes an installer downloads are the ones we built. Pull each immutable object
+# back through the CDN and compare its SHA-256 against the local file.
+for f in "${PUBLISHED_PATHS[@]}"; do
+  key="releases/$(basename "$f")"
+  want="$(sha256_of "$f")"
+  if ! curl -fsS --max-time 300 -o "$WORK/verify.bin" "${CDN}/${key}"; then
+    echo "::error::could not fetch ${CDN}/${key} - the object is not publicly readable"
+    exit 1
+  fi
+  got="$(sha256_of "$WORK/verify.bin")"
+  rm -f "$WORK/verify.bin"
+  if [ "$want" != "$got" ]; then
+    echo "::error::${CDN}/${key} does not match the artifact we uploaded (want ${want}, got ${got})"
+    exit 1
+  fi
+  echo "  ok ${CDN}/${key} sha256=${want}"
+done
+
+# The rolling keys get a byte check only on their status code: they carry
+# max-age=60, so the CDN may legitimately still be serving the previous publish
+# for up to a minute and a hash comparison here would be flaky by design.
 for key in "releases/SHA256SUMS" "status.json"; do
   code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "${CDN}/${key}")"
   if [ "$code" != "200" ]; then

--- a/scripts/publish_spaces.sh
+++ b/scripts/publish_spaces.sh
@@ -63,10 +63,18 @@ trap 'rm -rf "$WORK"' EXIT
 
 PUBLISHED=()
 
+# ---------------------------------------------------------------------------
+# Phase 1: immutable, versioned objects.
+#
+# Every key written here is new, so nothing an installer can already be
+# pointing at changes. With `set -e` a failure anywhere in this phase aborts
+# before a single rolling pointer moves, leaving the previous publish fully
+# intact rather than a mix of old and new. That is why the rolling pointers
+# below are deliberately NOT written next to their immutable counterparts.
+# ---------------------------------------------------------------------------
 if [ -n "$TARBALL" ]; then
   echo "Linux tarball: $TARBALL"
   put "$TARBALL" "releases/$(basename "$TARBALL")" application/gzip "$IMMUTABLE"
-  put "$TARBALL" "releases/wfl-latest-linux-x86_64.tar.gz" application/gzip "$ROLLING"
   ( cd "$(dirname "$TARBALL")" && sha256sum "$(basename "$TARBALL")" ) >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$(basename "$TARBALL")")
 else
@@ -76,7 +84,6 @@ fi
 if [ -n "$MSI" ]; then
   echo "Windows MSI: $MSI"
   put "$MSI" "releases/$(basename "$MSI")" application/x-msi "$IMMUTABLE"
-  put "$MSI" "releases/wfl-latest-windows-x86_64.msi" application/x-msi "$ROLLING"
   ( cd "$(dirname "$MSI")" && sha256sum "$(basename "$MSI")" ) >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$(basename "$MSI")")
 else
@@ -93,6 +100,24 @@ fi
 if [ "${#PUBLISHED[@]}" -eq 0 ]; then
   echo "::error::nothing was published - refusing to overwrite SHA256SUMS/status.json"
   exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 2: rolling pointers and metadata.
+#
+# Only reached once every immutable upload above succeeded, so "latest",
+# SHA256SUMS and status.json always describe the same publish. A failure here
+# can still leave the Linux pointer ahead of the Windows one, so the pointers
+# go first and the metadata that claims the publish is complete goes last.
+# ---------------------------------------------------------------------------
+echo "All immutable objects uploaded; updating rolling pointers..."
+
+if [ -n "$TARBALL" ]; then
+  put "$TARBALL" "releases/wfl-latest-linux-x86_64.tar.gz" application/gzip "$ROLLING"
+fi
+
+if [ -n "$MSI" ]; then
+  put "$MSI" "releases/wfl-latest-windows-x86_64.msi" application/x-msi "$ROLLING"
 fi
 
 put "$WORK/SHA256SUMS" "releases/SHA256SUMS" text/plain "$ROLLING"


### PR DESCRIPTION
## What this does

Three changes that only make sense together: CI now builds Linux, artifacts publish to DigitalOcean Spaces, and runners were right-sized per job.

### 1. Linux builds move into CI, statically linked against musl

New `build-linux` job produces **`wfl` and `wfl-lsp`** for `x86_64-unknown-linux-musl`. Until now the project shipped a Windows MSI nightly and **no Linux artifact from CI at all** - the tarballs that exist were built by hand on an out-of-band host against glibc.

That is issue #616: a binary linked against glibc 2.39 will not start on Debian 12 or Ubuntu 22.04. Building on Ubuntu 22.04 instead would only *lower* the floor; a static musl binary removes it, closing the class of bug rather than deferring it.

**`wfl-lsp` is now in the Linux tarball.** The MSI has always shipped both; the Linux tarball carried only `wfl`, making editor support Windows-only by accident of packaging. Layout is otherwise unchanged and remains a strict superset, so existing installers keep working.

### 2. Publishing to Spaces

`scripts/publish_spaces.sh` is the only writer to the bucket, so the layout lives in one place. Spaces is canonical; the GitHub Release is a mirror.

Three things it gets right that are easy to get wrong:
- **Objects upload `public-read`.** The bucket's contents were private - the CDN returned `AccessDenied` for every key, so nothing could actually install from the published URL. The script now pulls **every immutable object back through the CDN and compares its SHA-256** against the local artifact, so neither an ACL regression nor a corrupted upload can hide behind a green run. (Rolling keys get a status-code check only: at `max-age=60` the CDN may still legitimately serve the previous publish, so a hash comparison there would be flaky by design.)
- **Rolling pointers get `max-age=60`**, not the CDN's 1-hour default, so an installer can't fetch a stale "latest" for an hour after a successful publish.
- **AWS CLI v2.23+ sends CRC32 headers that Spaces rejects with a 400.** `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` handles it.
- **The CDN host is derived from the endpoint**, not hardcoded, so a publish to a non-`nyc3` region verifies the host it actually uploaded to. `status.json` is built with `jq -n --arg` rather than a here-doc, so a quote or newline in a version or branch name can't publish unparseable JSON.

Two failure orderings matter, and the obvious choice for each is the wrong one:
- **Inside the script**, all immutable objects upload first; rolling pointers, `SHA256SUMS` and `status.json` are written only once every one of them succeeded. Writing each pointer next to its immutable upload reads better, but under `set -e` a later failure would leave `wfl-latest-linux-x86_64.tar.gz` on the new build while the Windows pointer, the checksums and `status.json` still described the previous one - a mixed release consumers could observe indefinitely.
- **Inside the release job**, the publish runs *before* the nightly tag and Release. Publishing last looks safer, but the tag *is* the success marker `check-for-changes` reads: it resolves the newest `nightly-*` tag and sets `should_build=false` when it matches HEAD, so a publish failure behind an already-pushed tag would never be retried and the rolling downloads would stay stale until an unrelated commit landed. Failing before the tag is written keeps the run retryable.

### 3. Runner sizing

Cost is strictly linear in vCPU, so a bigger runner only saves money if wall-clock drops proportionally. Sized per job, not blanket.

| Job | Before | After |
|---|---|---|
| nightly `build` (Windows) | `4vcpu-windows-2025` | `8vcpu-windows-2025` |
| nightly `build-linux` | *(new)* | `8vcpu-ubuntu-2404` |
| `fmt`, `auto-fmt`, `update-security-doc` | `4vcpu-ubuntu-2404` | `2vcpu-ubuntu-2404-arm` |
| `fuzz-check`, both `bump-version`, `config-lint` | `4vcpu-ubuntu-2404` | `4vcpu-ubuntu-2404-arm` |

**The Windows change fixes a spiral, not just a slow job.** It had died on its own timeout twice; a cancelled job never runs its cache-save step, so each failure left the next nightly equally cold and it timed out identically. Raising the timeout treated the symptom. Compiling 112 release-mode test binaries parallelizes well: ~70min at $0.016/min ($1.12) becomes ~30min at $0.032/min ($0.96) - cheaper *and* the loop breaks.

**`clippy-and-test`, `integration-tests`, `database-tests` and `run-wfl-programs` deliberately stay on x64** even though nothing in them requires it. They gate the x86_64 binary we ship; moving them to ARM would mean testing an architecture we don't release. The ~38% saving isn't worth that gap.

Also on ci.yml: `concurrency` with `cancel-in-progress` for every ref **except `main`** (the post-merge `bump-version` job commits and *then* tags, and cancelling between those writes would leave main carrying an untagged version bump), `CARGO_INCREMENTAL: 0`, and `retention-days: 7` on artifact uploads (the 90-day default retained ~90 nightlies of MSIs on separately-billed storage). `.github/actionlint.yaml` declares the Blacksmith runner labels so actionlint stops flagging every `runs-on:` in the repo as unknown.

## Test evidence

Per the testing policy, the property claimed is *portability*, and it's verified at the real boundary rather than by proxy:

- **Both** binaries must have no `PT_INTERP` program header (`readelf`) or the job fails - a binary naming no interpreter cannot ask a loader for libc. A musl *target* does not guarantee a static *binary*: one dynamic dep silently reintroduces the floor while CI still goes green. (Not `file` output: Rust's musl target emits a static-PIE, which `file` calls `static-pie linked`, so matching on `statically linked` fails a perfectly static binary.)
- The gate runs **after packaging** and extracts the **shipped tarball** inside **`debian:12-slim`** - the exact distro where the glibc build failed in #616 - then runs both binaries and `TestPrograms/basic_syntax_comprehensive.wfl` from it. Testing the pre-package binaries would leave `strip` and the tar round-trip unverified on the only distro this gate exists for.
- The publish script verifies public readability through the CDN and fails the job otherwise.

**Red evidence:** the current `main` artifact fails the Debian 12 gate by construction - that's the content of #616. This PR is the Green.

## Risk

`aws-lc-sys` (via reqwest 0.13) compiles C and assembly and is the one dependency with a musl story to get wrong. There is **no `openssl-sys`** anywhere - TLS is rustls end to end - so the usual blocker doesn't apply, and `musl-tools`/`cmake`/`clang` are installed for it. If it fights, the clean escape hatch is pinning reqwest to `rustls-tls-ring`, which belongs in its own PR.

Risk class: **R3** (backward compatibility - artifact layout and download URLs are user-facing).

## Docs

`Docs/reference/supported-platforms.md` no longer claims static-musl Linux has "no CI lane" and is unverified; it stays **Tier 2**, since the new lane is post-merge only and does not run the integration or full `TestPrograms` suites, and the promotion policy in that document requires both. `Docs/02-getting-started/installation.md` gains a *Linux x86_64 Tarball* section covering the canonical CDN download, checksum verification against `SHA256SUMS`, and install steps for `wfl` and `wfl-lsp`.

Closes #616.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WebFirstLanguage/codesmith/wfl/pr/656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux x86_64 nightlies as statically linked musl tarballs, including the language server.
  * Linux release downloads are now available through DigitalOcean Spaces, with GitHub Releases retained as a mirror.
  * Added versioned and “latest” artifact downloads, checksums, release status information, and post-upload availability checks.

* **Improvements**
  * Reduced wasted CI work by canceling superseded runs.
  * Improved nightly Windows build reliability and artifact retention.
  * Optimized CI runner selection and build performance across workflows.

* **Documentation**
  * Documented Linux publishing, validation, downloads, and CI improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

