### PR TITLE
Retry outbound requests on reused keep-alive connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,10 +76,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `Failed to send HTTP POST request: error sending request for url (...)` for a
   request the server never received — most visibly as an intermittent failure
   after a program had been idle between calls. Pooled connections are now
-  reused only while idle for under three seconds, and a request that failed
-  before any of the response arrived is re-sent once on a fresh connection, on
-  both the `read response`/`read content` and `stream response` paths. A
-  request that reached a response head is never re-sent
+  reused only while idle for under three seconds, and a request whose
+  connection was lost before any of the response arrived is re-sent once on a
+  fresh connection, on both the `read response`/`read content` and
+  `stream response` paths. Only a lost connection qualifies: a peer that replied
+  with something unparseable, one that refused the connection, and any request
+  that reached a response head are all reported as they stand. Because a
+  connection can also be lost after a server acted on the body, outbound
+  delivery is at-least-once — see the interoperability guide for how to make a
+  non-idempotent call safe to repeat
 - `header "<Name>" of <request>` now reads headers from the request object, so it works inside actions that receive `req` as a parameter (previously looked only at loop-scoped `headers` and failed with "no request in scope") (#597)
 - `respond to ... with <content> and status <code> and content_type <type>` previously parsed the status as the boolean expression `<code> and content_type`, which failed at runtime and left the HTTP request unanswered; status/content_type values now parse as primary expressions
 - `header "<Name>" of <request>` is now case-insensitive; warp normalizes header names to lowercase, so canonically-spelled names like `User-Agent` always returned nothing on real requests. Absent headers now compare equal to `nothing`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - New documentation: `Docs/04-advanced-features/databases.md`; route-parameters section in `Docs/04-advanced-features/web-servers.md`
 
 ### Fixed
+- Outbound HTTP requests no longer fail when they land on a pooled keep-alive
+  connection the peer has already closed. reqwest's 90-second idle window was
+  left at its default while peers close idle connections far sooner (Node at 5
+  seconds, many proxies between 5 and 15), and neither send site could recover,
+  so a `POST` written to a dead socket surfaced as
+  `Failed to send HTTP POST request: error sending request for url (...)` for a
+  request the server never received — most visibly as an intermittent failure
+  after a program had been idle between calls. Pooled connections are now
+  reused only while idle for under three seconds, and a request that failed
+  before any of the response arrived is re-sent once on a fresh connection, on
+  both the `read response`/`read content` and `stream response` paths. A
+  request that reached a response head is never re-sent
 - `header "<Name>" of <request>` now reads headers from the request object, so it works inside actions that receive `req` as a parameter (previously looked only at loop-scoped `headers` and failed with "no request in scope") (#597)
 - `respond to ... with <content> and status <code> and content_type <type>` previously parsed the status as the boolean expression `<code> and content_type`, which failed at runtime and left the HTTP request unanswered; status/content_type values now parse as primary expressions
 - `header "<Name>" of <request>` is now case-insensitive; warp normalizes header names to lowercase, so canonically-spelled names like `User-Agent` always returned nothing on real requests. Absent headers now compare equal to `nothing`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3947,6 +3947,7 @@ dependencies = [
  "glob",
  "hkdf 0.12.4",
  "hmac 0.12.1",
+ "hyper 1.10.1",
  "libc",
  "log",
  "logos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ num-bigint-dig = "0.8.6"
 # present; installing one up front keeps any ambient-default TLS path from
 # panicking. `ring` matches sqlx.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
+hyper = "1"
 
 [features]
 dhat-heap = ["dhat"]    # if you are doing heap profiling

--- a/Dev diary/2026-07-29-http-connection-reuse-retry.md
+++ b/Dev diary/2026-07-29-http-connection-reuse-retry.md
@@ -1,0 +1,121 @@
+# 2026-07-29 — outbound POSTs died on reused keep-alive connections
+
+## Symptom
+
+A WFL app proxying an SSE chat endpoint (Rin) failed roughly 3 runs in 100 of
+its end-to-end suite, and only under CI-style concurrency — a single container
+alone passed 20/20. The app reported:
+
+```
+anthropic proxy (http) ended early: Failed to send HTTP POST request:
+        error sending request for url (http://127.0.0.1:18999/v1/messages)
+```
+
+The mock upstream recorded every request it received, and it had recorded
+nothing: the server never saw the POST. The API key was read correctly and the
+proxy did try to send. The outbound POST simply never left.
+
+The controlled experiment that identified it (4 parallel containers × 25 runs,
+one variable changed, WFL 26.7.57):
+
+| Variant | Runs | Failures |
+|---|---|---|
+| stock mock (Node's default 5s `keepAliveTimeout`) | 100 | 3 |
+| mock with `keepAliveTimeout = 120000` | 100 | 0 |
+
+The failing step sat between two upstream calls, producing local replies for
+several seconds with no upstream traffic. Under load the idle gap crossed 5
+seconds, Node closed the socket, and WFL's next POST went out on a dead one.
+
+## Root cause
+
+Two independent gaps in `src/interpreter/mod.rs`, both in the shared
+`IoClient`:
+
+**1. The connection pool was never configured.**
+
+```rust
+reqwest::Client::builder().build()   // no pool tuning at all
+```
+
+Nothing set `pool_idle_timeout`, so reqwest's default 90-second idle window
+applied. Peers are far less patient — Node closes idle keep-alive sockets at 5
+seconds, most proxies between 5 and 15 — so WFL would happily hand out a socket
+the peer had abandoned 85 seconds ago.
+
+**2. Neither send site could recover.**
+
+```rust
+request.send().await.map_err(|e| {
+    HttpClientError::Request(format!("Failed to send HTTP {method} request: {e}"))
+})
+```
+
+`open_http_stream` (backing `stream response`) and `send_http_request` (the
+buffered `read response`/`read content` path) both turned a send failure
+straight into a runtime error. hyper will not silently replay a non-idempotent
+request — that is not its call to make — so a POST written onto an
+already-closed socket failed permanently instead of reconnecting.
+
+The concurrency dependence was a red herring about the mechanism: contention
+only widened the idle gap. The defect needs nothing but an idle period, which is
+why it is production-relevant — the same client talks to `api.anthropic.com`,
+where a first chat message after an idle spell could 500 rather than reconnect.
+
+## Fix
+
+`pool_idle_timeout` is now 3 seconds (`HTTP_POOL_IDLE_TIMEOUT_SECONDS`), well
+under the common 5-second floor. hyper checks expiry when it takes a connection
+*out* of the pool, so this is not merely a background sweep: a connection idle
+longer than that is never handed out, whatever the runtime is doing. Reuse still
+covers back-to-back requests, where the handshake saving actually is.
+
+That narrows the race but cannot close it — the peer can always close between
+the pool's check and the write — so both send sites now go through
+`IoClient::send_with_reuse_retry`, which re-sends once on a fresh connection
+when `reqwest::Error::is_request()` holds. That predicate means no response head
+arrived, so the caller observed nothing and a re-send cannot duplicate anything
+it could have acted on. The retry is bounded at one attempt (a peer that is
+genuinely gone must surface promptly, not be replayed in a loop), it never fires
+once a response head is in hand (a 500 is the program's to handle), it declines
+to retry a body that cannot be cloned, and it runs inside the existing
+timeout/budget wrapper so it cannot extend a request past its deadline.
+
+## Testing
+
+R3 (lifecycle, streaming, concurrency). Red first:
+`tests/http_connection_reuse_retry_test.rs`, commit `545e4c4`, 3 of 4 failing —
+two of them with the reported message verbatim, `Failed to send HTTP POST
+request: error sending request for url (...)`, reproduced inside WFL with no
+reference to the reporting app.
+
+The upstream in those tests is a raw TCP server rather than a timer, so the
+"peer closed the keep-alive socket" moment is deterministic: it answers normally
+except for the request numbers it is told to drop, where it closes the socket
+with no response — precisely what a client sees when it writes to a socket the
+peer had already decided to close. Coverage:
+
+* buffered `read response` recovers, and the retry lands on a fresh connection;
+* `stream response` recovers (the path the reported failure took);
+* an upstream that closes *every* request is attempted exactly twice and then
+  raises — the retry is bounded, not a loop;
+* an answered request is sent exactly once — no replay behind the program's
+  back;
+* the reported real-world shape: a peer whose keep-alive window is shorter than
+  the gap the program leaves between calls still yields a reply. This one is
+  time-based, so it deliberately does not pin *which* recovery ran — the pool
+  may drop the expired socket, or hand it over and let the re-send fix it.
+
+Stability, since the defect this replaces was itself intermittent: 90 runs green
+(30 sequential + 60 across 6 concurrent copies), 0 failures.
+
+## Residual risk
+
+`is_request()` also covers a request that was fully written and then lost
+without a response — a server that dies mid-request rather than an idle socket.
+Re-sending there could reach a server that had already acted on the first copy.
+The pool timeout makes the stale-socket case, which is the common one, rare
+enough that the retry is mostly a backstop; the alternative (leave it) means
+programs keep seeing spurious hard failures for requests no server ever saw. If
+a caller ever needs "never re-send under any circumstance", that belongs in an
+explicit per-request opt-out rather than in the default.

--- a/Dev diary/2026-07-29-http-connection-reuse-retry.md
+++ b/Dev diary/2026-07-29-http-connection-reuse-retry.md
@@ -73,13 +73,63 @@ covers back-to-back requests, where the handshake saving actually is.
 That narrows the race but cannot close it — the peer can always close between
 the pool's check and the write — so both send sites now go through
 `IoClient::send_with_reuse_retry`, which re-sends once on a fresh connection
-when `reqwest::Error::is_request()` holds. That predicate means no response head
-arrived, so the caller observed nothing and a re-send cannot duplicate anything
-it could have acted on. The retry is bounded at one attempt (a peer that is
-genuinely gone must surface promptly, not be replayed in a loop), it never fires
-once a response head is in hand (a 500 is the program's to handle), it declines
-to retry a body that cannot be cloned, and it runs inside the existing
-timeout/budget wrapper so it cannot extend a request past its deadline.
+when the connection was lost before any of the response arrived. The retry is
+bounded at one attempt (a peer that is genuinely gone must surface promptly, not
+be replayed in a loop), it never fires once a response head is in hand (a 500 is
+the program's to handle), it declines to retry a body that cannot be cloned, and
+it runs inside the existing timeout/budget wrapper so it cannot extend a request
+past its deadline.
+
+### What counts as a lost connection
+
+The first cut keyed on `reqwest::Error::is_request()`, and review caught that
+this is too broad: it is the general "the request phase failed" bucket, so it
+also replayed a POST that a peer had answered with an unparseable reply — a peer
+that demonstrably handled the request — and burned a pointless second attempt on
+a refused connection. The predicate is the entire safety argument for re-sending
+something that may not be idempotent, so it now tests the specific evidence.
+
+Rather than guess at the error shapes, they were measured against a raw TCP peer:
+
+| Failure | Classification |
+|---|---|
+| keep-alive socket closed with no response | `hyper::Error::is_incomplete_message` |
+| non-HTTP reply | `hyper::Error::is_parse` |
+| nothing listening | `is_connect`, io `ConnectionRefused` |
+
+`connection_was_lost` walks the cause chain for the first of those, plus an I/O
+error whose kind says the socket was reset, aborted, broken, or read to an
+unexpected end (the same event as some platforms surface it). Everything else is
+reported to the program as it stands. This needs `hyper` as a direct dependency
+to downcast; it is already in the tree via reqwest and resolves to the same 1.x
+instance.
+
+### The retry future has to be boxed
+
+CI caught a second-order cost on Windows: `execute_file_test`'s depth guard —
+a WFL file that executes itself — died with `STATUS_STACK_OVERFLOW`, on a test
+that had nothing to do with HTTP.
+
+The mechanism is that an inline `async fn` becomes part of the state machine of
+everything that awaits it. Holding a request builder, its replay clone, and an
+in-flight `send()` inline embedded all of that in every statement that can make
+a request, and an `execute file` chain nests one such state machine per level.
+Measured on Linux by shrinking the test thread's stack with `RUST_MIN_STACK`,
+running the same depth-guard test:
+
+| Build | 2048 KiB | 1920 KiB | 1792 KiB |
+|---|---|---|---|
+| before this change | ok | ok | overflow |
+| inline retry future | ok | **overflow** | overflow |
+| boxed retry future | ok | ok | overflow |
+
+So the inline form cost about 150 KiB of headroom on that recursion, and Windows
+test threads sit just about there. `Box::pin` puts the retry's state on the heap
+and restores the previous threshold exactly. One allocation per outbound request
+is not measurable next to a network round trip.
+
+Worth remembering generally: the stack cost of an `async fn` is paid by every
+caller that awaits it inline, and recursion multiplies it.
 
 ## Testing
 
@@ -101,6 +151,8 @@ peer had already decided to close. Coverage:
   raises — the retry is bounded, not a loop;
 * an answered request is sent exactly once — no replay behind the program's
   back;
+* a peer that replies with something unparseable is not replayed either: it
+  handled the request, so the failure is real but the delivery must stay single;
 * the reported real-world shape: a peer whose keep-alive window is shorter than
   the gap the program leaves between calls still yields a reply. This one is
   time-based, so it deliberately does not pin *which* recovery ran — the pool
@@ -111,11 +163,18 @@ Stability, since the defect this replaces was itself intermittent: 90 runs green
 
 ## Residual risk
 
-`is_request()` also covers a request that was fully written and then lost
-without a response — a server that dies mid-request rather than an idle socket.
-Re-sending there could reach a server that had already acted on the first copy.
-The pool timeout makes the stale-socket case, which is the common one, rare
-enough that the retry is mostly a backstop; the alternative (leave it) means
-programs keep seeing spurious hard failures for requests no server ever saw. If
-a caller ever needs "never re-send under any circumstance", that belongs in an
-explicit per-request opt-out rather than in the default.
+A connection can be lost *after* a server has read and acted on the body — a
+server that dies mid-request rather than an idle socket — and nothing on this
+side distinguishes that from a socket the peer abandoned before the request
+arrived. Re-sending there could reach a server that already acted on the first
+copy, so outbound delivery is at-least-once, now stated plainly in the
+interoperability guide.
+
+Narrowing the predicate removed the cases that were provably safe to refuse (an
+answered-but-unparseable reply, a refused connection); this last one is not
+decidable from the client. The pool timeout keeps the recoverable stale-socket
+case dominant, so the retry is mostly a backstop. The alternative — refusing to
+retry — means programs keep seeing spurious hard failures for requests no server
+ever saw, which is the defect this fixes. If a caller ever needs "never re-send
+under any circumstance", that belongs in an explicit per-request opt-out rather
+than in the default.

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -115,27 +115,30 @@ between five and fifteen), and writing to a connection the peer has already
 closed just fails.
 
 That still leaves a narrow window where the peer closes a connection at the
-moment WFL writes a request onto it. So when a request fails before *any* of the
-response reaches WFL — no status, no headers, nothing the program could have
-observed — WFL sends it once more on a fresh connection. This applies to both
-`read response`/`read content` and `stream response`, and both attempts share
-the one timeout described above, so the re-send cannot push a request past its
-deadline.
+moment WFL writes a request onto it. So when the connection is *lost* before any
+of the response reaches WFL — no status, no headers, nothing the program could
+have observed — WFL sends the request once more on a fresh connection. This
+applies to both `read response`/`read content` and `stream response`, and both
+attempts share the one timeout described above, so the re-send cannot push a
+request past its deadline.
 
-A request that got as far as a response head is never re-sent, whatever the
-status: a `500` from the server is yours to handle, not something WFL retries
-behind your back. If the second attempt fails too, the error is raised as usual
-and can be caught with `try`/`catch`.
+Only a lost connection earns that second send. A peer that replied with
+something unparseable, or one that refused the connection outright, has either
+handled the request or cannot be helped by trying again — both are reported to
+your program as they stand. A request that got as far as a response head is never
+re-sent either, whatever the status: a `500` from the server is yours to handle,
+not something WFL retries behind your back. If the second attempt fails too, the
+error is raised as usual and can be caught with `try`/`catch`.
 
 **Non-idempotent requests:** "nothing the program could have observed" is a
-statement about your program, not a guarantee about the server. The same failure
-also covers a request that was fully written and then lost its response — an
-upstream that dies after acting on the body — and WFL cannot tell the two apart,
-so the re-send can reach a server that already processed the first copy. Delivery
-is therefore at-least-once, not exactly-once. If a `POST` (or any other
-non-idempotent call) must never run twice, make it safe to repeat: send an
-idempotency key the upstream deduplicates on, or check server-side state before
-retrying the operation at the WFL level.
+statement about your program, not a guarantee about the server. A connection can
+also be lost *after* a server has read and acted on the body, and nothing on
+WFL's side can tell that apart from a socket the peer abandoned before the
+request arrived — so the re-send can reach a server that already processed the
+first copy. Delivery is therefore at-least-once, not exactly-once. If a `POST`
+(or any other non-idempotent call) must never run twice, make it safe to repeat:
+send an idempotency key the upstream deduplicates on, or check server-side state
+before retrying the operation at the WFL level.
 
 #### Streaming a response incrementally
 

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -127,6 +127,16 @@ status: a `500` from the server is yours to handle, not something WFL retries
 behind your back. If the second attempt fails too, the error is raised as usual
 and can be caught with `try`/`catch`.
 
+**Non-idempotent requests:** "nothing the program could have observed" is a
+statement about your program, not a guarantee about the server. The same failure
+also covers a request that was fully written and then lost its response — an
+upstream that dies after acting on the body — and WFL cannot tell the two apart,
+so the re-send can reach a server that already processed the first copy. Delivery
+is therefore at-least-once, not exactly-once. If a `POST` (or any other
+non-idempotent call) must never run twice, make it safe to repeat: send an
+idempotency key the upstream deduplicates on, or check server-side state before
+retrying the operation at the WFL level.
+
 #### Streaming a response incrementally
 
 `read content` / `read response` buffer the whole body before returning. For a

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -105,6 +105,28 @@ request that is waiting on the remote peer.
 `body` introduce clauses, so use different variable names there (e.g.
 `request_headers`, `payload`).
 
+#### Connection reuse and the automatic re-send
+
+Outbound requests share a pool of keep-alive connections, so back-to-back calls
+to the same host skip the TCP and TLS handshake. A pooled connection is reused
+only while it has been idle for less than three seconds: peers close idle
+connections on their own schedule (Node closes at five seconds, many proxies
+between five and fifteen), and writing to a connection the peer has already
+closed just fails.
+
+That still leaves a narrow window where the peer closes a connection at the
+moment WFL writes a request onto it. So when a request fails before *any* of the
+response reaches WFL — no status, no headers, nothing the program could have
+observed — WFL sends it once more on a fresh connection. This applies to both
+`read response`/`read content` and `stream response`, and both attempts share
+the one timeout described above, so the re-send cannot push a request past its
+deadline.
+
+A request that got as far as a response head is never re-sent, whatever the
+status: a `500` from the server is yours to handle, not something WFL retries
+behind your back. If the second attempt fails too, the error is raised as usual
+and can be caught with `try`/`catch`.
+
 #### Streaming a response incrementally
 
 `read content` / `read response` buffer the whole body before returning. For a

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "glob",
  "hkdf 0.12.4",
  "hmac 0.12.1",
+ "hyper 1.10.1",
  "log",
  "logos",
  "num-bigint-dig",

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2151,6 +2151,23 @@ const HTTP_CANCELLATION_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// observed promptly.
 const REQUEST_DISCONNECT_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
+/// How long an idle keep-alive connection may sit in the outbound pool before
+/// it is dropped instead of reused.
+///
+/// reqwest's own default is 90 seconds, which is longer than most peers keep an
+/// idle connection alive: Node closes at 5 seconds, and proxies commonly sit
+/// between 5 and 15. Reusing a socket the peer has already closed turns the
+/// next request into a spurious failure, so the pool is kept well under that
+/// floor. It does not *close* the race — the peer can still close between the
+/// pool's check and the write, which is what [`IoClient::send_with_reuse_retry`]
+/// is for — it just makes the race rare instead of routine. Connections are
+/// still reused for back-to-back requests, where the win actually is.
+const HTTP_POOL_IDLE_TIMEOUT_SECONDS: u64 = 3;
+
+/// Total attempts (initial send + retries) for an outbound request that never
+/// reached a response head. See [`IoClient::send_with_reuse_retry`].
+const HTTP_SEND_MAX_ATTEMPTS: u32 = 2;
+
 #[derive(Debug)]
 enum FileReadError {
     Io(String),
@@ -2207,10 +2224,71 @@ impl IoClient {
     /// error raised at the request that needs it.
     fn http_client(&self) -> Result<&reqwest::Client, HttpClientError> {
         self.http_client.get_or_try_init(|| {
-            reqwest::Client::builder().build().map_err(|error| {
-                HttpClientError::Request(format!("Could not create HTTP client: {error}"))
-            })
+            reqwest::Client::builder()
+                // Defence in depth against reusing a socket the peer has
+                // already closed: see HTTP_POOL_IDLE_TIMEOUT_SECONDS.
+                .pool_idle_timeout(Duration::from_secs(HTTP_POOL_IDLE_TIMEOUT_SECONDS))
+                .build()
+                .map_err(|error| {
+                    HttpClientError::Request(format!("Could not create HTTP client: {error}"))
+                })
         })
+    }
+
+    /// Send a request, re-sending it once on a fresh connection if the first
+    /// attempt never reached a response head.
+    ///
+    /// Keep-alive connections are pooled, and the peer may close an idle one at
+    /// any moment — Node closes at 5 seconds by default, many proxies between 5
+    /// and 15. When a request is written to a socket the peer has already
+    /// closed, hyper reports a send failure and does *not* replay it: replaying
+    /// a non-idempotent request is not hyper's call to make. Left alone, that
+    /// surfaces to the WFL program as a hard error for a request the server
+    /// never even saw — an intermittent failure that looks exactly like the
+    /// upstream being down, and that gets more likely the longer a program idles
+    /// between calls.
+    ///
+    /// A `reqwest::Error` for which `is_request()` holds means no response head
+    /// arrived, so the caller observed nothing; re-sending it once cannot
+    /// duplicate anything the caller could have acted on, and it is the same
+    /// recovery a person would make by retrying. The retry is deliberately
+    /// bounded at one: a peer that is genuinely gone must surface as an error
+    /// promptly rather than being replayed in a loop. A body that cannot be
+    /// cloned (a streaming body) is never retried, since it cannot be re-sent
+    /// faithfully.
+    ///
+    /// Both send sites use this, so the buffered and streaming paths recover
+    /// identically. The whole thing runs inside the caller's timeout/budget
+    /// wrapper, so the retry cannot extend a request past its deadline.
+    async fn send_with_reuse_retry(
+        request: reqwest::RequestBuilder,
+        method: &str,
+    ) -> Result<reqwest::Response, HttpClientError> {
+        let mut attempt = request;
+        let mut attempts_left = HTTP_SEND_MAX_ATTEMPTS;
+
+        loop {
+            attempts_left -= 1;
+            let replay = if attempts_left > 0 {
+                attempt.try_clone()
+            } else {
+                None
+            };
+
+            match attempt.send().await {
+                Ok(response) => return Ok(response),
+                Err(error) => match replay {
+                    // Nothing came back, so nothing was observed: try once more
+                    // on a connection that is known to be fresh.
+                    Some(retry) if error.is_request() => attempt = retry,
+                    _ => {
+                        return Err(HttpClientError::Request(format!(
+                            "Failed to send HTTP {method} request: {error}"
+                        )));
+                    }
+                },
+            }
+        }
     }
 
     fn new(config: Arc<WflConfig>) -> Self {
@@ -2370,11 +2448,7 @@ impl IoClient {
             }
             None => idle_timeout,
         };
-        let op = async move {
-            request.send().await.map_err(|e| {
-                HttpClientError::Request(format!("Failed to send HTTP {method_owned} request: {e}"))
-            })
-        };
+        let op = async move { Self::send_with_reuse_retry(request, &method_owned).await };
         // Only the head is awaited here; dropping this future on
         // timeout/cancel aborts the connection cleanly.
         let response =
@@ -2961,9 +3035,7 @@ impl IoClient {
         let operation = async move {
             use futures_util::StreamExt;
 
-            let response = request.send().await.map_err(|e| {
-                HttpClientError::Request(format!("Failed to send HTTP {method} request: {e}"))
-            })?;
+            let response = Self::send_with_reuse_retry(request, &method).await?;
 
             let status = response.status().as_u16();
             // Header names are normalized to lowercase for consistent access

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2251,7 +2251,14 @@ impl IoClient {
     /// A `reqwest::Error` for which `is_request()` holds means no response head
     /// arrived, so the caller observed nothing; re-sending it once cannot
     /// duplicate anything the caller could have acted on, and it is the same
-    /// recovery a person would make by retrying. The retry is deliberately
+    /// recovery a person would make by retrying. Note that this is a claim about
+    /// the *caller*, not the upstream: `is_request()` also covers a request that
+    /// was written in full and then lost its response, so a re-sent
+    /// non-idempotent request can reach a server that already acted on the first
+    /// copy. Delivery is at-least-once, which is documented for WFL programs in
+    /// `Docs/04-advanced-features/interoperability.md`; the pool idle timeout
+    /// above is what keeps the recoverable stale-socket case dominant. The retry
+    /// is deliberately
     /// bounded at one: a peer that is genuinely gone must surface as an error
     /// promptly rather than being replayed in a loop. A body that cannot be
     /// cloned (a streaming body) is never retried, since it cannot be re-sent

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -56,9 +56,11 @@ use crate::stdlib;
 use once_cell::sync::OnceCell;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
 use std::io::{self, Write};
 use std::net::IpAddr;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -2274,35 +2276,48 @@ impl IoClient {
     /// Both send sites use this, so the buffered and streaming paths recover
     /// identically. The whole thing runs inside the caller's timeout/budget
     /// wrapper, so the retry cannot extend a request past its deadline.
-    async fn send_with_reuse_retry(
+    ///
+    /// The future is boxed rather than left inline, which is a stack-size
+    /// decision, not a style one. Holding a request builder, its replay clone,
+    /// and an in-flight `send()` inline would embed all of that in the async
+    /// state machine of every statement that can make a request — and a
+    /// `execute file` chain nests one such state machine per level. Measured on
+    /// the self-executing-file depth guard, the inline form cost roughly 150 KiB
+    /// of stack headroom (survived a 2048 KiB thread stack, overflowed at 1920
+    /// KiB, where the same test survived 1920 KiB before this change). One heap
+    /// allocation per outbound request is not measurable next to a network
+    /// round trip; the stack headroom is worth keeping.
+    fn send_with_reuse_retry<'a>(
         request: reqwest::RequestBuilder,
-        method: &str,
-    ) -> Result<reqwest::Response, HttpClientError> {
-        let mut attempt = request;
-        let mut attempts_left = HTTP_SEND_MAX_ATTEMPTS;
+        method: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<reqwest::Response, HttpClientError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut attempt = request;
+            let mut attempts_left = HTTP_SEND_MAX_ATTEMPTS;
 
-        loop {
-            attempts_left -= 1;
-            let replay = if attempts_left > 0 {
-                attempt.try_clone()
-            } else {
-                None
-            };
+            loop {
+                attempts_left -= 1;
+                let replay = if attempts_left > 0 {
+                    attempt.try_clone()
+                } else {
+                    None
+                };
 
-            match attempt.send().await {
-                Ok(response) => return Ok(response),
-                Err(error) => match replay {
-                    // The connection died with nothing to observe: try once
-                    // more on a connection that is known to be fresh.
-                    Some(retry) if Self::connection_was_lost(&error) => attempt = retry,
-                    _ => {
-                        return Err(HttpClientError::Request(format!(
-                            "Failed to send HTTP {method} request: {error}"
-                        )));
-                    }
-                },
+                match attempt.send().await {
+                    Ok(response) => return Ok(response),
+                    Err(error) => match replay {
+                        // The connection died with nothing to observe: try once
+                        // more on a connection that is known to be fresh.
+                        Some(retry) if Self::connection_was_lost(&error) => attempt = retry,
+                        _ => {
+                            return Err(HttpClientError::Request(format!(
+                                "Failed to send HTTP {method} request: {error}"
+                            )));
+                        }
+                    },
+                }
             }
-        }
+        })
     }
 
     /// Did this send failure mean the connection died before any of the response

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2248,21 +2248,28 @@ impl IoClient {
     /// upstream being down, and that gets more likely the longer a program idles
     /// between calls.
     ///
-    /// A `reqwest::Error` for which `is_request()` holds means no response head
-    /// arrived, so the caller observed nothing; re-sending it once cannot
-    /// duplicate anything the caller could have acted on, and it is the same
-    /// recovery a person would make by retrying. Note that this is a claim about
-    /// the *caller*, not the upstream: `is_request()` also covers a request that
-    /// was written in full and then lost its response, so a re-sent
-    /// non-idempotent request can reach a server that already acted on the first
-    /// copy. Delivery is at-least-once, which is documented for WFL programs in
+    /// Only a *lost connection* earns a re-send — see
+    /// [`Self::connection_was_lost`]. The narrower test matters because the
+    /// request may not be idempotent: a peer that answered, even with something
+    /// unparseable, has demonstrably handled the request, and replaying it could
+    /// duplicate whatever it did with the first copy. A connection that died
+    /// before any of the response arrived leaves the caller nothing to have
+    /// acted on, which is what makes the second send the same recovery a person
+    /// would make by retrying.
+    ///
+    /// That last point is a claim about the *caller*, not a guarantee about the
+    /// upstream. A connection can also be lost after a server has read and acted
+    /// on the body, and nothing on this side can tell that apart from a socket
+    /// the peer abandoned before the request arrived — so a re-sent
+    /// non-idempotent request can reach a server that already processed the
+    /// first copy. Delivery is at-least-once, documented for WFL programs in
     /// `Docs/04-advanced-features/interoperability.md`; the pool idle timeout
-    /// above is what keeps the recoverable stale-socket case dominant. The retry
-    /// is deliberately
-    /// bounded at one: a peer that is genuinely gone must surface as an error
-    /// promptly rather than being replayed in a loop. A body that cannot be
-    /// cloned (a streaming body) is never retried, since it cannot be re-sent
-    /// faithfully.
+    /// above is what keeps the recoverable stale-socket case the dominant one.
+    ///
+    /// The retry is deliberately bounded at one: a peer that is genuinely gone
+    /// must surface as an error promptly rather than being replayed in a loop. A
+    /// body that cannot be cloned (a streaming body) is never retried, since it
+    /// cannot be re-sent faithfully.
     ///
     /// Both send sites use this, so the buffered and streaming paths recover
     /// identically. The whole thing runs inside the caller's timeout/budget
@@ -2285,9 +2292,9 @@ impl IoClient {
             match attempt.send().await {
                 Ok(response) => return Ok(response),
                 Err(error) => match replay {
-                    // Nothing came back, so nothing was observed: try once more
-                    // on a connection that is known to be fresh.
-                    Some(retry) if error.is_request() => attempt = retry,
+                    // The connection died with nothing to observe: try once
+                    // more on a connection that is known to be fresh.
+                    Some(retry) if Self::connection_was_lost(&error) => attempt = retry,
                     _ => {
                         return Err(HttpClientError::Request(format!(
                             "Failed to send HTTP {method} request: {error}"
@@ -2296,6 +2303,54 @@ impl IoClient {
                 },
             }
         }
+    }
+
+    /// Did this send failure mean the connection died before any of the response
+    /// arrived — as opposed to the peer answering, or never being reachable at
+    /// all?
+    ///
+    /// This is the whole safety argument for re-sending a request that may not
+    /// be idempotent, so it tests the specific evidence rather than the general
+    /// shape of the failure. `reqwest::Error::is_request()` is far too broad: it
+    /// also covers a peer that replied with something unparseable (which handled
+    /// the request) and a peer that refused the connection (which cannot be
+    /// fixed by trying again immediately). The two signals that do mean the
+    /// connection was lost mid-request:
+    ///
+    /// * `hyper::Error::is_incomplete_message` — the connection closed before
+    ///   the response head, which is exactly what a peer's expired keep-alive
+    ///   socket produces;
+    /// * an I/O error whose kind says the socket was reset, aborted, broken, or
+    ///   read to an unexpected end — the same event seen at the syscall layer,
+    ///   which is what some platforms surface instead.
+    ///
+    /// Anything else — a parse failure, a refused connection, a TLS error — is
+    /// reported to the program as it stands.
+    fn connection_was_lost(error: &reqwest::Error) -> bool {
+        use std::io::ErrorKind as IoErrorKind;
+
+        let mut cause: Option<&(dyn std::error::Error + 'static)> = Some(error);
+        while let Some(current) = cause {
+            if let Some(hyper_error) = current.downcast_ref::<hyper::Error>()
+                && hyper_error.is_incomplete_message()
+            {
+                return true;
+            }
+            if let Some(io_error) = current.downcast_ref::<io::Error>()
+                && matches!(
+                    io_error.kind(),
+                    IoErrorKind::ConnectionReset
+                        | IoErrorKind::ConnectionAborted
+                        | IoErrorKind::BrokenPipe
+                        | IoErrorKind::NotConnected
+                        | IoErrorKind::UnexpectedEof
+                )
+            {
+                return true;
+            }
+            cause = current.source();
+        }
+        false
     }
 
     fn new(config: Arc<WflConfig>) -> Self {

--- a/tests/http_connection_reuse_retry_test.rs
+++ b/tests/http_connection_reuse_retry_test.rs
@@ -24,6 +24,7 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
@@ -43,12 +44,17 @@ struct ServerStats {
     reused_connection_requests: AtomicUsize,
 }
 
-/// Which request numbers (1-based, counted across all connections) the upstream
-/// should answer by closing the socket instead of writing a response.
+/// How the upstream misbehaves.
 #[derive(Clone)]
 enum DropPolicy {
+    /// Close the socket, with no response, on these request numbers (1-based,
+    /// counted across every connection).
     Requests(Vec<usize>),
+    /// Close the socket on every request.
     All,
+    /// Answer everything, but close a kept-alive connection once it has been
+    /// idle this long — what Node's `keepAliveTimeout` does at 5 seconds.
+    IdleAfter(Duration),
 }
 
 impl DropPolicy {
@@ -56,6 +62,14 @@ impl DropPolicy {
         match self {
             DropPolicy::Requests(numbers) => numbers.contains(&request_number),
             DropPolicy::All => true,
+            DropPolicy::IdleAfter(_) => false,
+        }
+    }
+
+    fn idle_timeout(&self) -> Option<Duration> {
+        match self {
+            DropPolicy::IdleAfter(duration) => Some(*duration),
+            _ => None,
         }
     }
 }
@@ -79,6 +93,7 @@ async fn spawn_upstream(policy: DropPolicy) -> (String, Arc<ServerStats>) {
             let conn_stats = Arc::clone(&server_stats);
 
             tokio::spawn(async move {
+                let idle_timeout = policy.idle_timeout();
                 let mut buf: Vec<u8> = Vec::new();
                 let mut requests_on_this_connection = 0usize;
 
@@ -89,7 +104,18 @@ async fn spawn_upstream(policy: DropPolicy) -> (String, Arc<ServerStats>) {
                         if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
                             break Some(pos);
                         }
-                        match socket.read(&mut tmp).await {
+                        // Between requests, an idle connection may time out and
+                        // be closed — the client is not told.
+                        let read = match idle_timeout {
+                            Some(limit) if buf.is_empty() => {
+                                match tokio::time::timeout(limit, socket.read(&mut tmp)).await {
+                                    Ok(result) => result,
+                                    Err(_elapsed) => break None,
+                                }
+                            }
+                            _ => socket.read(&mut tmp).await,
+                        };
+                        match read {
                             Ok(0) | Err(_) => break None,
                             Ok(n) => buf.extend_from_slice(&tmp[..n]),
                         }
@@ -280,6 +306,48 @@ async fn a_permanently_closing_upstream_is_retried_once_and_then_fails() {
         stats.requests.load(Ordering::SeqCst),
         2,
         "the send should be attempted exactly twice (initial + one retry)"
+    );
+}
+
+/// The shape the defect was reported in: a peer whose keep-alive window is
+/// shorter than the gap the program leaves between two calls (Node's 5s default
+/// versus a chat turn spent talking to somebody else).
+///
+/// Unlike the tests above this one is time-based, so it does not pin *which*
+/// recovery ran — the pool may drop the expired socket before the second call,
+/// or hand it over and let the re-send recover. It pins the outcome that
+/// matters either way: an idle gap past the peer's keep-alive window still
+/// yields a reply rather than a spurious send failure. Both calls run through
+/// one interpreter, so they share one connection pool.
+#[tokio::test]
+async fn an_idle_gap_past_the_peers_keepalive_still_gets_a_reply() {
+    let (url, stats) = spawn_upstream(DropPolicy::IdleAfter(Duration::from_millis(300))).await;
+
+    let first = parse(&format!(
+        r#"open url at "{url}" with method "POST" and body "first" and read response as resp
+           store body1 as resp["body"]"#
+    ));
+    let second = parse(&format!(
+        r#"open url at "{url}" with method "POST" and body "second" and read response as later
+           store body2 as later["body"]"#
+    ));
+
+    let mut interpreter = Interpreter::new();
+    interpreter.interpret(&first).await.expect("first call");
+    assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
+
+    // Long enough that the peer has certainly closed the socket it was keeping
+    // alive for us.
+    tokio::time::sleep(Duration::from_millis(900)).await;
+
+    interpreter
+        .interpret(&second)
+        .await
+        .unwrap_or_else(|e| panic!("call after the peer's keep-alive expired: {e:?}"));
+    assert_eq!(get_text(&interpreter, "body2"), "reply2\n");
+    assert!(
+        stats.connections.load(Ordering::SeqCst) >= 2,
+        "the second call must end up on a live connection"
     );
 }
 

--- a/tests/http_connection_reuse_retry_test.rs
+++ b/tests/http_connection_reuse_retry_test.rs
@@ -1,0 +1,306 @@
+// Regression tests for outbound HTTP requests that die on a *reused* keep-alive
+// connection (issue: "connection reuse timeout").
+//
+// The failure in the wild: WFL's shared `reqwest::Client` pools keep-alive
+// sockets for reqwest's default 90-second idle window, while the peer closes
+// idle sockets far sooner (Node's `keepAliveTimeout` is 5s; many proxies sit at
+// 5-15s). After an idle gap the next POST is written onto a socket the peer has
+// already closed. hyper will not silently replay a non-idempotent request, so
+// the send fails permanently — surfacing to the WFL program as
+// "Failed to send HTTP POST request: error sending request for url (...)"
+// instead of transparently reconnecting.
+//
+// A request that never received a response head demonstrably produced no
+// observable effect the caller can see, so re-sending it once on a fresh
+// connection is the correct recovery — that is what these tests pin down, for
+// BOTH send sites (the buffered `read response` path and the `stream response`
+// path), plus the bound that stops the retry from looping.
+//
+// The upstream here is a raw TCP server so the "peer closed the keep-alive
+// socket" moment is deterministic rather than a timing race: it answers
+// normally except for the request numbers it is told to drop, where it closes
+// the socket without writing a response — exactly what the client observes when
+// it writes onto a socket the peer had already decided to close.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
+#[derive(Default)]
+struct ServerStats {
+    /// Requests fully read off the wire, across every connection.
+    requests: AtomicUsize,
+    /// Accepted TCP connections.
+    connections: AtomicUsize,
+    /// Requests that arrived on an already-used (kept-alive) connection.
+    reused_connection_requests: AtomicUsize,
+}
+
+/// Which request numbers (1-based, counted across all connections) the upstream
+/// should answer by closing the socket instead of writing a response.
+#[derive(Clone)]
+enum DropPolicy {
+    Requests(Vec<usize>),
+    All,
+}
+
+impl DropPolicy {
+    fn drops(&self, request_number: usize) -> bool {
+        match self {
+            DropPolicy::Requests(numbers) => numbers.contains(&request_number),
+            DropPolicy::All => true,
+        }
+    }
+}
+
+/// A keep-alive HTTP/1.1 upstream that serves `reply<N>\n` for request N, except
+/// for the request numbers `policy` drops — those get the socket closed with no
+/// response at all, standing in for a peer whose idle timeout fired.
+async fn spawn_upstream(policy: DropPolicy) -> (String, Arc<ServerStats>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let stats = Arc::new(ServerStats::default());
+    let server_stats = Arc::clone(&stats);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut socket, _)) = listener.accept().await else {
+                break;
+            };
+            server_stats.connections.fetch_add(1, Ordering::SeqCst);
+            let policy = policy.clone();
+            let conn_stats = Arc::clone(&server_stats);
+
+            tokio::spawn(async move {
+                let mut buf: Vec<u8> = Vec::new();
+                let mut requests_on_this_connection = 0usize;
+
+                loop {
+                    // Read one complete request (head + Content-Length body).
+                    let mut tmp = [0u8; 1024];
+                    let header_end = loop {
+                        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                            break Some(pos);
+                        }
+                        match socket.read(&mut tmp).await {
+                            Ok(0) | Err(_) => break None,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                    };
+                    let Some(header_end) = header_end else {
+                        return; // client hung up between requests
+                    };
+
+                    let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+                    let content_length = head
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().ok())?
+                        })
+                        .unwrap_or(0);
+
+                    let body_start = header_end + 4;
+                    while buf.len() < body_start + content_length {
+                        match socket.read(&mut tmp).await {
+                            Ok(0) | Err(_) => return,
+                            Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                        }
+                    }
+                    buf.drain(..body_start + content_length);
+
+                    let number = conn_stats.requests.fetch_add(1, Ordering::SeqCst) + 1;
+                    if requests_on_this_connection > 0 {
+                        conn_stats
+                            .reused_connection_requests
+                            .fetch_add(1, Ordering::SeqCst);
+                    }
+                    requests_on_this_connection += 1;
+
+                    if policy.drops(number) {
+                        // The peer's idle timeout "fired": close without a
+                        // response. Dropping the socket at the end of this task
+                        // sends the FIN.
+                        return;
+                    }
+
+                    let body = format!("reply{number}\n");
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{body}",
+                        body.len()
+                    );
+                    if socket.write_all(response.as_bytes()).await.is_err() {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+
+    (format!("http://{addr}"), stats)
+}
+
+fn parse(code: &str) -> wfl::parser::ast::Program {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error: {e:?}"))
+}
+
+async fn run_wfl(code: &str) -> Interpreter {
+    let program = parse(code);
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&program)
+        .await
+        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
+    interpreter
+}
+
+fn get_text(interpreter: &Interpreter, name: &str) -> String {
+    match interpreter.global_env().borrow().get(name) {
+        Some(Value::Text(t)) => t.to_string(),
+        other => panic!("Expected '{name}' to be text, got {other:?}"),
+    }
+}
+
+/// The buffered path: `open url ... and read response`.
+///
+/// Two POSTs through one interpreter (hence one pooled client). The second one
+/// lands on the connection the first one left in the pool, and the peer closes
+/// it instead of answering — the program must still get its reply.
+#[tokio::test]
+async fn buffered_post_survives_a_peer_closed_keepalive_socket() {
+    let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![2])).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "first" and read response as resp1
+        store body1 as resp1["body"]
+        open url at "{url}" with method "POST" and body "second" and read response as resp2
+        store body2 as resp2["body"]
+        store status2 as resp2["status"]
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+
+    assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
+    // Request 2 was dropped by the peer; the retry is request 3.
+    assert_eq!(get_text(&interpreter, "body2"), "reply3\n");
+    match interpreter.global_env().borrow().get("status2") {
+        Some(Value::Number(n)) => assert_eq!(n, 200.0),
+        other => panic!("Expected numeric status, got {other:?}"),
+    }
+
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        3,
+        "expected the dropped request to be re-sent exactly once"
+    );
+    assert!(
+        stats.connections.load(Ordering::SeqCst) >= 2,
+        "the retry must go out on a fresh connection"
+    );
+    assert!(
+        stats.reused_connection_requests.load(Ordering::SeqCst) >= 1,
+        "the second request should have reused the pooled keep-alive socket — \
+         without reuse this test is not exercising the defect"
+    );
+}
+
+/// The streaming path: `open url ... and stream response`. This is the one an
+/// SSE/LLM proxy uses, and the one that produced the reported 500.
+#[tokio::test]
+async fn streaming_post_survives_a_peer_closed_keepalive_socket() {
+    let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![2])).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "warm" and read response as resp1
+        store body1 as resp1["body"]
+        open url at "{url}" with method "POST" and body "stream" and stream response as up
+        wait for next line from up as line1
+        store first_line as line1
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+
+    assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
+    assert_eq!(get_text(&interpreter, "first_line"), "reply3");
+
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        3,
+        "expected the dropped stream request to be re-sent exactly once"
+    );
+    assert!(
+        stats.reused_connection_requests.load(Ordering::SeqCst) >= 1,
+        "the streaming request should have reused the pooled keep-alive socket"
+    );
+}
+
+/// The retry is bounded: an upstream that closes *every* request must produce a
+/// runtime error after exactly one re-send, not an unbounded replay loop.
+#[tokio::test]
+async fn a_permanently_closing_upstream_is_retried_once_and_then_fails() {
+    let (url, stats) = spawn_upstream(DropPolicy::All).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "doomed" and read response as resp
+        "#
+    );
+
+    let program = parse(&code);
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(&program).await;
+
+    let errors = result.expect_err("a peer that never answers must surface an error");
+    let message = errors
+        .iter()
+        .map(|e| e.message.clone())
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        message.contains("Failed to send HTTP POST request"),
+        "unexpected error: {message}"
+    );
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        2,
+        "the send should be attempted exactly twice (initial + one retry)"
+    );
+}
+
+/// A response that *did* arrive is never re-sent: a 500 from the upstream is
+/// the program's to see, not something to replay behind its back.
+#[tokio::test]
+async fn an_answered_request_is_never_re_sent() {
+    let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![])).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "once" and read response as resp
+        store body1 as resp["body"]
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+    assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        1,
+        "a request that got a response head must be sent exactly once"
+    );
+}

--- a/tests/http_connection_reuse_retry_test.rs
+++ b/tests/http_connection_reuse_retry_test.rs
@@ -52,6 +52,8 @@ enum DropPolicy {
     Requests(Vec<usize>),
     /// Close the socket on every request.
     All,
+    /// Answer with something that is not HTTP at all.
+    Garbage,
     /// Answer everything, but close a kept-alive connection once it has been
     /// idle this long — what Node's `keepAliveTimeout` does at 5 seconds.
     IdleAfter(Duration),
@@ -62,8 +64,12 @@ impl DropPolicy {
         match self {
             DropPolicy::Requests(numbers) => numbers.contains(&request_number),
             DropPolicy::All => true,
-            DropPolicy::IdleAfter(_) => false,
+            DropPolicy::Garbage | DropPolicy::IdleAfter(_) => false,
         }
+    }
+
+    fn garbles(&self) -> bool {
+        matches!(self, DropPolicy::Garbage)
     }
 
     fn idle_timeout(&self) -> Option<Duration> {
@@ -155,6 +161,16 @@ async fn spawn_upstream(policy: DropPolicy) -> (String, Arc<ServerStats>) {
                         // The peer's idle timeout "fired": close without a
                         // response. Dropping the socket at the end of this task
                         // sends the FIN.
+                        return;
+                    }
+
+                    if policy.garbles() {
+                        // A reply arrives, but it is not HTTP. The connection
+                        // is alive and the peer clearly handled the request —
+                        // nothing here says the request went unseen.
+                        let _ = socket.write_all(b"NOT-HTTP AT ALL\r\n\r\n").await;
+                        let _ = socket.flush().await;
+                        tokio::time::sleep(Duration::from_millis(200)).await;
                         return;
                     }
 
@@ -348,6 +364,36 @@ async fn an_idle_gap_past_the_peers_keepalive_still_gets_a_reply() {
     assert!(
         stats.connections.load(Ordering::SeqCst) >= 2,
         "the second call must end up on a live connection"
+    );
+}
+
+/// Only a *lost connection* earns a re-send. A peer that answers — even with
+/// something unparseable — has demonstrably handled the request, so replaying it
+/// could duplicate whatever the peer did with the first copy. The send failure
+/// is real either way; what must not happen is a second delivery.
+///
+/// This is the line between "the connection died under the request" and "the
+/// request phase failed for some other reason", and it is why the retry keys on
+/// the connection being lost rather than on any request-phase error.
+#[tokio::test]
+async fn a_non_http_reply_is_not_replayed() {
+    let (url, stats) = spawn_upstream(DropPolicy::Garbage).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "once" and read response as resp
+        "#
+    );
+
+    let program = parse(&code);
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(&program).await;
+
+    result.expect_err("an unparseable reply is still a failed request");
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        1,
+        "a peer that answered must not have the request delivered twice"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes intermittent `Failed to send HTTP POST request` errors that occur when WFL writes to a pooled keep-alive connection the peer has already closed. The peer's idle timeout (typically 5 seconds in Node, 5–15 seconds in proxies) is much shorter than reqwest's default 90-second pool idle window, creating a race where a reused connection may be dead on arrival.

Fixes #659.

## Changes

- **Pool idle timeout**: Set `pool_idle_timeout` to 3 seconds (well under the common 5-second floor) so stale connections are dropped before reuse rather than handed out to fail. hyper checks expiry when it takes a connection *out* of the pool, so an over-idle connection is never handed out, whatever the runtime is doing.

- **Automatic re-send on a lost connection**: Added `IoClient::send_with_reuse_retry()`, which re-sends a request exactly once on a fresh connection when the connection died before any of the response arrived. This applies to both the buffered `read response`/`read content` path and the `stream response` path.

- **What counts as "lost"**: `connection_was_lost()` walks the error's cause chain for `hyper::Error::is_incomplete_message` (the connection closed before the response head — what an expired keep-alive socket produces), or an I/O error whose kind says the socket was reset, aborted, broken, or read to an unexpected end. The error shapes were measured against a raw TCP peer rather than assumed:

  | Failure | Classification | Re-sent? |
  |---|---|---|
  | keep-alive socket closed with no response | `hyper::Error::is_incomplete_message` | yes |
  | non-HTTP reply | `hyper::Error::is_parse` | no |
  | nothing listening | `is_connect`, io `ConnectionRefused` | no |

- **Bounded retry**: Limited to one attempt (initial + one retry = 2 total). A peer that is genuinely gone must surface as an error promptly rather than loop.

- **No replay of observed responses**: A request that reached a response head is never re-sent, even a 500 — the caller has already observed the outcome.

- **Timeout preservation**: Both attempts run inside the caller's existing timeout/budget wrapper, so the retry cannot extend a request past its deadline.

- **At-least-once, stated plainly**: a connection can also be lost *after* a server acted on the body, and that is not decidable from the client. The interoperability guide now says so, and says how to make a non-idempotent call safe to repeat.

## Implementation Details

- `HTTP_POOL_IDLE_TIMEOUT_SECONDS = 3`: the pool idle window.
- `HTTP_SEND_MAX_ATTEMPTS = 2`: the retry bound.
- Both `send_http_request()` (buffered path) and `open_http_stream()` (streaming path) call `send_with_reuse_retry()` instead of `send()` directly.
- The retry only fires if `try_clone()` succeeds on the request builder (streaming bodies that cannot be cloned are never retried).
- `hyper` becomes a direct dependency, used only to downcast the cause chain. It is already in the tree via reqwest and resolves to the same 1.x instance.
- The retry future is **boxed**. That is a stack-size decision, not a style one — see the Windows finding below.

## Testing

`tests/http_connection_reuse_retry_test.rs`:
- Buffered `read response` recovery on a peer-closed keep-alive socket
- Streaming `stream response` recovery (the path the reported failure took)
- Bounded retry: a permanently-closing upstream is attempted exactly twice, then fails
- No re-send of answered requests (a 500 is the program's to handle)
- No re-send of a non-HTTP reply — the peer handled the request, so delivery must stay single
- Real-world shape: an idle gap past the peer's keep-alive window still yields a reply

The recovery tests use a deterministic raw TCP upstream (not timers), so the "peer closed the socket" moment is reproducible.

## Documentation

`Docs/04-advanced-features/interoperability.md` gains a "Connection reuse and the automatic re-send" section covering the pool timeout, what does and does not earn a re-send, and the at-least-once delivery guarantee with mitigations. Dev diary entry at `Dev diary/2026-07-29-http-connection-reuse-retry.md`. `CHANGELOG.md` updated.

## Test evidence

- **Risk class:** R3 — lifecycle and connection reuse on the outbound HTTP path, including the streaming path. Not lowered: the defect is a transport-lifecycle race whose visible symptom was intermittent.
- **Acceptance criteria → tests** (all in `tests/http_connection_reuse_retry_test.rs`):
  - A buffered request that lands on a peer-closed pooled socket still returns its reply, on a fresh connection → `buffered_post_survives_a_peer_closed_keepalive_socket`
  - The same holds for `stream response` → `streaming_post_survives_a_peer_closed_keepalive_socket`
  - The re-send is bounded: a peer that never answers is attempted exactly twice, then raises → `a_permanently_closing_upstream_is_retried_once_and_then_fails`
  - A request that reached a response head is never re-sent → `an_answered_request_is_never_re_sent`
  - A peer that answered with something unparseable is never re-sent → `a_non_http_reply_is_not_replayed`
  - A program idling past the peer's keep-alive window still gets a reply → `an_idle_gap_past_the_peers_keepalive_still_gets_a_reply`
- **Red evidence:**
  - `545e4c4` (test-only, ancestor of Green) — 3 of 4 failing, two with the reported message verbatim: `Failed to send HTTP POST request: error sending request for url (...)`, reproduced inside WFL with no reference to the reporting application. Green at `08a394f`.
  - `c9c0bff` (test-only, ancestor of Green) — the review finding on the re-send condition: the upstream observed 2 deliveries where it must observe 1. Green at `dadbd65`.
- **Green evidence:** `0d3b712` — 6 of 6 passing. Because the defect being fixed was itself intermittent, the suite was re-run 90 times (30 sequential + 60 across 6 concurrent copies): 0 failures.
- **Unit/component:** `cargo test --test http_connection_reuse_retry_test`
- **Integration/contract:** `cargo test --all --no-fail-fast` — 149 test targets, 0 failures.
- **End-to-end:** TestPrograms — 111 passed, 0 failed, 24 skipped (pre-existing skips). `scripts/run_web_tests.sh` — 3/3. `python scripts/validate_docs_examples.py` — 18/18. All against a release binary rebuilt from the final commit.
- **Concurrency/lifecycle (§11.3):** the retry-bound, never-replay-after-response, and never-replay-an-answered-peer tests; the concurrent 60-run stability sweep; and a real-boundary check — the release binary against a stock Node server at its default 5000 ms `keepAliveTimeout`, where a 7-second idle gap opens a fresh connection and succeeds while back-to-back requests still share one connection (reuse preserved, verified from the server's own connection log).
- **Stack headroom (Windows regression, caught by CI and fixed in `0d3b712`):** the first cut left the retry future inline, which embedded a request builder, its replay clone, and an in-flight `send()` in the async state machine of every statement that can make a request — and an `execute file` chain nests one per level. `execute_file_test`'s depth guard overflowed the stack on Windows. Measured on Linux with `RUST_MIN_STACK` on that same test:

  | Build | 2048 KiB | 1920 KiB | 1792 KiB |
  |---|---|---|---|
  | before this branch | ok | ok | overflow |
  | inline retry future | ok | **overflow** | overflow |
  | boxed retry future | ok | ok | overflow |

  `Box::pin` restores the previous threshold exactly, at one allocation per outbound request.
- **Platforms:** Linux x86_64 (`stable-x86_64-unknown-linux-gnu`), debug and release. Windows covered by CI.
- **Not applicable, with reason:** no new syntax, keywords, CLI flags, or config options, so no keyword-reference or configuration-reference updates and no new `TestPrograms/` example; the change is behavior-only on an existing statement.
- **Rollback/recovery:** revert the branch. No external or persisted state changes, no migration.
- **Residual risk:** a connection can be lost *after* a server has read and acted on the body — a server dying mid-request rather than an idle socket — and nothing on the client side distinguishes that from a socket the peer abandoned before the request arrived. Outbound delivery is therefore at-least-once, documented for WFL programs rather than left implicit. Narrowing the predicate removed the cases that were provably safe to refuse; this one is not decidable from the client. A caller needing "never re-send under any circumstance" should get an explicit per-request opt-out rather than a change to the default.

https://claude.ai/code/session_0135fvuWLqRoeDiR8eD5mZQo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<a href="https://app.blacksmith.sh/WebFirstLanguage/codesmith/wfl/pr/658" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"&gt;``</a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>
