### PR TITLE
fix(ci): stop the nightly release job failing on an immutable tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -687,32 +687,45 @@ jobs:
         run: |
           DATE=$(date +'%Y-%m-%d')
           TAG="nightly-${DATE}"
+          SHA=$(git rev-parse HEAD)
 
-          # Delete existing local tag if it exists
-          echo "Checking for existing local tag: $TAG"
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Deleting existing local tag: $TAG"
-            git tag -d "$TAG"
-          else
-            echo "No existing local tag found"
+          # This repository has GitHub immutable releases enabled, so the tag of a
+          # published release is permanently protected: pushing a delete is refused
+          # with "GH013 ... Cannot delete this tag". The previous
+          # delete-then-recreate flow swallowed that refusal as a warning and then
+          # died on "tag already exists", failing the whole release job on any run
+          # that happened after a release already existed for the same date -- a
+          # manual re-dispatch on a day the scheduled nightly had already
+          # published, for instance -- even with every build job green.
+          # Tagging is idempotent now and never fails on an already-published tag.
+          REFS=$(git ls-remote --tags origin "refs/tags/$TAG" "refs/tags/$TAG^{}" || true)
+
+          if [ -z "$REFS" ]; then
+            echo "No existing remote tag $TAG; creating it at $SHA."
+            git tag -f -a "$TAG" -m "Nightly build $DATE"
+            git push origin "refs/tags/$TAG"
+            exit 0
           fi
 
-          # Delete existing remote tag if it exists
-          echo "Checking for existing remote tag: $TAG"
-          if git ls-remote --tags origin | grep -q "refs/tags/$TAG$"; then
-            echo "Deleting existing remote tag: $TAG"
-            if ! git push origin ":refs/tags/$TAG" 2>&1; then
-              echo "::warning::Failed to delete remote tag $TAG, but continuing (may not exist or insufficient permissions)"
-            fi
-          else
-            echo "No existing remote tag found"
+          # An annotated tag reports the tag object on the plain line and the
+          # commit it points at on the "^{}" line; prefer the latter.
+          TAGGED=$(printf '%s\n' "$REFS" | awk '$2 ~ /\^\{\}$/ { print $1 }' | head -n 1)
+          if [ -z "$TAGGED" ]; then
+            TAGGED=$(printf '%s\n' "$REFS" | awk 'NR == 1 { print $1 }')
           fi
 
-          # Create new tag and push
-          echo "Creating new tag: $TAG"
-          git tag -a "$TAG" -m "Nightly build $DATE"
-          echo "Pushing new tag: $TAG"
-          git push origin "$TAG"
+          if [ "$TAGGED" = "$SHA" ]; then
+            echo "Tag $TAG already points at $SHA; nothing to do."
+            exit 0
+          fi
+
+          echo "::warning::Tag $TAG already exists at $TAGGED but this build is $SHA; attempting to move it."
+          git tag -f -a "$TAG" -m "Nightly build $DATE"
+          if git push --force origin "refs/tags/$TAG"; then
+            echo "Moved $TAG to $SHA."
+          else
+            echo "::warning::Could not move $TAG; it is protected by an immutable release. Leaving the published tag at $TAGGED."
+          fi
 
       - name: Publish or update nightly release
         env:
@@ -720,7 +733,6 @@ jobs:
           SHORT_SHA: ${{ needs.check-for-changes.outputs.short_sha }}
         run: |
           TAG="nightly-$(date +'%Y-%m-%d')"
-          gh release delete "$TAG" --yes 2>/dev/null || true
 
           # Collect all artifact files to upload with the release
           # GitHub's immutable releases require assets to be attached during creation
@@ -745,6 +757,22 @@ jobs:
 
           echo "Files to upload: $ASSET_FILES"
           echo "Number of files: $(echo $ASSET_FILES | wc -w)"
+
+          # An immutable release cannot be deleted or edited once published, so the
+          # old unconditional "delete, then create" could not refresh one: the
+          # delete was silently discarded by "|| true" and the create then failed
+          # because the release already existed. Only replace a release that is
+          # still mutable.
+          RELEASE_ID=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" -q '.id' 2>/dev/null || true)
+          if [ -n "$RELEASE_ID" ]; then
+            IMMUTABLE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" -q '.immutable' 2>/dev/null || true)
+            if [ "$IMMUTABLE" = "true" ]; then
+              echo "::warning::Release $TAG is already published and immutable, so it cannot be replaced. Skipping the GitHub release step; this run's artifacts are on DigitalOcean Spaces, which the release notes already name as the canonical download location."
+              exit 0
+            fi
+            echo "Replacing the existing (mutable) release $TAG."
+            gh release delete "$TAG" --yes 2>/dev/null || true
+          fi
 
           # Create release with assets attached in a single command
           # This works with immutable releases since assets are part of the creation


### PR DESCRIPTION
## What was broken

Nightly Build run [30528566163](https://github.com/WebFirstLanguage/wfl/actions/runs/30528566163) (manual dispatch, 2026-07-30 08:55 UTC, main `579eb806`) failed. All three build jobs were green — `Check for changes`, `Build WFL for Linux (static musl)`, and `Build WFL for Windows` (25m35s, through MSI packaging and the installer smoke test). The `Create or Update Nightly Release` job died at **`Tag commit for nightly`**:

```
Deleting existing remote tag: nightly-2026-07-30
remote: error: GH013: Repository rule violations found for refs/tags/nightly-2026-07-30.
remote: - Cannot delete this tag
##[warning]Failed to delete remote tag nightly-2026-07-30, but continuing ...
Creating new tag: nightly-2026-07-30
 ! [rejected]        nightly-2026-07-30 -> nightly-2026-07-30 (already exists)
##[error]Process completed with exit code 1
```

`Publish or update nightly release` was skipped, so a fully successful build published nothing.

## Root cause

This repository has **GitHub immutable releases** enabled — `GET /releases/tags/nightly-2026-07-30` reports `"immutable": true`. Once a release is published, its tag is permanently protected against deletion and movement. The release job was built on a delete-then-recreate model that this makes impossible:

1. `Tag commit for nightly` deletes the remote tag, then recreates and pushes it. The delete is refused (GH013); the refusal is downgraded to a warning and execution continues; the push then fails hard with "already exists".
2. `Publish or update nightly release` does the same thing one level up — `gh release delete "$TAG" --yes 2>/dev/null || true` followed by `gh release create "$TAG"`. An immutable release cannot be deleted either, so the delete is silently discarded and the create would fail because the release already exists. Despite the step's name it never updated anything; it only ever recreated. This is a **latent second failure** that today's run never reached because step 1 died first.

So any nightly run that happens after a release already exists for the same calendar date fails. In practice that means **every manual re-dispatch on a day the scheduled nightly already published**. It has not bitten before now only by luck: the 2026-07-29 re-dispatch worked because that day's scheduled nightly failed *before* tagging (the musl portability gate, fixed in #657), so no tag existed. Today's scheduled run succeeded and published at 06:18, and the 08:55 dispatch hit the wall.

## The fix

`.github/workflows/nightly.yml` only, two steps in the `release` job. No Rust code, no other job touched.

**`Tag commit for nightly`** — never deletes; is idempotent instead:

- tag absent → create and push (unchanged behaviour, the normal daily path);
- tag already points at this commit → no-op, log and continue;
- tag points elsewhere → try `git push --force`, and if that is refused, warn and continue rather than fail.

Annotated tags are resolved through the `^{}` line of `git ls-remote` so the comparison is against the tagged *commit*, with a fallback for a lightweight tag.

**`Publish or update nightly release`** — checks before it replaces:

- looks up the release for the tag; if it exists and is `immutable`, warn and exit 0 rather than attempt an impossible delete-and-recreate;
- if it exists and is still mutable, delete and recreate exactly as before;
- if it does not exist, create exactly as before.

Asset collection and validation moved above that check so the "empty file" and "no artifacts" errors still fire. Release notes, flags, and asset handling are byte-identical.

The deliberate judgement call: on a same-day re-run against an already-published immutable release the job now **succeeds with a warning** instead of failing. The build genuinely is good, and `Publish artifacts to DigitalOcean Spaces` — which runs earlier and is unaffected — has already refreshed the canonical CDN copies that the release notes point at. Only the case "release exists **and** is immutable" is tolerated; anything else still fails loudly.

## Verification

This is a pure CI-mechanics change with no Rust behaviour to test, so per `AGENTS.md` the existing checks are the test. What was verified locally:

- **YAML parses**, and a structural diff against `main` confirms step counts are unchanged in all four jobs (5 / 21 / 10 / 9), the `check-for-changes`, `build`, and `build-linux` jobs are byte-identical, and triggers are unchanged. Only the two named steps differ.
- `bash -n` clean on both step scripts.
- **Both scripts exercised against stubbed `git`/`gh`** covering every branch:
  - tag step, 8 cases (tag absent / at HEAD / elsewhere / lightweight, each with force-push succeeding and refused) — all exit 0 with the correct action, including the exact case that broke this run (tag elsewhere + push refused);
  - release step, 4 cases (release absent → creates; immutable → warns and skips without calling `gh release create`; mutable → deletes and recreates; no artifacts → still `::error::` and exit 1).
- The `git ls-remote` parsing was checked against the **real repository**, not just stubs: `refs/tags/nightly-2026-07-30` resolves to tag object `ab3166a6` and commit `1bb02f2a`, which is the commit the 05:57 scheduled nightly built.

Not verified: an actual Actions run. That is what this PR's CI is for. The most useful post-merge check is to dispatch Nightly Build from `main` on a day the scheduled run has already published — the previously failing path — and confirm the release job reports the skip warning and goes green.

---

*Automated triage PR from the WFL repo warden — please review and merge; the warden does not merge its own PRs.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/661" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly release handling to safely rerun without failing when tags or releases already exist.
  * Added compatibility with immutable or protected nightly tags and releases.
  * Preserved successful workflow completion when an existing immutable release cannot be replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->