### PR TITLE
Only replay outbound requests that are safe to repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,11 +79,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   reused only while idle for under three seconds, and a request whose
   connection was lost before any of the response arrived is re-sent once on a
   fresh connection, on both the `read response`/`read content` and
-  `stream response` paths. Only a lost connection qualifies: a peer that replied
-  with something unparseable, one that refused the connection, and any request
-  that reached a response head are all reported as they stand. Because a
-  connection can also be lost after a server acted on the body, outbound
-  delivery is at-least-once — see the interoperability guide for how to make a
+  `stream response` paths. Two conditions gate that re-send. Only a lost
+  connection qualifies: a peer that replied with something unparseable, one that
+  refused the connection, and any request that reached a response head are all
+  reported as they stand. And only a request that is safe to repeat is re-sent:
+  an idempotent method (`GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`, `TRACE`) or one
+  carrying an `Idempotency-Key` / `X-Idempotency-Key` header. A bare `POST` or
+  `PATCH` is never re-sent, since a lost connection cannot be distinguished from
+  an upstream that committed the body and then died; it relies on the shortened
+  idle window instead. See the interoperability guide for how to make a
   non-idempotent call safe to repeat
 - `header "<Name>" of <request>` now reads headers from the request object, so it works inside actions that receive `req` as a parameter (previously looked only at loop-scoped `headers` and failed with "no request in scope") (#597)
 - `respond to ... with <content> and status <code> and content_type <type>` previously parsed the status as the boolean expression `<code> and content_type`, which failed at runtime and left the HTTP request unanswered; status/content_type values now parse as primary expressions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   refused the connection, and any request that reached a response head are all
   reported as they stand. And only a request that is safe to repeat is re-sent:
   an idempotent method (`GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`, `TRACE`) or one
-  carrying an `Idempotency-Key` / `X-Idempotency-Key` header. A bare `POST` or
+  carrying a non-empty `Idempotency-Key` / `X-Idempotency-Key` header — an empty
+  key value gives the upstream nothing to deduplicate on, so it does not opt into
+  a re-send. A bare `POST` or
   `PATCH` is never re-sent, since a lost connection cannot be distinguished from
   an upstream that committed the body and then died; it relies on the shortened
   idle window instead. See the interoperability guide for how to make a

--- a/Dev diary/2026-07-29-http-connection-reuse-retry.md
+++ b/Dev diary/2026-07-29-http-connection-reuse-retry.md
@@ -149,6 +149,12 @@ to have been lost *and* the request to carry a promise it can be repeated:
 * an `Idempotency-Key` / `X-Idempotency-Key` header — the caller stating the
   upstream deduplicates repeats of this exact request.
 
+The promise lives in the header's *value*, so the predicate requires a non-empty
+one. A header sent as `""` names the key and says nothing: there is nothing for
+the upstream to deduplicate on, and in practice an empty value is an unset
+variable rather than a deliberate opt-in, which is the reading least likely to
+duplicate a charge.
+
 A bare `POST` or `PATCH` gets no re-send; its protection is the 3-second pool
 window, which is what made these failures routine in the first place. Building the
 replay clone up front doubles as the check that the body can be reproduced, so a
@@ -183,6 +189,8 @@ peer had already decided to close. Coverage:
 * the negative half of the replay contract: an unkeyed `POST` against an upstream
   that reads it in full and then closes reaches the server **exactly once** and
   surfaces the failure, rather than being silently submitted twice;
+* the boundary of the key itself: a `POST` carrying `Idempotency-Key` with an
+  empty value is treated as unkeyed and delivered exactly once;
 * the reported real-world shape: a peer whose keep-alive window is shorter than
   the gap the program leaves between calls still yields a reply. The gap is
   longer than our own pool window, since an unkeyed POST has to survive this
@@ -190,7 +198,9 @@ peer had already decided to close. Coverage:
 
 Red for the added replay contract is the test commit preceding the change: with
 the old predicate, `an_unkeyed_post_is_never_replayed` observed 2 deliveries
-where it requires 1.
+where it requires 1. The empty-key boundary was checked the same way, by
+weakening the predicate to accept any present key value:
+`an_empty_idempotency_key_is_not_a_promise` then observed 2 deliveries as well.
 
 Stability, since the defect this replaces was itself intermittent: 90 runs green
 (30 sequential + 60 across 6 concurrent copies), 0 failures.

--- a/Dev diary/2026-07-29-http-connection-reuse-retry.md
+++ b/Dev diary/2026-07-29-http-connection-reuse-retry.md
@@ -73,12 +73,12 @@ covers back-to-back requests, where the handshake saving actually is.
 That narrows the race but cannot close it — the peer can always close between
 the pool's check and the write — so both send sites now go through
 `IoClient::send_with_reuse_retry`, which re-sends once on a fresh connection
-when the connection was lost before any of the response arrived. The retry is
-bounded at one attempt (a peer that is genuinely gone must surface promptly, not
-be replayed in a loop), it never fires once a response head is in hand (a 500 is
-the program's to handle), it declines to retry a body that cannot be cloned, and
-it runs inside the existing timeout/budget wrapper so it cannot extend a request
-past its deadline.
+when the connection was lost before any of the response arrived *and* repeating
+the request is safe. The retry is bounded at one attempt (a peer that is genuinely
+gone must surface promptly, not be replayed in a loop), it never fires once a
+response head is in hand (a 500 is the program's to handle), it declines to retry
+a body that cannot be cloned, and it runs inside the existing timeout/budget
+wrapper so it cannot extend a request past its deadline.
 
 ### What counts as a lost connection
 
@@ -131,6 +131,29 @@ is not measurable next to a network round trip.
 Worth remembering generally: the stack cost of an `async fn` is paid by every
 caller that awaits it inline, and recursion multiplies it.
 
+### A lost connection is not enough on its own
+
+Review then pushed back a second time, and rightly: a lost connection says the
+*caller* saw no response head, not that the upstream saw nothing. A connection
+can also be lost after a server read and committed the body, and nothing on this
+side distinguishes that from a socket the peer abandoned before the request
+arrived. The tests' own upstream reads a dropped request in full before closing,
+which is that ambiguity in miniature — so the narrowed predicate alone would
+still let WFL submit the same charge twice.
+
+`request_may_be_replayed` is the second gate. A re-send now needs the connection
+to have been lost *and* the request to carry a promise it can be repeated:
+
+* an idempotent method per RFC 9110 §9.2.2 (`GET`, `HEAD`, `PUT`, `DELETE`,
+  `OPTIONS`, `TRACE`), or
+* an `Idempotency-Key` / `X-Idempotency-Key` header — the caller stating the
+  upstream deduplicates repeats of this exact request.
+
+A bare `POST` or `PATCH` gets no re-send; its protection is the 3-second pool
+window, which is what made these failures routine in the first place. Building the
+replay clone up front doubles as the check that the body can be reproduced, so a
+streaming body drops out of eligibility there too.
+
 ## Testing
 
 R3 (lifecycle, streaming, concurrency). Red first:
@@ -145,36 +168,46 @@ except for the request numbers it is told to drop, where it closes the socket
 with no response — precisely what a client sees when it writes to a socket the
 peer had already decided to close. Coverage:
 
-* buffered `read response` recovers, and the retry lands on a fresh connection;
-* `stream response` recovers (the path the reported failure took);
+* buffered `read response` recovers for a keyed POST, and the retry lands on a
+  fresh connection;
+* `stream response` recovers for a keyed POST (the path the reported failure
+  took);
+* an idempotent `GET` through `read content` recovers with no key at all;
 * an upstream that closes *every* request is attempted exactly twice and then
   raises — the retry is bounded, not a loop;
 * an answered request is sent exactly once — no replay behind the program's
   back;
-* a peer that replies with something unparseable is not replayed either: it
-  handled the request, so the failure is real but the delivery must stay single;
+* a peer that replies with something unparseable is not replayed either, even
+  with a key permitting it: the peer handled the request, so the failure is real
+  but the delivery must stay single;
+* an idempotent `GET` through `read content` recovers with no key at all;
+* the negative half of the replay contract: an unkeyed `POST` against an upstream
+  that reads it in full and then closes reaches the server **exactly once** and
+  surfaces the failure, rather than being silently submitted twice;
 * the reported real-world shape: a peer whose keep-alive window is shorter than
-  the gap the program leaves between calls still yields a reply. This one is
-  time-based, so it deliberately does not pin *which* recovery ran — the pool
-  may drop the expired socket, or hand it over and let the re-send fix it.
+  the gap the program leaves between calls still yields a reply. The gap is
+  longer than our own pool window, since an unkeyed POST has to survive this
+  case without any re-send — it pins the pool defence specifically.
+
+Red for the added replay contract is the test commit preceding the change: with
+the old predicate, `an_unkeyed_post_is_never_replayed` observed 2 deliveries
+where it requires 1.
 
 Stability, since the defect this replaces was itself intermittent: 90 runs green
 (30 sequential + 60 across 6 concurrent copies), 0 failures.
 
 ## Residual risk
 
-A connection can be lost *after* a server has read and acted on the body — a
-server that dies mid-request rather than an idle socket — and nothing on this
-side distinguishes that from a socket the peer abandoned before the request
-arrived. Re-sending there could reach a server that already acted on the first
-copy, so outbound delivery is at-least-once, now stated plainly in the
-interoperability guide.
+An unkeyed `POST` onto a socket the peer closed inside the 3-second window still
+surfaces as a hard error, because a lost connection is not decidable from the
+client: it cannot be told apart from a delivered request whose response was lost.
+That is the deliberate trade — a spurious, catchable failure beats a duplicated
+charge — and it is narrower than it sounds, since the pool window already removes
+the case that made this routine. Callers who want that last case recovered opt in
+with an idempotency key, the same contract the upstream APIs (Stripe and friends)
+already ask for.
 
-Narrowing the predicate removed the cases that were provably safe to refuse (an
-answered-but-unparseable reply, a refused connection); this last one is not
-decidable from the client. The pool timeout keeps the recoverable stale-socket
-case dominant, so the retry is mostly a backstop. The alternative — refusing to
-retry — means programs keep seeing spurious hard failures for requests no server
-ever saw, which is the defect this fixes. If a caller ever needs "never re-send
-under any circumstance", that belongs in an explicit per-request opt-out rather
-than in the default.
+The key is taken at the caller's word: WFL cannot verify the upstream actually
+deduplicates on it. A program that sends the header to a service which ignores it
+gets at-least-once delivery for that request, which is documented alongside the
+feature in `Docs/04-advanced-features/interoperability.md`.

--- a/Dev diary/2026-07-29-http-connection-reuse-retry.md
+++ b/Dev diary/2026-07-29-http-connection-reuse-retry.md
@@ -180,7 +180,6 @@ peer had already decided to close. Coverage:
 * a peer that replies with something unparseable is not replayed either, even
   with a key permitting it: the peer handled the request, so the failure is real
   but the delivery must stay single;
-* an idempotent `GET` through `read content` recovers with no key at all;
 * the negative half of the replay contract: an unkeyed `POST` against an upstream
   that reads it in full and then closes reaches the server **exactly once** and
   surfaces the failure, rather than being silently submitted twice;

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -124,8 +124,11 @@ repeating that request is safe**. Two things make it safe:
   `TRACE`. Making one of these twice is defined to affect the server the same as
   making it once.
 - **The request carries an idempotency key** — an `Idempotency-Key` (or
-  `X-Idempotency-Key`) header, which is you telling WFL that the upstream
-  collapses repeats of this exact request.
+  `X-Idempotency-Key`) header with a non-empty value, which is you telling WFL
+  that the upstream collapses repeats of this exact request. The promise is the
+  value, not the header name: sending the header with an empty string does not
+  opt into a re-send, so a key that came from an unset variable leaves the
+  request treated as unkeyed.
 
 ```wfl
 create map charge_headers:

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -132,6 +132,8 @@ create map charge_headers:
     "Idempotency-Key" is "order-4417-capture"
 end map
 
+store payload as "{\"order\": \"4417\", \"amount\": 2500}"
+
 // Safe to re-send: the upstream will honour the key and charge once.
 open url at "https://api.example.com/charges"
     with method "POST"

--- a/Docs/04-advanced-features/interoperability.md
+++ b/Docs/04-advanced-features/interoperability.md
@@ -117,28 +117,47 @@ closed just fails.
 That still leaves a narrow window where the peer closes a connection at the
 moment WFL writes a request onto it. So when the connection is *lost* before any
 of the response reaches WFL — no status, no headers, nothing the program could
-have observed — WFL sends the request once more on a fresh connection. This
-applies to both `read response`/`read content` and `stream response`, and both
-attempts share the one timeout described above, so the re-send cannot push a
-request past its deadline.
+have observed — WFL sends the request once more on a fresh connection, **if
+repeating that request is safe**. Two things make it safe:
 
-Only a lost connection earns that second send. A peer that replied with
-something unparseable, or one that refused the connection outright, has either
-handled the request or cannot be helped by trying again — both are reported to
-your program as they stand. A request that got as far as a response head is never
-re-sent either, whatever the status: a `500` from the server is yours to handle,
-not something WFL retries behind your back. If the second attempt fails too, the
-error is raised as usual and can be caught with `try`/`catch`.
+- **The method is idempotent** — `GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS`, and
+  `TRACE`. Making one of these twice is defined to affect the server the same as
+  making it once.
+- **The request carries an idempotency key** — an `Idempotency-Key` (or
+  `X-Idempotency-Key`) header, which is you telling WFL that the upstream
+  collapses repeats of this exact request.
 
-**Non-idempotent requests:** "nothing the program could have observed" is a
-statement about your program, not a guarantee about the server. A connection can
-also be lost *after* a server has read and acted on the body, and nothing on
-WFL's side can tell that apart from a socket the peer abandoned before the
-request arrived — so the re-send can reach a server that already processed the
-first copy. Delivery is therefore at-least-once, not exactly-once. If a `POST`
-(or any other non-idempotent call) must never run twice, make it safe to repeat:
-send an idempotency key the upstream deduplicates on, or check server-side state
-before retrying the operation at the WFL level.
+```wfl
+create map charge_headers:
+    "Idempotency-Key" is "order-4417-capture"
+end map
+
+// Safe to re-send: the upstream will honour the key and charge once.
+open url at "https://api.example.com/charges"
+    with method "POST"
+    and headers charge_headers
+    and body payload
+    and read response as resp
+```
+
+Anything else — a plain `POST` or `PATCH` — is **never** re-sent, and the failure
+is raised for you to handle. That is deliberate: WFL cannot tell "the peer closed
+the socket before reading your request" apart from "the server read your order,
+committed it, then died before replying", so replaying an unkeyed `POST` could
+charge a card or write a record twice. Unkeyed requests rely on the three-second
+idle window above instead, which is what keeps this failure rare rather than
+routine.
+
+Even for a request that *is* safe to repeat, only a lost connection earns the
+second send. A peer that replied with something unparseable, or one that refused
+the connection outright, has either handled the request or cannot be helped by
+trying again — both are reported to your program as they stand. A request that got
+as far as a response head is never re-sent either, whatever the status: a `500`
+from the server is yours to handle, not something WFL retries behind your back.
+The re-send applies to both `read response`/`read content` and `stream response`,
+and both attempts share the one timeout described above, so it cannot push a
+request past its deadline. If the second attempt fails too, the error is raised as
+usual and can be caught with `try`/`catch`.
 
 #### Streaming a response incrementally
 

--- a/TestPrograms/docs_examples/_meta/manifest.json
+++ b/TestPrograms/docs_examples/_meta/manifest.json
@@ -402,6 +402,23 @@
     ],
     "doc_purpose": "Docs README tour: containers/objects"
   },
+  "docs_examples/interoperability/idempotency_key_resend.wfl": {
+    "doc_section": "Docs/04-advanced-features/interoperability.md#connection-reuse-and-the-automatic-re-send",
+    "type": "snippet",
+    "validate_layers": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "skip_execution": true,
+    "tags": [
+      "http-client",
+      "idempotency",
+      "interoperability"
+    ],
+    "description": "A POST carrying an Idempotency-Key header, the shape WFL is allowed to re-send after a lost connection."
+  },
   "docs_examples/interoperability/streaming_response.wfl": {
     "doc_section": "Docs/04-advanced-features/interoperability.md#streaming-a-response-incrementally",
     "type": "snippet",

--- a/TestPrograms/docs_examples/interoperability/idempotency_key_resend.wfl
+++ b/TestPrograms/docs_examples/interoperability/idempotency_key_resend.wfl
@@ -1,0 +1,30 @@
+// CI-SKIP: needs a live upstream; validated via docs-examples layers 1-4
+// An outbound POST that WFL is allowed to re-send after a lost connection.
+//
+// A re-send needs two things: the connection was lost before any of the
+// response reached WFL, and repeating the request is safe. An idempotent
+// method is safe on its own; a POST becomes safe when it carries an
+// `Idempotency-Key` header, which tells WFL the upstream collapses repeats.
+//
+// Inside `open url` the words `method`, `headers`, and `body` introduce
+// clauses, so the values they take live in differently named variables
+// (`charge_headers`, `payload`).
+//
+// Validated for syntax/analysis/lint only (layers 1-4): running it needs a
+// live upstream, so execution is skipped.
+
+create map charge_headers:
+    "Idempotency-Key" is "order-4417-capture"
+end map
+
+store payload as "{\"order\": \"4417\", \"amount\": 2500}"
+display "Charging with body: " with payload
+
+// Safe to re-send: the upstream will honour the key and charge once.
+open url at "https://api.example.com/charges"
+    with method "POST"
+    and headers charge_headers
+    and body payload
+    and read response as resp
+
+display "Status: " with resp["status"]

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2174,7 +2174,9 @@ const HTTP_SEND_MAX_ATTEMPTS: u32 = 2;
 /// safe: the upstream deduplicates on the key, so a second delivery of the same
 /// request is not a second side effect. `Idempotency-Key` is the name the
 /// payment and API ecosystem settled on; the `X-` form is accepted because
-/// plenty of services still publish it.
+/// plenty of services still publish it. The promise is in the *value*, so only a
+/// non-empty one counts: an empty key gives the upstream nothing to deduplicate
+/// on, and is usually an unset variable rather than a deliberate opt-in.
 const HTTP_IDEMPOTENCY_KEY_HEADERS: [&str; 2] = ["idempotency-key", "x-idempotency-key"];
 
 /// Whether re-sending `request` after a failure that produced no response head
@@ -2191,8 +2193,8 @@ const HTTP_IDEMPOTENCY_KEY_HEADERS: [&str; 2] = ["idempotency-key", "x-idempoten
 ///
 /// * an idempotent method (RFC 9110 §9.2.2), where repeating the request is
 ///   defined to have the same effect on the server as issuing it once, or
-/// * an explicit idempotency-key header, the caller's own statement that the
-///   upstream collapses retries of this exact request.
+/// * an explicit idempotency-key header with a non-empty value, the caller's own
+///   statement that the upstream collapses retries of this exact request.
 ///
 /// Every other request surfaces the send failure instead. A bare `POST` is not
 /// left unprotected: [`HTTP_POOL_IDLE_TIMEOUT_SECONDS`] keeps a connection from
@@ -2304,7 +2306,7 @@ impl IoClient {
     ///    also be lost after a server read and committed the body, and nothing on
     ///    this side can tell that apart from a socket the peer abandoned before
     ///    the request arrived. So the replay is restricted to requests that carry
-    ///    a promise they can be repeated — an idempotent method, or an
+    ///    a promise they can be repeated — an idempotent method, or a non-empty
     ///    idempotency-key header — and a bare `POST` relies on the pool idle
     ///    timeout above instead.
     ///

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -2170,6 +2170,47 @@ const HTTP_POOL_IDLE_TIMEOUT_SECONDS: u64 = 3;
 /// reached a response head. See [`IoClient::send_with_reuse_retry`].
 const HTTP_SEND_MAX_ATTEMPTS: u32 = 2;
 
+/// Headers with which a caller states that repeating an outbound request is
+/// safe: the upstream deduplicates on the key, so a second delivery of the same
+/// request is not a second side effect. `Idempotency-Key` is the name the
+/// payment and API ecosystem settled on; the `X-` form is accepted because
+/// plenty of services still publish it.
+const HTTP_IDEMPOTENCY_KEY_HEADERS: [&str; 2] = ["idempotency-key", "x-idempotency-key"];
+
+/// Whether re-sending `request` after a failure that produced no response head
+/// can only ever duplicate work the upstream is prepared for.
+///
+/// `reqwest::Error::is_request()` establishes that the *caller* saw no response.
+/// It does not establish that the upstream never received the request: hyper
+/// reports the same error for a socket the peer closed before reading anything
+/// and for one it closed after reading — and possibly committing — the body, and
+/// the two are indistinguishable from the client side. Replaying the second case
+/// would deliver a non-idempotent request twice, duplicating a charge or a write
+/// the program never asked to repeat, so replay requires a request that carries
+/// a promise it is safe:
+///
+/// * an idempotent method (RFC 9110 §9.2.2), where repeating the request is
+///   defined to have the same effect on the server as issuing it once, or
+/// * an explicit idempotency-key header, the caller's own statement that the
+///   upstream collapses retries of this exact request.
+///
+/// Every other request surfaces the send failure instead. A bare `POST` is not
+/// left unprotected: [`HTTP_POOL_IDLE_TIMEOUT_SECONDS`] keeps a connection from
+/// being reused once it has been idle long enough for the peer to have dropped
+/// it, which is the case that made these failures routine.
+fn request_may_be_replayed(request: &reqwest::Request) -> bool {
+    if request.method().is_idempotent() {
+        return true;
+    }
+
+    HTTP_IDEMPOTENCY_KEY_HEADERS.iter().any(|name| {
+        request
+            .headers()
+            .get(*name)
+            .is_some_and(|value| !value.is_empty())
+    })
+}
+
 #[derive(Debug)]
 enum FileReadError {
     Io(String),
@@ -2250,23 +2291,22 @@ impl IoClient {
     /// upstream being down, and that gets more likely the longer a program idles
     /// between calls.
     ///
-    /// Only a *lost connection* earns a re-send — see
-    /// [`Self::connection_was_lost`]. The narrower test matters because the
-    /// request may not be idempotent: a peer that answered, even with something
-    /// unparseable, has demonstrably handled the request, and replaying it could
-    /// duplicate whatever it did with the first copy. A connection that died
-    /// before any of the response arrived leaves the caller nothing to have
-    /// acted on, which is what makes the second send the same recovery a person
-    /// would make by retrying.
+    /// A re-send needs *both* of two conditions, because either one alone would
+    /// duplicate work:
     ///
-    /// That last point is a claim about the *caller*, not a guarantee about the
-    /// upstream. A connection can also be lost after a server has read and acted
-    /// on the body, and nothing on this side can tell that apart from a socket
-    /// the peer abandoned before the request arrived — so a re-sent
-    /// non-idempotent request can reach a server that already processed the
-    /// first copy. Delivery is at-least-once, documented for WFL programs in
-    /// `Docs/04-advanced-features/interoperability.md`; the pool idle timeout
-    /// above is what keeps the recoverable stale-socket case the dominant one.
+    /// 1. The connection was lost — see [`Self::connection_was_lost`]. A peer
+    ///    that answered, even with something unparseable, has demonstrably
+    ///    handled the request, so replaying it could duplicate whatever it did
+    ///    with the first copy. Only a connection that died before any of the
+    ///    response arrived leaves the caller nothing to have acted on.
+    /// 2. Repeating the request is safe — see [`request_may_be_replayed`]. A
+    ///    lost connection says nothing about whether the *upstream* acted: it can
+    ///    also be lost after a server read and committed the body, and nothing on
+    ///    this side can tell that apart from a socket the peer abandoned before
+    ///    the request arrived. So the replay is restricted to requests that carry
+    ///    a promise they can be repeated — an idempotent method, or an
+    ///    idempotency-key header — and a bare `POST` relies on the pool idle
+    ///    timeout above instead.
     ///
     /// The retry is deliberately bounded at one: a peer that is genuinely gone
     /// must surface as an error promptly rather than being replayed in a loop. A
@@ -2291,13 +2331,21 @@ impl IoClient {
         request: reqwest::RequestBuilder,
         method: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<reqwest::Response, HttpClientError>> + Send + 'a>> {
+        // Decided once, before anything goes out: whether this request may be
+        // repeated at all. Building a clone is also what proves the body can be
+        // reproduced faithfully, so a streaming body drops out here too.
+        let replayable = request
+            .try_clone()
+            .and_then(|probe| probe.build().ok())
+            .is_some_and(|probe| request_may_be_replayed(&probe));
+
         Box::pin(async move {
             let mut attempt = request;
             let mut attempts_left = HTTP_SEND_MAX_ATTEMPTS;
 
             loop {
                 attempts_left -= 1;
-                let replay = if attempts_left > 0 {
+                let replay = if replayable && attempts_left > 0 {
                     attempt.try_clone()
                 } else {
                     None
@@ -2306,8 +2354,9 @@ impl IoClient {
                 match attempt.send().await {
                     Ok(response) => return Ok(response),
                     Err(error) => match replay {
-                        // The connection died with nothing to observe: try once
-                        // more on a connection that is known to be fresh.
+                        // The connection died with nothing to observe, and this
+                        // request is safe to repeat: try once more on a
+                        // connection that is known to be fresh.
                         Some(retry) if Self::connection_was_lost(&error) => attempt = retry,
                         _ => {
                             return Err(HttpClientError::Request(format!(
@@ -2324,9 +2373,10 @@ impl IoClient {
     /// arrived — as opposed to the peer answering, or never being reachable at
     /// all?
     ///
-    /// This is the whole safety argument for re-sending a request that may not
-    /// be idempotent, so it tests the specific evidence rather than the general
-    /// shape of the failure. `reqwest::Error::is_request()` is far too broad: it
+    /// This is one half of the safety argument for a re-send (the other is
+    /// [`request_may_be_replayed`]), so it tests the specific evidence rather
+    /// than the general shape of the failure. `reqwest::Error::is_request()` is
+    /// far too broad: it
     /// also covers a peer that replied with something unparseable (which handled
     /// the request) and a peer that refused the connection (which cannot be
     /// fixed by trying again immediately). The two signals that do mean the

--- a/tests/http_connection_reuse_retry_test.rs
+++ b/tests/http_connection_reuse_retry_test.rs
@@ -470,6 +470,36 @@ async fn an_unkeyed_post_is_never_replayed() {
     );
 }
 
+/// An empty key value is not a promise. `"Idempotency-Key" is ""` names the
+/// header but tells the upstream nothing to deduplicate on, so it must not buy a
+/// replay that a bare POST is denied.
+#[tokio::test]
+async fn an_empty_idempotency_key_is_not_a_promise() {
+    let (url, stats) = spawn_upstream(DropPolicy::All).await;
+
+    let code = format!(
+        r#"
+        create map blank_headers:
+            "Idempotency-Key" is ""
+        end map
+
+        open url at "{url}" with method "POST" and headers blank_headers and body "charge=1000" and read response as resp
+        "#
+    );
+
+    let program = parse(&code);
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(&program).await;
+
+    result.expect_err("a peer that never answers must surface an error");
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        1,
+        "an empty idempotency key carries no promise of deduplication, so the \
+         POST must reach the upstream exactly once"
+    );
+}
+
 /// An idempotent method needs no key: repeating a GET is defined to have the
 /// same effect as making it once (RFC 9110 §9.2.2), so the `read content` path
 /// recovers from a peer-closed pooled socket on its own.

--- a/tests/http_connection_reuse_retry_test.rs
+++ b/tests/http_connection_reuse_retry_test.rs
@@ -10,11 +10,13 @@
 // "Failed to send HTTP POST request: error sending request for url (...)"
 // instead of transparently reconnecting.
 //
-// A request that never received a response head demonstrably produced no
-// observable effect the caller can see, so re-sending it once on a fresh
-// connection is the correct recovery — that is what these tests pin down, for
-// BOTH send sites (the buffered `read response` path and the `stream response`
-// path), plus the bound that stops the retry from looping.
+// A request that never received a response head produced no effect the caller
+// can see, but the *upstream* may still have acted on it, so re-sending one is
+// only correct when repeating it is safe: an idempotent method, or a caller-
+// supplied idempotency key the upstream deduplicates on. These tests pin both
+// halves of that contract — the recovery, for BOTH send sites (the buffered
+// `read response`/`read content` path and the `stream response` path), the bound
+// that stops the retry from looping, and the refusal to replay a bare POST.
 //
 // The upstream here is a raw TCP server so the "peer closed the keep-alive
 // socket" moment is deterministic rather than a timing race: it answers
@@ -220,15 +222,27 @@ fn get_text(interpreter: &Interpreter, name: &str) -> String {
 /// Two POSTs through one interpreter (hence one pooled client). The second one
 /// lands on the connection the first one left in the pool, and the peer closes
 /// it instead of answering — the program must still get its reply.
+///
+/// The POSTs carry an `Idempotency-Key`, which is what makes them replayable:
+/// this upstream reads a dropped request in full before closing, so a client
+/// cannot know the body was not acted on, and only the caller's key says a
+/// second delivery is safe. See the negative test below for a bare POST.
 #[tokio::test]
-async fn buffered_post_survives_a_peer_closed_keepalive_socket() {
+async fn buffered_keyed_post_survives_a_peer_closed_keepalive_socket() {
     let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![2])).await;
 
     let code = format!(
         r#"
-        open url at "{url}" with method "POST" and body "first" and read response as resp1
+        create map first_headers:
+            "Idempotency-Key" is "buffered-first"
+        end map
+        create map second_headers:
+            "Idempotency-Key" is "buffered-second"
+        end map
+
+        open url at "{url}" with method "POST" and headers first_headers and body "first" and read response as resp1
         store body1 as resp1["body"]
-        open url at "{url}" with method "POST" and body "second" and read response as resp2
+        open url at "{url}" with method "POST" and headers second_headers and body "second" and read response as resp2
         store body2 as resp2["body"]
         store status2 as resp2["status"]
         "#
@@ -263,14 +277,18 @@ async fn buffered_post_survives_a_peer_closed_keepalive_socket() {
 /// The streaming path: `open url ... and stream response`. This is the one an
 /// SSE/LLM proxy uses, and the one that produced the reported 500.
 #[tokio::test]
-async fn streaming_post_survives_a_peer_closed_keepalive_socket() {
+async fn streaming_keyed_post_survives_a_peer_closed_keepalive_socket() {
     let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![2])).await;
 
     let code = format!(
         r#"
+        create map stream_headers:
+            "Idempotency-Key" is "streamed-turn"
+        end map
+
         open url at "{url}" with method "POST" and body "warm" and read response as resp1
         store body1 as resp1["body"]
-        open url at "{url}" with method "POST" and body "stream" and stream response as up
+        open url at "{url}" with method "POST" and headers stream_headers and body "stream" and stream response as up
         wait for next line from up as line1
         store first_line as line1
         "#
@@ -300,7 +318,11 @@ async fn a_permanently_closing_upstream_is_retried_once_and_then_fails() {
 
     let code = format!(
         r#"
-        open url at "{url}" with method "POST" and body "doomed" and read response as resp
+        create map doomed_headers:
+            "Idempotency-Key" is "doomed"
+        end map
+
+        open url at "{url}" with method "POST" and headers doomed_headers and body "doomed" and read response as resp
         "#
     );
 
@@ -329,12 +351,12 @@ async fn a_permanently_closing_upstream_is_retried_once_and_then_fails() {
 /// shorter than the gap the program leaves between two calls (Node's 5s default
 /// versus a chat turn spent talking to somebody else).
 ///
-/// Unlike the tests above this one is time-based, so it does not pin *which*
-/// recovery ran — the pool may drop the expired socket before the second call,
-/// or hand it over and let the re-send recover. It pins the outcome that
-/// matters either way: an idle gap past the peer's keep-alive window still
-/// yields a reply rather than a spurious send failure. Both calls run through
-/// one interpreter, so they share one connection pool.
+/// This is the case a bare, unkeyed POST has to survive *without* a re-send,
+/// since replaying it is not safe: the pool must refuse to hand out a socket it
+/// has held past its own idle timeout, so the second call opens a fresh
+/// connection instead of writing onto a dead one. Hence the gap below is longer
+/// than the pool's idle timeout, not merely longer than the peer's. Both calls
+/// run through one interpreter, so they share one connection pool.
 #[tokio::test]
 async fn an_idle_gap_past_the_peers_keepalive_still_gets_a_reply() {
     let (url, stats) = spawn_upstream(DropPolicy::IdleAfter(Duration::from_millis(300))).await;
@@ -353,14 +375,20 @@ async fn an_idle_gap_past_the_peers_keepalive_still_gets_a_reply() {
     assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
 
     // Long enough that the peer has certainly closed the socket it was keeping
-    // alive for us.
-    tokio::time::sleep(Duration::from_millis(900)).await;
+    // alive for us, and long enough that our own pool has expired it too — the
+    // only protection an unkeyed POST gets.
+    tokio::time::sleep(Duration::from_millis(3_500)).await;
 
     interpreter
         .interpret(&second)
         .await
         .unwrap_or_else(|e| panic!("call after the peer's keep-alive expired: {e:?}"));
     assert_eq!(get_text(&interpreter, "body2"), "reply2\n");
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        2,
+        "the pool should have avoided the dead socket outright, with no re-send"
+    );
     assert!(
         stats.connections.load(Ordering::SeqCst) >= 2,
         "the second call must end up on a live connection"
@@ -381,7 +409,11 @@ async fn a_non_http_reply_is_not_replayed() {
 
     let code = format!(
         r#"
-        open url at "{url}" with method "POST" and body "once" and read response as resp
+        create map keyed_headers:
+            "Idempotency-Key" is "unparseable-reply"
+        end map
+
+        open url at "{url}" with method "POST" and headers keyed_headers and body "once" and read response as resp
         "#
     );
 
@@ -393,7 +425,78 @@ async fn a_non_http_reply_is_not_replayed() {
     assert_eq!(
         stats.requests.load(Ordering::SeqCst),
         1,
-        "a peer that answered must not have the request delivered twice"
+        "a peer that answered must not have the request delivered twice, even \
+         with an idempotency key permitting a replay"
+    );
+}
+
+/// The other half of the contract: even a lost connection does not earn a
+/// re-send when the request cannot be safely repeated.
+///
+/// This upstream reads the dropped request in full before closing the socket,
+/// which is exactly the ambiguity that makes replay unsafe: from the client the
+/// failure is identical whether the server ignored the body or committed it. An
+/// unkeyed POST therefore surfaces the failure after a single delivery, rather
+/// than the interpreter quietly submitting the same payment twice.
+#[tokio::test]
+async fn an_unkeyed_post_is_never_replayed() {
+    let (url, stats) = spawn_upstream(DropPolicy::All).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" with method "POST" and body "charge=1000" and read response as resp
+        "#
+    );
+
+    let program = parse(&code);
+    let mut interpreter = Interpreter::new();
+    let result = interpreter.interpret(&program).await;
+
+    let errors = result.expect_err("a peer that never answers must surface an error");
+    let message = errors
+        .iter()
+        .map(|e| e.message.clone())
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        message.contains("Failed to send HTTP POST request"),
+        "unexpected error: {message}"
+    );
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        1,
+        "a non-idempotent request with no idempotency key must reach the upstream \
+         exactly once, even though the failure looks retryable"
+    );
+}
+
+/// An idempotent method needs no key: repeating a GET is defined to have the
+/// same effect as making it once (RFC 9110 §9.2.2), so the `read content` path
+/// recovers from a peer-closed pooled socket on its own.
+#[tokio::test]
+async fn an_idempotent_get_is_replayed_without_a_key() {
+    let (url, stats) = spawn_upstream(DropPolicy::Requests(vec![2])).await;
+
+    let code = format!(
+        r#"
+        open url at "{url}" and read content as body1
+        open url at "{url}" and read content as body2
+        "#
+    );
+
+    let interpreter = run_wfl(&code).await;
+
+    assert_eq!(get_text(&interpreter, "body1"), "reply1\n");
+    // Request 2 was dropped by the peer; the retry is request 3.
+    assert_eq!(get_text(&interpreter, "body2"), "reply3\n");
+    assert_eq!(
+        stats.requests.load(Ordering::SeqCst),
+        3,
+        "expected the dropped GET to be re-sent exactly once"
+    );
+    assert!(
+        stats.reused_connection_requests.load(Ordering::SeqCst) >= 1,
+        "the second GET should have reused the pooled keep-alive socket"
     );
 }
 


### PR DESCRIPTION
Follow-up to #658, which merged before this could land on its branch.

#658 narrowed the outbound re-send to a *lost connection*, but a lost connection only tells us the **caller** saw no response head; it says nothing about whether the upstream acted. hyper reports the same error for a socket the peer closed before reading anything and for one it closed after reading (and committing) the body, and nothing on the client side distinguishes them. The regression test's own upstream is that ambiguity in miniature: it reads a dropped request in full before closing. So the merged behaviour could still deliver an unkeyed `POST` twice, duplicating a charge or a write. Both review bots flagged this, one at P1.

A re-send now requires two independent conditions: the connection was lost, **and** the request carries a promise it can be repeated.

```rust
fn request_may_be_replayed(request: &reqwest::Request) -> bool {
    if request.method().is_idempotent() {
        return true;
    }

    HTTP_IDEMPOTENCY_KEY_HEADERS.iter().any(|name| {
        request
            .headers()
            .get(*name)
            .is_some_and(|value| !value.is_empty())
    })
}
```

That is an idempotent method per RFC 9110 §9.2.2, or an `Idempotency-Key` / `X-Idempotency-Key` header — the caller stating the upstream deduplicates repeats. It is decided once, before the first send, and building the replay clone up front doubles as the check that the body can be reproduced, so a streaming body drops out there too.

A bare `POST` or `PATCH` gets no re-send. Its protection is the three-second pool idle timeout from #658, which is what made these failures routine in the first place; the residual case (peer closes inside that window) surfaces as a catchable error, which beats a duplicated charge.

Tests (`tests/http_connection_reuse_retry_test.rs`, 8 passing locally): the existing keyed-POST recovery tests now carry a key; a new negative test pins that an unkeyed POST against an upstream that reads it in full and then closes reaches the server **exactly once**; a new test covers an idempotent `GET` through `read content` recovering with no key; and the time-based idle-gap test now uses a gap longer than our own pool window, since an unkeyed POST has to survive that case with no re-send at all. Red for the contract is commit 1de8b20, ancestor of the fix: under the merged predicate the unkeyed-POST test observed 2 deliveries where it requires 1.

Docs and CHANGELOG state the contract, and the dev diary records why a lost connection alone was not enough.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic HTTP request retries after connection loss now occur only when the request is safe to repeat.
  * Idempotent methods and requests with idempotency keys may be retried; unkeyed `POST` and `PATCH` requests are not resent.
  * Requests are not retried after a response begins, and streaming request bodies remain excluded when they cannot be safely replayed.

* **Documentation**
  * Clarified retry behavior, safety requirements, timeout handling, and delivery expectations.
  * Added examples and expanded coverage of keyed and unkeyed request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->