### PR TITLE
Fix #662: Immutable .sha256 sidecars for pinned release verification

### DIFF
--- a/.github/workflows/backfill-checksums.yml
+++ b/.github/workflows/backfill-checksums.yml
@@ -25,6 +25,15 @@ on:
 permissions:
   contents: read
 
+# Shared with the nightly release job, so a backfill and a publish can never
+# write to the bucket at the same time. Without it, this run's bucket listing
+# could report a sidecar missing, the publisher could then create it, and this
+# run would overwrite it with a checksum computed from the bytes it read
+# earlier. Queue rather than cancel: neither side is safe to interrupt midway.
+concurrency:
+  group: spaces-publish
+  cancel-in-progress: false
+
 jobs:
   backfill:
     name: Backfill missing .sha256 sidecars

--- a/.github/workflows/backfill-checksums.yml
+++ b/.github/workflows/backfill-checksums.yml
@@ -1,0 +1,53 @@
+name: Backfill Release Checksums
+
+# On-demand repair of the published-artifact checksum sidecars in the
+# DigitalOcean Spaces bucket.
+#
+# The nightly release job already runs this after every publish, so under normal
+# operation there is nothing for this workflow to do. It exists so the repair can
+# be run - or, with dry_run, inspected - without waiting for or forcing a
+# nightly build. The obvious use is the one-time pass over the artifacts that
+# were published before checksum sidecars existed (issue #662).
+#
+# The script only ever creates missing `<artifact>.sha256` keys. It never
+# rewrites an existing sidecar, never touches an artifact, a rolling pointer,
+# SHA256SUMS, or status.json, and is safe to run repeatedly.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'List the sidecars that are missing without uploading anything'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  backfill:
+    name: Backfill missing .sha256 sidecars
+    # I/O-bound, never CPU-bound. x86 rather than the cheaper ARM label only
+    # because this is the runner the nightly publish step already uses, so the
+    # AWS CLI is known to be preinstalled on it.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Backfill checksums
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.SPACES_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_KEY }}
+          SPACES_BUCKET:         wfl
+          SPACES_ENDPOINT:       https://nyc3.digitaloceanspaces.com
+          AWS_DEFAULT_REGION:    nyc3
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            ./scripts/backfill_spaces_checksums.sh --dry-run
+          else
+            ./scripts/backfill_spaces_checksums.sh
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,24 @@ jobs:
       - name: Type-check fuzz targets against the current API
         run: cargo check --locked --manifest-path fuzz/Cargo.toml
 
+  # The release publishing scripts never run in PR CI - they only execute in the
+  # nightly job, against the live bucket, with credentials no PR has. A mistake
+  # in them is therefore invisible until it has already published (or failed to
+  # publish) a real release, which is how issue #662 shipped. These tests run
+  # the real scripts against a recording stub of the AWS CLI and assert the keys,
+  # bytes and cache headers they write.
+  release-scripts:
+    name: Release Script Tests
+    # Bash, jq and sha256sum over a handful of tiny files.
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    needs: fmt
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Test publish/backfill scripts
+        run: ./scripts/test_publish_spaces.sh
+
   clippy-and-test:
     name: Build, Test, Clippy
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -579,7 +597,7 @@ jobs:
     # out to a locked `cargo check` on the fuzz crate - so this compiles and
     # needs the same 4 cores as fuzz-check. ARM: no x86 artifact produced.
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
-    needs: [fmt, fuzz-check, clippy-and-test, integration-tests, database-tests, run-wfl-programs]
+    needs: [fmt, fuzz-check, release-scripts, clippy-and-test, integration-tests, database-tests, run-wfl-programs]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -612,6 +612,16 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
+    # Serializes every writer of the Spaces bucket - this job, a second nightly
+    # run (a manual dispatch on a day the schedule already fired), and the
+    # on-demand backfill workflow, which shares this group name. The rolling
+    # pointers, SHA256SUMS and status.json are read-modify-write against a
+    # single set of keys, and two publishes interleaving can leave them
+    # describing different builds. Queue rather than cancel: a publish
+    # interrupted midway is exactly the state this ordering exists to avoid.
+    concurrency:
+      group: spaces-publish
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -678,6 +678,28 @@ jobs:
             "${{ github.sha }}" \
             "${{ github.ref_name }}"
 
+      # Artifacts published before the `.sha256` sidecars existed have no
+      # immutable checksum, so pinning one of them stopped being verifiable as
+      # soon as a newer nightly rewrote SHA256SUMS (issue #662). This repairs
+      # them in place. It is idempotent and additive - once every historical
+      # object has a sidecar, the step is a single list call - so it stays wired
+      # in rather than being run once and removed, and any future gap heals
+      # itself on the next nightly.
+      #
+      # It cannot invalidate the release that just published: it only ever
+      # creates missing `*.sha256` keys, and never rewrites an existing one. A
+      # failure here therefore means "history is still partly unrepaired", not
+      # "this release is bad", so it must not fail the release job.
+      - name: Backfill checksums for previously published artifacts
+        continue-on-error: true
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.SPACES_ACCESS_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SPACES_SECRET_KEY }}
+          SPACES_BUCKET:         wfl
+          SPACES_ENDPOINT:       https://nyc3.digitaloceanspaces.com
+          AWS_DEFAULT_REGION:    nyc3
+        run: ./scripts/backfill_spaces_checksums.sh
+
       - name: Configure git identity
         run: |
           git config user.name "github-actions[bot]"

--- a/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
+++ b/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
@@ -5,7 +5,7 @@
 Every versioned artifact published to Spaces now gets its own checksum file,
 written once and never rewritten:
 
-```
+```text
 releases/wfl-<version>-linux-x86_64-<sha>.tar.gz
 releases/wfl-<version>-linux-x86_64-<sha>.tar.gz.sha256   <- new
 releases/wfl-<version>.msi
@@ -17,8 +17,8 @@ releases/vscode-wfl-<version>.vsix.sha256                 <- new
 Three parts:
 
 1. **`publish_spaces.sh`** writes the sidecar in the same step as the artifact it
-   describes, and verifies both back through the CDN before the publish is
-   allowed to complete.
+   describes, verifies both back through the CDN before the publish is allowed
+   to complete, and refuses to replace either object once published.
 2. **`backfill_spaces_checksums.sh`** (new) writes the sidecars for everything
    already in the bucket. It runs after every nightly publish and on demand via
    the new **Backfill Release Checksums** workflow.
@@ -92,34 +92,54 @@ one they check downloads against.
 | Every versioned artifact gets a sidecar holding its real hash | `test_publish_spaces.sh`: runs the real script, compares each sidecar against `sha256sum` of the artifact | Integration, in-CI |
 | Sidecars are cached as immutable and served as text | Same test, asserting the recorded `--cache-control` / `--content-type` per key | Integration, in-CI |
 | Rolling keys get no sidecar | Same test, asserting absence for `wfl-latest-*`, `SHA256SUMS`, `status.json` | Integration, in-CI |
-| An artifact can never be published without its checksum | Sidecar upload is in phase 1 under `set -e`; test injects a sidecar-upload failure and asserts non-zero exit with rolling pointers and `status.json` unwritten | Integration, in-CI (negative) |
+| A publish that fails partway cannot claim success | Test injects a sidecar-upload failure and asserts non-zero exit with the rolling pointers and `status.json` unwritten | Integration, in-CI (negative) |
+| A partial publish is completed by a re-run, not blocked by it | Same test re-runs the publish and asserts it succeeds, fills in the missing sidecar, and moves the pointer | Integration, in-CI |
+| A published key is never replaced with different bytes | Test re-publishes a version with altered bytes and asserts a non-zero exit naming the refusal, with the stored artifact and sidecar byte-identical afterwards | Integration, in-CI (negative) |
+| Re-publishing identical bytes still works | Same test: exits 0, records zero uploads for both keys, still refreshes the rolling pointer | Integration, in-CI |
+| A slow-propagating CDN edge does not fail a good publish | Test makes the sidecar 404 twice before appearing; publish succeeds and the retry count is asserted | Integration, in-CI |
+| …but an object that never becomes readable still fails it | Same test with a permanently absent sidecar: non-zero exit | Integration, in-CI (negative) |
 | Existing `SHA256SUMS` consumers are unaffected | Same test: still published, still lists all three artifacts, still `max-age=60` | Integration, in-CI |
 | The CDN actually serves the sidecar we uploaded | `publish_spaces.sh` fetches each sidecar back and compares content; publish fails otherwise | E2E, against the real bucket, every nightly |
 | The backfill hashes the bucket's bytes, not CI's | `test_publish_spaces.sh`: seeds objects, asserts each backfilled sidecar matches the stored object | Integration, in-CI |
 | The backfill never rewrites a published checksum | Same test: a pre-existing sidecar is byte-identical afterwards and recorded zero uploads | Integration, in-CI (negative) |
+| A sidecar published *during* a backfill survives it (§11.3 race) | Same test: a hook creates the sidecar between the backfill's download and its upload; the concurrent sidecar is intact and zero uploads are recorded | Integration, in-CI (race) |
 | The backfill is safe to run repeatedly | Same test: second run performs zero uploads | Integration, in-CI |
+| Two bucket writers cannot interleave | `nightly.yml`'s release job and `backfill-checksums.yml` share `concurrency: spaces-publish`, `cancel-in-progress: false` | Workflow, by construction |
 
-**Red evidence.** `987f3a7` is a test-only commit, an ancestor of the Green
-implementation: 13 failing / 15 passing, failing for the intended reasons — no
-`.sha256` key for any artifact, a sidecar-upload failure not aborting the
-publish, and no backfill script to run (127). The implementation commit takes it
-to 43 passing / 0 failing.
+**Red evidence.** Two test-only commits, each an ancestor of its Green
+implementation:
+
+- `987f3a7` — 13 failing / 15 passing, failing for the intended reasons: no
+  `.sha256` key for any artifact, a sidecar-upload failure not aborting the
+  publish, and no backfill script to run (127). Green at 43 passing / 0 failing.
+- `e2091e3` — the three defects raised in review on this PR, reproduced before
+  fixing: 11 failing / 50 passing (silent overwrite of a published artifact, no
+  retry on the sidecar's CDN read, a sidecar published mid-backfill being
+  overwritten). Green at 61 passing / 0 failing.
 
 **Layers executed.** `bash -n` and `shellcheck` on all three scripts,
-`test_publish_spaces.sh` (43 assertions, 0 failures), `actionlint` on the three
+`test_publish_spaces.sh` (61 assertions, 0 failures), `actionlint` on the three
 changed/added workflows (clean; the remaining findings in `ci.yml` and
 `nightly.yml` are pre-existing and in untouched steps).
 
-The documented consumer flow was also checked against the live bucket: the
-published `wfl-26.7.59-linux-x86_64-579eb80.tar.gz` was downloaded through the
-CDN, and a sidecar in the exact format `publish_spaces.sh` writes was verified
-with `sha256sum -c` → `OK`. That is the format and the command the install docs
-now tell people to use.
+The Cargo gates ran green in CI on this PR — `Check formatting` (`cargo fmt
+--all -- --check`), `Build, Test, Clippy` (`clippy -D warnings` + `cargo test`),
+`Fuzz targets compile`, `Integration Tests` on Linux and Windows, `Database
+Tests`, and `Run WFL Programs` — all `success` in
+[run 30602922900](https://github.com/WebFirstLanguage/wfl/actions/runs/30602922900).
+This change touches no Rust, so those gates are a regression check rather than
+evidence about the change itself; the linked run is the execution record.
 
-`scripts/validate_docs_examples.py` is not applicable here — the documentation
-change adds shell snippets, not WFL examples, and no `TestPrograms/` example was
-touched. The Rust suites are likewise untouched by this change and run as usual
-in `ci.yml`.
+The documented consumer flow was checked against the live bucket, not just
+asserted: the published `wfl-26.7.59-linux-x86_64-579eb80.tar.gz` was downloaded
+through the CDN and verified with `sha256sum -c` against a sidecar in the exact
+format `publish_spaces.sh` writes → `OK`. That is the command and the file the
+install docs now tell people to use, run against a real artifact.
+
+`scripts/validate_docs_examples.py` reports nothing for this change because it
+validates WFL programs under `TestPrograms/`, and no example there was touched —
+the docs added here are shell. The shell example is covered by the live-bucket
+run above instead, which is the stronger check of the two.
 
 **Residual risk.**
 
@@ -138,6 +158,70 @@ in `ci.yml`.
   integrity, not authenticity. Signing remains a tracked Operations follow-up,
   and the install docs now say so plainly rather than implying more than the
   file provides.
+
+## Neither upload order is atomic
+
+Review asked for the sidecar to be uploaded *before* its artifact, so that a
+failed sidecar upload cannot leave an artifact published without a checksum.
+That swaps one orphan for the other rather than removing it: a sidecar uploaded
+first can be left describing an artifact that never lands, and if the release is
+then rebuilt, that stale sidecar is a *wrong* checksum sitting at the exact key
+consumers are told to trust — strictly worse than a missing one. There is no
+transaction across two object-store writes, so some window exists either way.
+
+What actually makes the window harmless is that nothing points at a versioned
+key until every immutable upload has succeeded. The rolling pointers,
+`SHA256SUMS` and `status.json` are all written in phase 2. An artifact left by a
+failed phase 1 is unreferenced: it is not in any manifest, not behind `latest`,
+and its name is not discoverable without already knowing the version and commit
+of a build that was never announced.
+
+Three things then close it, and each is tested rather than asserted:
+
+- **A re-run completes it.** The publish is deliberately retryable — the nightly
+  writes its success marker after this step for exactly that reason — so the
+  fix for a half-finished publish is to run it again. That only works if the
+  re-run tolerates its own leftovers, which is why identical bytes are a no-op
+  rather than an error.
+- **The nightly's backfill step fills it in** on the next run regardless.
+- **A rebuild cannot quietly replace it.** Same-key different-bytes now aborts.
+
+## Immutable is a promise to caches, not a lock on the bucket
+
+The strongest point raised in review: `Cache-Control: immutable` tells caches not
+to revalidate, and does nothing to stop a later `aws s3 cp` from replacing the
+object. A manual dispatch with `version_override`, or a rebuild of a version
+whose artifacts differ, would have silently replaced a build someone had pinned.
+
+The sidecar makes that worse rather than better, which is what makes it in scope
+here: artifact and sidecar are two objects cached independently for a year, so
+an edge can serve the old artifact next to the new checksum. A consumer
+following the documented flow then sees a hash mismatch — the signature of a
+tampered download — on an artifact nobody tampered with. That is the same class
+of false alarm as #662 itself, and it would be harder to explain.
+
+So `publish_immutable` now reads the published state first:
+
+- **key absent** → upload.
+- **key present, identical bytes** → skip the write, keep going. This is the
+  retry case and must not fail.
+- **key present, different bytes** → abort the publish, naming both hashes and
+  saying to publish under a new version.
+
+The existence check reads the key's own sidecar (a few dozen bytes) rather than
+re-downloading the artifact. A sidecar that lied about its artifact would make
+that answer wrong, but only in the direction of proceeding with an upload — and
+the CDN round-trip at the end re-hashes the artifact bytes themselves, so a
+wrong answer there cannot survive the publish.
+
+The same reasoning applies across processes, not just within one: the on-demand
+backfill and a nightly publish can genuinely overlap, and the backfill's bucket
+listing is a snapshot. Two defences, because one of them is best-effort by
+nature: the two workflows share a `concurrency: spaces-publish` group so they
+queue instead of racing, and the backfill re-checks for the sidecar immediately
+before uploading and yields to the publisher if it appeared in the meantime —
+the publisher's checksum describes bytes it just uploaded, the backfill's
+describes bytes it read earlier.
 
 ## Testing a script that only ever runs in production
 

--- a/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
+++ b/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
@@ -129,7 +129,11 @@ in `ci.yml`.
   change.
 - The backfill has to be run once against the live bucket to repair the
   artifacts published before this change. Until it runs, those artifacts remain
-  in the state #662 describes.
+  in the state #662 describes. The scope is small and known: Spaces publishing
+  began with 26.7.57, so the pass covers 26.7.57, 26.7.58 and 26.7.59 — nine
+  objects, none of which had a sidecar when this was written (verified by
+  probing the CDN for each `<artifact>.sha256`). Anything published from now on
+  gets its sidecar at publish time.
 - A checksum served from the same host as the artifact demonstrates transport
   integrity, not authenticity. Signing remains a tracked Operations follow-up,
   and the install docs now say so plainly rather than implying more than the

--- a/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
+++ b/Dev diary/2026-07-31-issue-662-immutable-release-checksums.md
@@ -1,0 +1,172 @@
+# 2026-07-31 — Pinned releases stay verifiable: immutable `.sha256` sidecars (#662)
+
+## What changed
+
+Every versioned artifact published to Spaces now gets its own checksum file,
+written once and never rewritten:
+
+```
+releases/wfl-<version>-linux-x86_64-<sha>.tar.gz
+releases/wfl-<version>-linux-x86_64-<sha>.tar.gz.sha256   <- new
+releases/wfl-<version>.msi
+releases/wfl-<version>.msi.sha256                         <- new
+releases/vscode-wfl-<version>.vsix
+releases/vscode-wfl-<version>.vsix.sha256                 <- new
+```
+
+Three parts:
+
+1. **`publish_spaces.sh`** writes the sidecar in the same step as the artifact it
+   describes, and verifies both back through the CDN before the publish is
+   allowed to complete.
+2. **`backfill_spaces_checksums.sh`** (new) writes the sidecars for everything
+   already in the bucket. It runs after every nightly publish and on demand via
+   the new **Backfill Release Checksums** workflow.
+3. **`test_publish_spaces.sh`** (new) tests both, in CI, on every PR.
+
+`releases/SHA256SUMS` is unchanged: same name, same location, same contents, same
+rolling cache headers. Nothing that reads it today has to change.
+
+## The bug
+
+`SHA256SUMS` is rewritten from scratch on every publish, so it only ever
+describes the newest build. The artifacts it describes are immutable and stay
+served indefinitely — their attestation does not.
+
+The consequence is that pinning a version and verifying it were mutually
+exclusive. A downstream GitLab pipeline pinned `26.7.57 / 2d74737`, verified
+against `SHA256SUMS`, and was green for two days; when 26.7.59 published on
+2026-07-30 the pipeline went red with "sha256 … is not in the published
+SHA256SUMS". Nothing was wrong with the pinned build. It just stopped being
+provable.
+
+The failure mode is worse than a plain outage because of how it reads. The
+consumer sees "this checksum is not published", which is what a *tampered
+download* looks like. The one signal we give people for detecting corruption
+fires, routinely, on correct downloads — which is exactly how a check gets
+switched off.
+
+The header comment in `publish_spaces.sh` said `checksums for this publish`, so
+the behaviour was intentional. The name and location were not: `SHA256SUMS`
+sitting in `releases/` reads as "the manifest for the releases directory", and
+that is how it was reasonably used.
+
+## Why sidecars rather than a cumulative SHA256SUMS
+
+Making `SHA256SUMS` cumulative would fix existing consumers with no client
+change, which is genuinely attractive. It was rejected on two grounds:
+
+- **It reintroduces a mutable object into the trust path.** A pinned consumer
+  would still be fetching a file that every subsequent publish rewrites. Correct
+  behaviour would then depend on every future publish preserving history —
+  one bad merge, one restored-from-backup object, and pinned verification breaks
+  again with the same confusing symptom.
+- **It requires read-modify-write on a shared key.** Two publishes overlapping
+  (a scheduled nightly and a manual dispatch, which this repo permits) can
+  interleave and drop entries. There is no compare-and-swap here to prevent it.
+
+A sidecar has neither property. It is written exactly once, next to the object it
+describes, with the object's own lifetime and cache policy — `max-age=31536000,
+immutable`, the same header as the artifact. Nothing rewrites it, so nothing can
+race on it, and its correctness does not depend on the behaviour of any later
+publish. It also composes with what people already do: `sha256sum -c
+wfl-….tar.gz.sha256` verifies in place and exits non-zero on mismatch.
+
+The sidecar carries sha256sum's own `<hash>  <name>` line rather than a bare
+hash, so `sha256sum -c` works directly and the name is bound into the
+attestation.
+
+Rolling keys (`wfl-latest-*`, `SHA256SUMS`, `status.json`) deliberately get **no**
+sidecar. A checksum published beside a key whose bytes change would be wrong the
+next time it changed — the same bug in a new place, and one that would look
+authoritative because of where it sat.
+
+## Risk class and verification (R3)
+
+**R3: backward compatibility and integrity/verification tooling.** This is the
+publish path for every artifact users install, and the object it produces is the
+one they check downloads against.
+
+| Acceptance criterion | Gate that proves it | Layer |
+|---|---|---|
+| Every versioned artifact gets a sidecar holding its real hash | `test_publish_spaces.sh`: runs the real script, compares each sidecar against `sha256sum` of the artifact | Integration, in-CI |
+| Sidecars are cached as immutable and served as text | Same test, asserting the recorded `--cache-control` / `--content-type` per key | Integration, in-CI |
+| Rolling keys get no sidecar | Same test, asserting absence for `wfl-latest-*`, `SHA256SUMS`, `status.json` | Integration, in-CI |
+| An artifact can never be published without its checksum | Sidecar upload is in phase 1 under `set -e`; test injects a sidecar-upload failure and asserts non-zero exit with rolling pointers and `status.json` unwritten | Integration, in-CI (negative) |
+| Existing `SHA256SUMS` consumers are unaffected | Same test: still published, still lists all three artifacts, still `max-age=60` | Integration, in-CI |
+| The CDN actually serves the sidecar we uploaded | `publish_spaces.sh` fetches each sidecar back and compares content; publish fails otherwise | E2E, against the real bucket, every nightly |
+| The backfill hashes the bucket's bytes, not CI's | `test_publish_spaces.sh`: seeds objects, asserts each backfilled sidecar matches the stored object | Integration, in-CI |
+| The backfill never rewrites a published checksum | Same test: a pre-existing sidecar is byte-identical afterwards and recorded zero uploads | Integration, in-CI (negative) |
+| The backfill is safe to run repeatedly | Same test: second run performs zero uploads | Integration, in-CI |
+
+**Red evidence.** `987f3a7` is a test-only commit, an ancestor of the Green
+implementation: 13 failing / 15 passing, failing for the intended reasons — no
+`.sha256` key for any artifact, a sidecar-upload failure not aborting the
+publish, and no backfill script to run (127). The implementation commit takes it
+to 43 passing / 0 failing.
+
+**Layers executed.** `bash -n` and `shellcheck` on all three scripts,
+`test_publish_spaces.sh` (43 assertions, 0 failures), `actionlint` on the three
+changed/added workflows (clean; the remaining findings in `ci.yml` and
+`nightly.yml` are pre-existing and in untouched steps).
+
+The documented consumer flow was also checked against the live bucket: the
+published `wfl-26.7.59-linux-x86_64-579eb80.tar.gz` was downloaded through the
+CDN, and a sidecar in the exact format `publish_spaces.sh` writes was verified
+with `sha256sum -c` → `OK`. That is the format and the command the install docs
+now tell people to use.
+
+`scripts/validate_docs_examples.py` is not applicable here — the documentation
+change adds shell snippets, not WFL examples, and no `TestPrograms/` example was
+touched. The Rust suites are likewise untouched by this change and run as usual
+in `ci.yml`.
+
+**Residual risk.**
+
+- The publish path cannot be fully exercised without live Spaces credentials, so
+  the stubbed tests plus the script's own CDN verification are what stand behind
+  it until the first real nightly. Same posture as the original publishing
+  change.
+- The backfill has to be run once against the live bucket to repair the
+  artifacts published before this change. Until it runs, those artifacts remain
+  in the state #662 describes.
+- A checksum served from the same host as the artifact demonstrates transport
+  integrity, not authenticity. Signing remains a tracked Operations follow-up,
+  and the install docs now say so plainly rather than implying more than the
+  file provides.
+
+## Testing a script that only ever runs in production
+
+`publish_spaces.sh` had no automated tests, for an understandable reason: it only
+runs in the nightly job, against a live bucket, with credentials no PR has. A
+mistake in it is invisible until it has already published — or failed to publish
+— a real release. That is precisely how #662 shipped.
+
+`test_publish_spaces.sh` closes that gap by stubbing the one boundary a test must
+not cross. The stub is a *recording fake with a real object store behind it*: a
+directory that uploads write into and later reads (including the CDN
+verification) read out of, plus a log of every key with its content-type and
+cache-control. So the assertions are about bytes and headers that actually moved,
+not about "the script called `aws`". Everything else is real — the real scripts,
+real `sha256sum`, real `jq`.
+
+Per the testing policy this is the right layer for it: the real Spaces boundary
+is verified where it exists, by the publish job's own CDN round-trip on every
+release.
+
+## For consumers
+
+Pinned verification, which is what anyone deploying WFL actually needs:
+
+```bash
+BASE=https://wfl.nyc3.cdn.digitaloceanspaces.com/releases
+TARBALL=wfl-26.7.59-linux-x86_64-579eb80.tar.gz
+
+curl -fLO "$BASE/$TARBALL"
+curl -fLO "$BASE/$TARBALL.sha256"
+sha256sum -c "$TARBALL.sha256"
+```
+
+`SHA256SUMS` keeps its existing meaning for anyone tracking `latest`, and the
+install docs now state which file is for which case instead of leaving it to be
+inferred from the name.

--- a/Docs/02-getting-started/installation.md
+++ b/Docs/02-getting-started/installation.md
@@ -109,6 +109,35 @@ grep linux-x86_64 SHA256SUMS
 
 The two hashes must match. If they do not, do not install the archive.
 
+#### Verifying a pinned version
+
+**`SHA256SUMS` describes only the most recent publish.** It is rewritten by every
+nightly, so it is the right file to check `latest` against and the wrong file to
+check a pinned version against — the entry you pinned disappears from it as soon
+as a newer build lands, even though your tarball is immutable and still served.
+
+Every versioned artifact therefore also has its own checksum file, published once
+alongside it and never rewritten:
+
+```bash
+BASE=https://wfl.nyc3.cdn.digitaloceanspaces.com/releases
+TARBALL=wfl-26.7.59-linux-x86_64-579eb80.tar.gz   # the build you pinned
+
+curl -fLO "$BASE/$TARBALL"
+curl -fLO "$BASE/$TARBALL.sha256"
+sha256sum -c "$TARBALL.sha256"
+```
+
+`sha256sum -c` prints `OK` and exits 0 on a match, so this drops straight into a
+deployment script. The same `<artifact>.sha256` naming applies to the MSI and the
+VS Code extension (`wfl-<version>.msi.sha256`,
+`vscode-wfl-<version>.vsix.sha256`).
+
+Both files are served from the same host as the artifact, so they prove the
+download arrived intact — not that it came from us. Signed installers are a
+tracked follow-up; until then, treat the checksum as an integrity check, and
+record the expected hash yourself if you need to detect a change at the source.
+
 ### Step 2: Extract
 
 ```bash

--- a/Docs/reference/supported-platforms.md
+++ b/Docs/reference/supported-platforms.md
@@ -100,8 +100,10 @@ testable, documented, and operable* for **supported language behaviour**:
 - Release artifacts are produced by the nightly/release workflows (not from PR
   CI) and installable via the documented paths. Each publish writes a
   `SHA256SUMS` file next to the artifacts at
-  <https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/>; signing the installers
-  remains a tracked Operations follow-up.
+  <https://wfl.nyc3.cdn.digitaloceanspaces.com/releases/>, describing that
+  publish only, plus an immutable `<artifact>.sha256` beside each versioned
+  object so a pinned build stays verifiable for as long as it stays
+  downloadable. Signing the installers remains a tracked Operations follow-up.
 
 Support **does not** extend to:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -129,8 +129,14 @@ Spaces (`SPACES_BUCKET`, `SPACES_ENDPOINT` override the defaults) and `jq`.
 Uploads one nightly's artifacts. Immutable versioned objects go up first, each
 with an immutable `<artifact>.sha256` sidecar; the rolling `latest` pointers,
 `SHA256SUMS` and `status.json` follow only once every one of them succeeded, so a
-partial publish is never observable as a release. Every object is then read back
-through the CDN and compared byte for byte against what was uploaded.
+partial publish is never observable as a release and anything it left behind is
+unreferenced. Every object is then read back through the CDN and compared byte
+for byte against what was uploaded.
+
+Versioned keys are treated as write-once: re-publishing identical bytes is a
+no-op, and a build whose bytes differ from what is already published under the
+same key **aborts the publish** rather than replacing it. Re-running a publish
+that failed partway is therefore the supported way to finish it.
 
 **Usage:**
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -118,6 +118,48 @@ Utility script for branch synchronization.
 .\scripts\sync-branch.ps1
 ```
 
+## Release Publishing Scripts
+
+These run from `.github/workflows/nightly.yml` against the DigitalOcean Spaces
+bucket that backs <https://wfl.nyc3.cdn.digitaloceanspaces.com>, the canonical
+download location. Both need `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` for
+Spaces (`SPACES_BUCKET`, `SPACES_ENDPOINT` override the defaults) and `jq`.
+
+### `publish_spaces.sh`
+Uploads one nightly's artifacts. Immutable versioned objects go up first, each
+with an immutable `<artifact>.sha256` sidecar; the rolling `latest` pointers,
+`SHA256SUMS` and `status.json` follow only once every one of them succeeded, so a
+partial publish is never observable as a release. Every object is then read back
+through the CDN and compared byte for byte against what was uploaded.
+
+**Usage:**
+```bash
+./scripts/publish_spaces.sh <artifact-dir> <version> <short-sha> <commit-sha> <branch>
+```
+
+### `backfill_spaces_checksums.sh`
+Creates the `<artifact>.sha256` sidecars for artifacts published before those
+existed. Idempotent and additive: it only ever creates missing `*.sha256` keys,
+never rewrites one, and never touches an artifact, a rolling pointer,
+`SHA256SUMS`, or `status.json`. Runs after every nightly publish, and on demand
+via the **Backfill Release Checksums** workflow.
+
+**Usage:**
+```bash
+./scripts/backfill_spaces_checksums.sh --dry-run   # report what is missing
+./scripts/backfill_spaces_checksums.sh             # repair it
+```
+
+### `test_publish_spaces.sh`
+Tests both of the above by running them against a recording stub of the AWS CLI,
+asserting the keys, bytes and cache headers they write. No credentials needed;
+runs in CI as the **Release Script Tests** job.
+
+**Usage:**
+```bash
+./scripts/test_publish_spaces.sh
+```
+
 ## Development Workflow
 
 ### Typical Development Cycle

--- a/scripts/backfill_spaces_checksums.sh
+++ b/scripts/backfill_spaces_checksums.sh
@@ -41,7 +41,9 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --dry-run) DRY_RUN=1; shift ;;
     --prefix)  PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
-    -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+    # Prints the whole header block rather than a hardcoded line range, which
+    # silently truncates the moment the header grows a line.
+    -h|--help) awk 'NR > 1 && /^#/ { print; next } NR > 1 { exit }' "$0"; exit 0 ;;
     *) echo "unknown argument: $1" >&2; exit 64 ;;
   esac
 done
@@ -123,6 +125,20 @@ while IFS= read -r key; do
   fi
 
   ( cd "$WORK" && sha256sum "$base" ) > "$WORK/$base.sha256"
+
+  # The listing above is a snapshot. A publish can land between it and this
+  # upload - the on-demand workflow and the nightly can genuinely overlap - and
+  # the publisher's sidecar is the authoritative one: it describes the bytes it
+  # just uploaded, where this run's describes the bytes it read earlier. Never
+  # replace it. (The workflows also share a concurrency group, so this window is
+  # the residual case rather than the expected one.)
+  if aws s3api head-object --bucket "$BUCKET" --key "${key}.sha256" \
+        --endpoint-url "$ENDPOINT" >/dev/null 2>&1; then
+    echo "  ${key}.sha256 was published while this run was working; leaving it alone"
+    SKIPPED=$((SKIPPED + 1))
+    rm -f "$WORK/$base" "$WORK/$base.sha256"
+    continue
+  fi
 
   if ! aws s3 cp "$WORK/$base.sha256" "s3://${BUCKET}/${key}.sha256" \
         --endpoint-url "$ENDPOINT" \

--- a/scripts/backfill_spaces_checksums.sh
+++ b/scripts/backfill_spaces_checksums.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Write the missing `.sha256` sidecars for artifacts already published to the
+# DigitalOcean Spaces bucket that backs https://wfl.nyc3.cdn.digitaloceanspaces.com.
+#
+# Why this exists
+# ---------------
+# publish_spaces.sh writes an immutable `<artifact>.sha256` next to every
+# versioned object it uploads, so a pinned build stays verifiable for as long as
+# it stays downloadable. Artifacts published before that change have no sidecar:
+# their only attestation was `releases/SHA256SUMS`, which is rewritten on every
+# publish and therefore describes only the newest build (issue #662).
+#
+# This script repairs that history. It reads each artifact back from the bucket,
+# hashes the bytes the bucket actually holds, and uploads the sidecar.
+#
+# It is safe to run at any time, and is meant to be:
+#
+#   * idempotent  - an artifact that already has a sidecar is skipped, never
+#                   re-uploaded. Published checksums are immutable; rewriting
+#                   one would defeat the point of publishing it.
+#   * additive    - it only ever creates `*.sha256` keys. No artifact, rolling
+#                   pointer, SHA256SUMS or status.json is touched.
+#   * unattended  - failures are reported per object and summarised, so one bad
+#                   object does not hide the rest of the run.
+#
+# Rolling keys (`wfl-latest-*`, `SHA256SUMS`, `status.json`) are deliberately
+# skipped: a checksum published beside a key whose bytes change would be wrong
+# the next time it changed, which is precisely the bug this whole change fixes.
+#
+# Usage: backfill_spaces_checksums.sh [--dry-run] [--prefix releases/]
+#
+# Required env: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+# Optional env: SPACES_BUCKET (default wfl), SPACES_ENDPOINT (default nyc3)
+
+set -euo pipefail
+
+DRY_RUN=0
+PREFIX="releases/"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --prefix)  PREFIX="${2:?--prefix needs a value}"; shift 2 ;;
+    -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 64 ;;
+  esac
+done
+
+BUCKET="${SPACES_BUCKET:-wfl}"
+ENDPOINT="${SPACES_ENDPOINT:-https://nyc3.digitaloceanspaces.com}"
+
+command -v jq >/dev/null || { echo "::error::jq is required but not installed"; exit 1; }
+
+# Same Spaces incompatibility publish_spaces.sh documents: AWS CLI v2.23+ sends
+# CRC32 integrity headers that Spaces rejects with an opaque 400.
+export AWS_REQUEST_CHECKSUM_CALCULATION="${AWS_REQUEST_CHECKSUM_CALCULATION:-when_required}"
+export AWS_RESPONSE_CHECKSUM_VALIDATION="${AWS_RESPONSE_CHECKSUM_VALIDATION:-when_required}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-nyc3}"
+
+IMMUTABLE="public, max-age=31536000, immutable"
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ---------------------------------------------------------------------------
+# Read the current bucket contents. The AWS CLI paginates list-objects-v2 for
+# us, so a bucket larger than one page still yields every key here.
+# ---------------------------------------------------------------------------
+aws s3api list-objects-v2 \
+  --bucket "$BUCKET" \
+  --prefix "$PREFIX" \
+  --endpoint-url "$ENDPOINT" \
+  --output json > "$WORK/listing.json"
+
+jq -r '.Contents[]?.Key' "$WORK/listing.json" | sort > "$WORK/keys.txt"
+
+TOTAL_KEYS="$(grep -c . "$WORK/keys.txt" || true)"
+echo "s3://${BUCKET}/${PREFIX}: ${TOTAL_KEYS} object(s)"
+
+# An artifact is a versioned, immutable object. Everything else in the bucket
+# either changes over time or is itself metadata about a publish.
+is_artifact() { # is_artifact <key>
+  local key="$1" base="${1##*/}"
+  case "$base" in
+    wfl-latest-*)         return 1 ;;  # rolling pointer
+    SHA256SUMS|status.json) return 1 ;;
+    *.sha256)             return 1 ;;  # a sidecar, not something to hash
+  esac
+  case "$key" in
+    *.tar.gz|*.msi|*.vsix) return 0 ;;
+    *)                     return 1 ;;
+  esac
+}
+
+CREATED=0
+SKIPPED=0
+FAILED=0
+
+while IFS= read -r key; do
+  [ -n "$key" ] || continue
+  is_artifact "$key" || continue
+
+  if grep -qxF "${key}.sha256" "$WORK/keys.txt"; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  base="${key##*/}"
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "  would create ${key}.sha256"
+    CREATED=$((CREATED + 1))
+    continue
+  fi
+
+  # Hash what the bucket serves, not what CI once built: the sidecar has to
+  # attest to the bytes a consumer will actually download.
+  if ! aws s3 cp "s3://${BUCKET}/${key}" "$WORK/$base" \
+        --endpoint-url "$ENDPOINT" --only-show-errors; then
+    echo "::warning::could not download ${key} - skipping"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  ( cd "$WORK" && sha256sum "$base" ) > "$WORK/$base.sha256"
+
+  if ! aws s3 cp "$WORK/$base.sha256" "s3://${BUCKET}/${key}.sha256" \
+        --endpoint-url "$ENDPOINT" \
+        --acl public-read \
+        --content-type text/plain \
+        --cache-control "$IMMUTABLE" \
+        --only-show-errors; then
+    echo "::warning::could not upload ${key}.sha256"
+    FAILED=$((FAILED + 1))
+    rm -f "$WORK/$base" "$WORK/$base.sha256"
+    continue
+  fi
+
+  echo "  created ${key}.sha256  $(cut -d' ' -f1 < "$WORK/$base.sha256")"
+  CREATED=$((CREATED + 1))
+  rm -f "$WORK/$base" "$WORK/$base.sha256"
+done < "$WORK/keys.txt"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  echo "dry run: ${CREATED} sidecar(s) would be created, ${SKIPPED} already present"
+else
+  echo "created ${CREATED} sidecar(s), skipped ${SKIPPED} already present, ${FAILED} failed"
+fi
+
+# A partial repair is still worth keeping - the sidecars that landed are
+# correct - but the run must not report success, or a scheduled invocation
+# would quietly leave gaps behind.
+[ "$FAILED" -eq 0 ]

--- a/scripts/publish_spaces.sh
+++ b/scripts/publish_spaces.sh
@@ -98,21 +98,80 @@ PUBLISHED=()
 # at the end can compare what the CDN serves against the bytes we uploaded.
 PUBLISHED_PATHS=()
 
+object_exists() { # object_exists <key>
+  aws s3api head-object \
+    --bucket "$BUCKET" --key "$1" --endpoint-url "$ENDPOINT" >/dev/null 2>&1
+}
+
+# published_sha256_of <key> -> the SHA-256 of what the bucket already holds under
+# that key, or the empty string if the key is not there.
+#
+# Prefers the key's own sidecar, which is a few dozen bytes, over re-downloading
+# the artifact. A sidecar that lies about its artifact would make this answer
+# wrong, but only in the direction of proceeding with an upload - and the CDN
+# round-trip at the end of this script re-checks the artifact bytes themselves,
+# so a wrong answer here cannot get past the publish.
+published_sha256_of() {
+  local key="$1"
+  if object_exists "${key}.sha256"; then
+    aws s3 cp "s3://${BUCKET}/${key}.sha256" "$WORK/existing.sha256" \
+      --endpoint-url "$ENDPOINT" --only-show-errors >/dev/null
+    cut -d' ' -f1 < "$WORK/existing.sha256"
+    rm -f "$WORK/existing.sha256"
+  elif object_exists "$key"; then
+    aws s3 cp "s3://${BUCKET}/${key}" "$WORK/existing.bin" \
+      --endpoint-url "$ENDPOINT" --only-show-errors >/dev/null
+    sha256_of "$WORK/existing.bin"
+    rm -f "$WORK/existing.bin"
+  fi
+}
+
 # publish_immutable <local-file> <content-type>
 #
 # Uploads one versioned artifact plus the `.sha256` sidecar that keeps it
 # verifiable after this publish stops being the newest one, and records the line
-# in the SHA256SUMS for this run. The sidecar goes up in the same step as the
-# artifact and under the same `set -e`, so an artifact can never end up in the
-# bucket without the checksum that attests to it.
+# in the SHA256SUMS for this run.
+#
+# Versioned keys are immutable, but `Cache-Control: immutable` is a promise to
+# caches - it does not stop a later `aws s3 cp` from replacing the object. A
+# manual dispatch with a version override, or a rebuild of a version whose
+# artifacts differ, would otherwise overwrite a build people have already
+# pinned. Worse, the artifact and its sidecar are cached independently for a
+# year, so an edge could serve the old artifact beside the new checksum and a
+# correct download would look tampered with. So: identical bytes are a no-op,
+# different bytes abort the publish, and only genuinely new keys are written.
+#
+# A retry after a partial failure therefore completes rather than trips over the
+# objects the previous attempt already landed. That matters because the sidecar
+# upload can fail *after* its artifact landed, leaving an object with no
+# checksum - unreferenced by any pointer, SHA256SUMS entry or status.json, since
+# those are only written once every immutable upload has succeeded, but present.
+# Re-running the publish is what completes it, and the nightly's backfill step
+# would also fill the sidecar in on the next run.
 publish_immutable() {
-  local f="$1" ct="$2" base
+  local f="$1" ct="$2" base want have
   base="$(basename "$f")"
+  want="$(sha256_of "$f")"
+  have="$(published_sha256_of "releases/$base")"
 
-  put "$f" "releases/$base" "$ct" "$IMMUTABLE"
+  if [ -n "$have" ] && [ "$have" != "$want" ]; then
+    echo "::error::refusing to overwrite releases/${base}: it is already published with different bytes (published ${have}, built ${want}). Versioned keys are immutable; publish this build under a new version."
+    exit 1
+  fi
 
   sha256_line_of "$f" > "$WORK/$base.sha256"
-  put "$WORK/$base.sha256" "releases/$base.sha256" text/plain "$IMMUTABLE"
+
+  if [ -z "$have" ]; then
+    put "$f" "releases/$base" "$ct" "$IMMUTABLE"
+  else
+    echo "  -> releases/$base already published with identical bytes; not rewriting"
+  fi
+
+  if ! object_exists "releases/$base.sha256"; then
+    put "$WORK/$base.sha256" "releases/$base.sha256" text/plain "$IMMUTABLE"
+  else
+    echo "  -> releases/$base.sha256 already published; not rewriting"
+  fi
 
   cat "$WORK/$base.sha256" >> "$WORK/SHA256SUMS"
   PUBLISHED+=("$base")
@@ -200,10 +259,27 @@ echo "Verifying public readability via CDN..."
 # For the artifacts, a 200 is not enough - it proves a key exists, not that the
 # bytes an installer downloads are the ones we built. Pull each immutable object
 # back through the CDN and compare its SHA-256 against the local file.
+# A key created seconds ago can take a moment to be readable at every edge, and
+# this check runs before the tag and GitHub release that mark the nightly as
+# done - so a propagation blip here costs a whole re-run. Retry a few times
+# before calling it a failed publish. A key that is genuinely not public stays a
+# failure; it just takes ~6 seconds longer to say so.
+fetch_cdn() { # fetch_cdn <key> <output-file> <max-time>
+  local key="$1" out="$2" maxtime="$3" attempt=1 delay=2
+  while :; do
+    if curl -fsS --max-time "$maxtime" -o "$out" "${CDN}/${key}"; then return 0; fi
+    if [ "$attempt" -ge 3 ]; then return 1; fi
+    echo "  ${CDN}/${key} not readable yet (attempt ${attempt}); retrying in ${delay}s"
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 for f in "${PUBLISHED_PATHS[@]}"; do
   key="releases/$(basename "$f")"
   want="$(sha256_of "$f")"
-  if ! curl -fsS --max-time 300 -o "$WORK/verify.bin" "${CDN}/${key}"; then
+  if ! fetch_cdn "$key" "$WORK/verify.bin" 300; then
     echo "::error::could not fetch ${CDN}/${key} - the object is not publicly readable"
     exit 1
   fi
@@ -220,7 +296,7 @@ for f in "${PUBLISHED_PATHS[@]}"; do
   # immutable, so unlike the rolling keys below there is no cache window in
   # which a correct publish could legitimately serve something else.
   sidecar="${key}.sha256"
-  if ! curl -fsS --max-time 30 -o "$WORK/verify.sha256" "${CDN}/${sidecar}"; then
+  if ! fetch_cdn "$sidecar" "$WORK/verify.sha256" 30; then
     echo "::error::could not fetch ${CDN}/${sidecar} - the checksum sidecar is not publicly readable"
     exit 1
   fi

--- a/scripts/publish_spaces.sh
+++ b/scripts/publish_spaces.sh
@@ -8,9 +8,18 @@
 #   releases/wfl-<version>-linux-x86_64-<sha>.tar.gz   immutable, versioned
 #   releases/wfl-<version>.msi                         immutable, versioned
 #   releases/vscode-wfl-<version>.vsix                 immutable, versioned
+#   releases/<any-of-the-above>.sha256                 immutable, versioned
 #   releases/wfl-latest-linux-x86_64.tar.gz            rolling pointer
-#   releases/SHA256SUMS                                checksums for this publish
+#   releases/SHA256SUMS                                checksums for THIS publish
 #   status.json                                        last-publish record
+#
+# Note the split between the two kinds of checksum. `SHA256SUMS` describes the
+# publish that wrote it and nothing else: it is rewritten every run, so a
+# consumer pinned to an older version finds their hash gone from it the moment a
+# newer nightly lands, even though the artifact they pinned is immutable and
+# still served. That is issue #662. The per-artifact `.sha256` sidecars exist so
+# a pinned build stays verifiable for as long as it stays downloadable - they
+# are written once, next to the object they describe, and never rewritten.
 #
 # Usage: publish_spaces.sh <artifact-dir> <version> <short-sha> <commit-sha> <branch>
 #
@@ -69,6 +78,11 @@ put() { # put <local-file> <remote-key> <content-type> <cache-control>
 
 sha256_of() { sha256sum "$1" | cut -d' ' -f1; }
 
+# The sidecar carries sha256sum's own line format ("<hash>  <name>") rather than
+# a bare hash, so `sha256sum -c wfl-<version>....tar.gz.sha256` verifies the
+# download in place with no shell plumbing on the consumer's side.
+sha256_line_of() { ( cd "$(dirname "$1")" && sha256sum "$(basename "$1")" ); }
+
 find_one() { find "$ARTIFACT_DIR" -type f -name "$1" | head -1; }
 
 TARBALL="$(find_one 'wfl-*-linux-x86_64-*.tar.gz')"
@@ -84,6 +98,27 @@ PUBLISHED=()
 # at the end can compare what the CDN serves against the bytes we uploaded.
 PUBLISHED_PATHS=()
 
+# publish_immutable <local-file> <content-type>
+#
+# Uploads one versioned artifact plus the `.sha256` sidecar that keeps it
+# verifiable after this publish stops being the newest one, and records the line
+# in the SHA256SUMS for this run. The sidecar goes up in the same step as the
+# artifact and under the same `set -e`, so an artifact can never end up in the
+# bucket without the checksum that attests to it.
+publish_immutable() {
+  local f="$1" ct="$2" base
+  base="$(basename "$f")"
+
+  put "$f" "releases/$base" "$ct" "$IMMUTABLE"
+
+  sha256_line_of "$f" > "$WORK/$base.sha256"
+  put "$WORK/$base.sha256" "releases/$base.sha256" text/plain "$IMMUTABLE"
+
+  cat "$WORK/$base.sha256" >> "$WORK/SHA256SUMS"
+  PUBLISHED+=("$base")
+  PUBLISHED_PATHS+=("$f")
+}
+
 # ---------------------------------------------------------------------------
 # Phase 1: immutable, versioned objects.
 #
@@ -95,30 +130,21 @@ PUBLISHED_PATHS=()
 # ---------------------------------------------------------------------------
 if [ -n "$TARBALL" ]; then
   echo "Linux tarball: $TARBALL"
-  put "$TARBALL" "releases/$(basename "$TARBALL")" application/gzip "$IMMUTABLE"
-  ( cd "$(dirname "$TARBALL")" && sha256sum "$(basename "$TARBALL")" ) >> "$WORK/SHA256SUMS"
-  PUBLISHED+=("$(basename "$TARBALL")")
-  PUBLISHED_PATHS+=("$TARBALL")
+  publish_immutable "$TARBALL" application/gzip
 else
   echo "::warning::no Linux tarball found in $ARTIFACT_DIR"
 fi
 
 if [ -n "$MSI" ]; then
   echo "Windows MSI: $MSI"
-  put "$MSI" "releases/$(basename "$MSI")" application/x-msi "$IMMUTABLE"
-  ( cd "$(dirname "$MSI")" && sha256sum "$(basename "$MSI")" ) >> "$WORK/SHA256SUMS"
-  PUBLISHED+=("$(basename "$MSI")")
-  PUBLISHED_PATHS+=("$MSI")
+  publish_immutable "$MSI" application/x-msi
 else
   echo "::warning::no MSI found in $ARTIFACT_DIR"
 fi
 
 if [ -n "$VSIX" ]; then
   echo "VS Code extension: $VSIX"
-  put "$VSIX" "releases/$(basename "$VSIX")" application/octet-stream "$IMMUTABLE"
-  ( cd "$(dirname "$VSIX")" && sha256sum "$(basename "$VSIX")" ) >> "$WORK/SHA256SUMS"
-  PUBLISHED+=("$(basename "$VSIX")")
-  PUBLISHED_PATHS+=("$VSIX")
+  publish_immutable "$VSIX" application/octet-stream
 fi
 
 if [ "${#PUBLISHED[@]}" -eq 0 ]; then
@@ -188,6 +214,22 @@ for f in "${PUBLISHED_PATHS[@]}"; do
     exit 1
   fi
   echo "  ok ${CDN}/${key} sha256=${want}"
+
+  # The sidecar is the whole point of pinning a build, so an unreadable or
+  # mismatched one is a failed publish, not a warning. Both objects are
+  # immutable, so unlike the rolling keys below there is no cache window in
+  # which a correct publish could legitimately serve something else.
+  sidecar="${key}.sha256"
+  if ! curl -fsS --max-time 30 -o "$WORK/verify.sha256" "${CDN}/${sidecar}"; then
+    echo "::error::could not fetch ${CDN}/${sidecar} - the checksum sidecar is not publicly readable"
+    exit 1
+  fi
+  if [ "$(cat "$WORK/verify.sha256")" != "$(sha256_line_of "$f")" ]; then
+    echo "::error::${CDN}/${sidecar} does not describe the artifact we uploaded"
+    exit 1
+  fi
+  rm -f "$WORK/verify.sha256"
+  echo "  ok ${CDN}/${sidecar}"
 done
 
 # The rolling keys get a byte check only on their status code: they carry

--- a/scripts/test_publish_spaces.sh
+++ b/scripts/test_publish_spaces.sh
@@ -112,12 +112,35 @@ case "$sub" in
         [ -f "$FAKE_BUCKET/$key" ] || { echo "fake aws: no such key: $key" >&2; exit 1; }
         cp "$FAKE_BUCKET/$key" "$dst" || exit 1
         printf 'GET\t%s\t\t\n' "$key" >> "$FAKE_LOG"
+        # Lets a test slip a concurrent publisher into the window between a
+        # backfill's download and its upload.
+        if [ -n "${FAKE_ON_GET_HOOK:-}" ]; then "$FAKE_ON_GET_HOOK" "$key"; fi
         ;;
     esac
     ;;
   s3api)
     op="${1:-}"; shift || true
-    [ "$op" = "list-objects-v2" ] || { echo "fake aws: unsupported: s3api $op" >&2; exit 64; }
+    case "$op" in
+      head-object)
+        key=""
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --key) key="$2"; shift 2 ;;
+            --bucket|--endpoint-url|--output) shift 2 ;;
+            --*) shift ;;
+            *) shift ;;
+          esac
+        done
+        if [ -f "$FAKE_BUCKET/$key" ]; then
+          jq -n --arg k "$key" '{ContentLength: 1, Key: $k}'
+          exit 0
+        fi
+        echo "fake aws: Not Found: $key" >&2
+        exit 254
+        ;;
+      list-objects-v2) : ;;
+      *) echo "fake aws: unsupported: s3api $op" >&2; exit 64 ;;
+    esac
     prefix=""
     while [ $# -gt 0 ]; do
       case "$1" in
@@ -141,6 +164,11 @@ FAKE_AWS
   cat > "$bin/curl" <<'FAKE_CURL'
 #!/usr/bin/env bash
 # Serves the fake bucket over "HTTP": the CDN host maps onto $FAKE_BUCKET.
+#
+# FAKE_CURL_FLAKY_KEY / FAKE_CURL_FLAKY_TIMES simulate a CDN edge that has not
+# yet propagated a freshly uploaded key: the first N requests for that key fail
+# as if the object were not there yet, and the attempts are counted in
+# $FAKE_BUCKET/../flaky.count so a test can assert the retry actually happened.
 set -uo pipefail
 out=""; wfmt=""; fail=0; url=""
 while [ $# -gt 0 ]; do
@@ -155,6 +183,17 @@ while [ $# -gt 0 ]; do
   esac
 done
 path="${url#*://}"; path="${path#*/}"
+if [ -n "${FAKE_CURL_FLAKY_KEY:-}" ] && [ "$path" = "$FAKE_CURL_FLAKY_KEY" ]; then
+  count_file="$(dirname "$FAKE_BUCKET")/flaky.count"
+  seen=0
+  [ -f "$count_file" ] && seen="$(cat "$count_file")"
+  if [ "$seen" -lt "${FAKE_CURL_FLAKY_TIMES:-1}" ]; then
+    echo "$((seen + 1))" > "$count_file"
+    [ -n "$wfmt" ] && printf '404'
+    [ "$fail" = "1" ] && exit 22
+    exit 0
+  fi
+fi
 if [ -f "$FAKE_BUCKET/$path" ]; then
   [ -n "$out" ] && cp "$FAKE_BUCKET/$path" "$out"
   [ -n "$wfmt" ] && printf '200'
@@ -284,6 +323,90 @@ assert_file_absent "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz" \
   "rolling Linux pointer is not moved by a failed publish"
 assert_file_absent "$SB/bucket/status.json" \
   "status.json is not written by a failed publish"
+
+# The artifact itself may have landed before the sidecar failed. That object is
+# unreferenced - no pointer, no SHA256SUMS entry, no status.json - and the
+# publish is retryable, so the fix is that a re-run completes it rather than
+# tripping over its own leftovers. Assert exactly that, because a re-run that
+# refused to proceed would strand the release until someone deleted the object
+# by hand.
+run_publish "$SB" "26.7.61" "def5678"
+rc=$?
+assert_eq "0" "$rc" "re-running the publish after a sidecar failure succeeds ($SB/out)"
+assert_file_exists "$SB/bucket/releases/wfl-26.7.61-linux-x86_64-def5678.tar.gz.sha256" \
+  "the re-run completes the sidecar the failed publish left missing"
+assert_file_exists "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz" \
+  "the re-run moves the rolling pointer"
+rm -rf "$SB"
+
+# A freshly created key can take a moment to be readable at a CDN edge. Failing
+# the whole release for that would be a false negative, and the release job's
+# success marker is written after this step, so a blip costs a re-run.
+echo "publish_spaces.sh: CDN verification tolerates a slow-propagating sidecar"
+SB="$(new_env)"
+make_artifacts "$SB" "26.7.62" "aaa1111"
+(
+  export FAKE_CURL_FLAKY_KEY="releases/wfl-26.7.62-linux-x86_64-aaa1111.tar.gz.sha256"
+  export FAKE_CURL_FLAKY_TIMES=2
+  run_publish "$SB" "26.7.62" "aaa1111"
+)
+rc=$?
+assert_eq "0" "$rc" "publish survives a sidecar that 404s twice before propagating ($SB/out)"
+assert_eq "2" "$(cat "$SB/flaky.count" 2>/dev/null || echo 0)" \
+  "the sidecar fetch was actually retried"
+
+# Tolerating a blip must not mean tolerating an absent object.
+: > "$SB/flaky.count"
+rm -rf "$SB/bucket" && mkdir -p "$SB/bucket"
+(
+  export FAKE_CURL_FLAKY_KEY="releases/wfl-26.7.62-linux-x86_64-aaa1111.tar.gz.sha256"
+  export FAKE_CURL_FLAKY_TIMES=99
+  run_publish "$SB" "26.7.62" "aaa1111"
+)
+rc=$?
+if [ "$rc" -ne 0 ]; then ok "publish still fails when the sidecar never becomes readable"; else
+  bad "publish still fails when the sidecar never becomes readable"; fi
+rm -rf "$SB"
+
+# `Cache-Control: immutable` governs caches, not bucket writes. A manual
+# dispatch with a version override, or a rebuild of a version whose artifacts
+# differ, would otherwise silently replace a published artifact - and because
+# artifact and sidecar are cached independently for a year, an edge could then
+# serve the old artifact beside the new checksum. That reads as tampering.
+echo "publish_spaces.sh: an immutable key is never replaced with different bytes"
+SB="$(new_env)"
+make_artifacts "$SB" "26.7.63" "bbb2222"
+run_publish "$SB" "26.7.63" "bbb2222"
+assert_eq "0" "$?" "first publish of 26.7.63 succeeds"
+
+# Same version, different bytes: the rebuild case.
+printf 'DIFFERENT tarball bytes\n' > "$SB/artifacts/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz"
+before="$(cat "$SB/bucket/releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz")"
+before_sidecar="$(cat "$SB/bucket/releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz.sha256")"
+: > "$SB/log"
+run_publish "$SB" "26.7.63" "bbb2222"
+rc=$?
+if [ "$rc" -ne 0 ]; then ok "publish refuses to overwrite a published artifact with different bytes"; else
+  bad "publish refuses to overwrite a published artifact with different bytes"; fi
+assert_eq "$before" "$(cat "$SB/bucket/releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz")" \
+  "the published artifact is left byte-identical"
+assert_eq "$before_sidecar" "$(cat "$SB/bucket/releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz.sha256")" \
+  "the published sidecar is left byte-identical"
+assert_contains "$(cat "$SB/out")" "refusing to overwrite" \
+  "the failure names what it refused to do"
+
+# Re-publishing identical bytes is the retry case, and must still work.
+make_artifacts "$SB" "26.7.63" "bbb2222"
+: > "$SB/log"
+run_publish "$SB" "26.7.63" "bbb2222"
+rc=$?
+assert_eq "0" "$rc" "re-publishing identical bytes succeeds ($SB/out)"
+assert_eq "0" "$(put_count "$SB" "releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz")" \
+  "re-publishing identical bytes does not rewrite the artifact"
+assert_eq "0" "$(put_count "$SB" "releases/wfl-26.7.63-linux-x86_64-bbb2222.tar.gz.sha256")" \
+  "re-publishing identical bytes does not rewrite the sidecar"
+assert_file_exists "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz" \
+  "re-publishing identical bytes still refreshes the rolling pointer"
 rm -rf "$SB"
 
 # ---------------------------------------------------------------------------
@@ -341,6 +464,34 @@ run_backfill "$SB"
 rc=$?
 assert_eq "0" "$rc" "second backfill run succeeds"
 assert_eq "0" "$(grep -c '^PUT' "$SB/log")" "second backfill run uploads nothing"
+rm -rf "$SB"
+
+# The bucket listing is a snapshot. A publish that lands between the snapshot and
+# the upload would otherwise have its sidecar replaced by one this run computed
+# from the bytes it downloaded earlier - and if the artifact was rebuilt in
+# between, that checksum describes bytes nobody can download any more.
+echo "backfill_spaces_checksums.sh: a sidecar published mid-run is not overwritten"
+SB="$(new_env)"
+KEY="releases/wfl-26.7.57-linux-x86_64-2d74737.tar.gz"
+put_object "$SB" "$KEY" "old linux bytes"
+cat > "$SB/concurrent-publisher.sh" <<EOF
+#!/usr/bin/env bash
+# Stands in for a nightly publish winning the race: the sidecar appears after
+# the backfill listed the bucket, while it is reading the artifact.
+[ "\$1" = "$KEY" ] || exit 0
+printf 'sidecar from the concurrent publisher' > "$SB/bucket/$KEY.sha256"
+EOF
+chmod +x "$SB/concurrent-publisher.sh"
+(
+  export FAKE_ON_GET_HOOK="$SB/concurrent-publisher.sh"
+  run_backfill "$SB"
+)
+rc=$?
+assert_eq "0" "$rc" "backfill succeeds when a publisher wins the race ($SB/out)"
+assert_eq "sidecar from the concurrent publisher" "$(cat "$SB/bucket/$KEY.sha256")" \
+  "the concurrently published sidecar is left intact"
+assert_eq "0" "$(put_count "$SB" "$KEY.sha256")" \
+  "the backfill uploads nothing over the concurrently published sidecar"
 rm -rf "$SB"
 
 echo "backfill_spaces_checksums.sh: --dry-run"

--- a/scripts/test_publish_spaces.sh
+++ b/scripts/test_publish_spaces.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# Tests for scripts/publish_spaces.sh and scripts/backfill_spaces_checksums.sh.
+#
+# What is real and what is not
+# ----------------------------
+# The scripts under test are pure orchestration: they decide *which keys* get
+# written, *with which bytes*, and *with which cache headers*. That decision is
+# the behaviour these tests verify, and it is verified end to end - the real
+# scripts run, the real sha256sum runs, the real jq runs.
+#
+# The one boundary that is stubbed is the AWS CLI (and the curl calls that read
+# back through the CDN), because the other side of it is a live DigitalOcean
+# Spaces bucket that a test must not write to. The stub is a recording fake with
+# a real object store behind it (a directory), so uploads are readable by later
+# reads in the same test and assertions are made against bytes and headers that
+# actually moved - not against "the script called aws".
+#
+# The genuine Spaces boundary is covered where it belongs: publish_spaces.sh
+# fetches every object back through the CDN and compares SHA-256 against the
+# local file on every real publish, and fails the release if it does not match.
+#
+# Usage: scripts/test_publish_spaces.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PUBLISH="$REPO_ROOT/scripts/publish_spaces.sh"
+BACKFILL="$REPO_ROOT/scripts/backfill_spaces_checksums.sh"
+
+command -v jq >/dev/null || { echo "jq is required to run these tests"; exit 1; }
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS + 1)); echo "  ok   $1"; }
+bad()  { FAIL=$((FAIL + 1)); echo "  FAIL $1"; }
+
+assert_eq() { # assert_eq <expected> <actual> <message>
+  if [ "$1" = "$2" ]; then ok "$3"; else
+    bad "$3"
+    echo "         expected: $1"
+    echo "         actual:   $2"
+  fi
+}
+
+assert_contains() { # assert_contains <haystack> <needle> <message>
+  case "$1" in
+    *"$2"*) ok "$3" ;;
+    *) bad "$3"; echo "         expected to contain: $2"; echo "         actual: $1" ;;
+  esac
+}
+
+assert_file_exists() { # assert_file_exists <path> <message>
+  if [ -f "$1" ]; then ok "$2"; else bad "$2"; echo "         missing: $1"; fi
+}
+
+assert_file_absent() { # assert_file_absent <path> <message>
+  if [ ! -e "$1" ]; then ok "$2"; else bad "$2"; echo "         unexpectedly present: $1"; fi
+}
+
+# ---------------------------------------------------------------------------
+# Fake bucket + fake `aws` / `curl`.
+#
+# The fake bucket is a directory: $FAKE_BUCKET/<key> holds the object bytes.
+# Every mutation is appended to $FAKE_LOG as "<verb> <key> <content-type>
+# <cache-control>", so a test can assert on headers as well as bytes.
+# ---------------------------------------------------------------------------
+make_fakes() { # make_fakes <bindir>
+  local bin="$1"
+  mkdir -p "$bin"
+
+  cat > "$bin/aws" <<'FAKE_AWS'
+#!/usr/bin/env bash
+set -uo pipefail
+sub="${1:-}"; shift || true
+
+key_of() { # key_of s3://bucket/key
+  local u="${1#s3://}"
+  echo "${u#*/}"
+}
+
+case "$sub" in
+  s3)
+    op="${1:-}"; shift || true
+    [ "$op" = "cp" ] || { echo "fake aws: unsupported: s3 $op" >&2; exit 64; }
+    src=""; dst=""; ct=""; cc=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --content-type)      ct="$2"; shift 2 ;;
+        --cache-control)     cc="$2"; shift 2 ;;
+        --endpoint-url|--acl) shift 2 ;;
+        --only-show-errors|--quiet) shift ;;
+        --*)                 shift ;;
+        *) if [ -z "$src" ]; then src="$1"; else dst="$1"; fi; shift ;;
+      esac
+    done
+    case "$dst" in
+      s3://*)
+        key="$(key_of "$dst")"
+        if [ -n "${FAKE_FAIL_KEY_GLOB:-}" ]; then
+          # shellcheck disable=SC2254
+          case "$key" in
+            $FAKE_FAIL_KEY_GLOB) echo "fake aws: injected upload failure for $key" >&2; exit 1 ;;
+          esac
+        fi
+        mkdir -p "$FAKE_BUCKET/$(dirname "$key")"
+        cp "$src" "$FAKE_BUCKET/$key" || exit 1
+        printf 'PUT\t%s\t%s\t%s\n' "$key" "$ct" "$cc" >> "$FAKE_LOG"
+        ;;
+      *)
+        key="$(key_of "$src")"
+        [ -f "$FAKE_BUCKET/$key" ] || { echo "fake aws: no such key: $key" >&2; exit 1; }
+        cp "$FAKE_BUCKET/$key" "$dst" || exit 1
+        printf 'GET\t%s\t\t\n' "$key" >> "$FAKE_LOG"
+        ;;
+    esac
+    ;;
+  s3api)
+    op="${1:-}"; shift || true
+    [ "$op" = "list-objects-v2" ] || { echo "fake aws: unsupported: s3api $op" >&2; exit 64; }
+    prefix=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --prefix) prefix="$2"; shift 2 ;;
+        --bucket|--endpoint-url|--output) shift 2 ;;
+        --*) shift ;;
+        *) shift ;;
+      esac
+    done
+    ( cd "$FAKE_BUCKET" 2>/dev/null && find . -type f | sed 's|^\./||' | sort ) \
+      | grep -E "^${prefix}" \
+      | jq -R -s '{Contents: (split("\n") | map(select(length > 0)) | map({Key: .})), IsTruncated: false}'
+    ;;
+  *)
+    echo "fake aws: unsupported command: $sub" >&2
+    exit 64
+    ;;
+esac
+FAKE_AWS
+
+  cat > "$bin/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+# Serves the fake bucket over "HTTP": the CDN host maps onto $FAKE_BUCKET.
+set -uo pipefail
+out=""; wfmt=""; fail=0; url=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    -w) wfmt="$2"; shift 2 ;;
+    --max-time) shift 2 ;;
+    -fsS|-fLO|-f) fail=1; shift ;;
+    -s|-sS|-sI|-I) shift ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+path="${url#*://}"; path="${path#*/}"
+if [ -f "$FAKE_BUCKET/$path" ]; then
+  [ -n "$out" ] && cp "$FAKE_BUCKET/$path" "$out"
+  [ -n "$wfmt" ] && printf '200'
+  exit 0
+fi
+[ -n "$wfmt" ] && printf '404'
+[ "$fail" = "1" ] && exit 22
+exit 0
+FAKE_CURL
+
+  chmod +x "$bin/aws" "$bin/curl"
+}
+
+new_env() { # new_env -> echoes a fresh sandbox dir with bucket/log/bin/artifacts
+  local d
+  d="$(mktemp -d)"
+  mkdir -p "$d/bucket" "$d/artifacts"
+  : > "$d/log"
+  make_fakes "$d/bin"
+  echo "$d"
+}
+
+# put_object <sandbox> <key> <content>  -- seed pre-existing bucket state
+put_object() {
+  mkdir -p "$1/bucket/$(dirname "$2")"
+  printf '%s' "$3" > "$1/bucket/$2"
+}
+
+log_line_for() { # log_line_for <sandbox> <key> -> last PUT log line for that key
+  awk -F'\t' -v k="$2" '$1 == "PUT" && $2 == k { line = $0 } END { print line }' "$1/log"
+}
+
+put_count() { # put_count <sandbox> <key>
+  awk -F'\t' -v k="$2" '$1 == "PUT" && $2 == k { n++ } END { print n + 0 }' "$1/log"
+}
+
+make_artifacts() { # make_artifacts <sandbox> <version> <sha>
+  local d="$1" v="$2" s="$3"
+  printf 'tarball bytes for %s\n' "$v" > "$d/artifacts/wfl-$v-linux-x86_64-$s.tar.gz"
+  printf 'msi bytes for %s\n'     "$v" > "$d/artifacts/wfl-$v.msi"
+  printf 'vsix bytes for %s\n'    "$v" > "$d/artifacts/vscode-wfl-$v.vsix"
+}
+
+run_publish() { # run_publish <sandbox> <version> <sha> -> writes $sandbox/out, returns exit code
+  local d="$1"
+  (
+    export PATH="$d/bin:$PATH"
+    export FAKE_BUCKET="$d/bucket" FAKE_LOG="$d/log"
+    export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test
+    "$PUBLISH" "$d/artifacts" "$2" "$3" "${3}deadbeef" main
+  ) > "$d/out" 2>&1
+}
+
+run_backfill() { # run_backfill <sandbox> [extra args...] -> writes $sandbox/out
+  local d="$1"; shift
+  (
+    export PATH="$d/bin:$PATH"
+    export FAKE_BUCKET="$d/bucket" FAKE_LOG="$d/log"
+    export AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test
+    "$BACKFILL" "$@"
+  ) > "$d/out" 2>&1
+}
+
+sha_line() { # sha_line <file> -> "<hash>  <basename>"
+  ( cd "$(dirname "$1")" && sha256sum "$(basename "$1")" )
+}
+
+# ---------------------------------------------------------------------------
+# publish_spaces.sh
+# ---------------------------------------------------------------------------
+echo "publish_spaces.sh: per-artifact checksum sidecars"
+
+SB="$(new_env)"
+make_artifacts "$SB" "26.7.60" "abc1234"
+run_publish "$SB" "26.7.60" "abc1234"
+rc=$?
+assert_eq "0" "$rc" "publish succeeds ($SB/out)"
+
+TARBALL="wfl-26.7.60-linux-x86_64-abc1234.tar.gz"
+MSI="wfl-26.7.60.msi"
+VSIX="vscode-wfl-26.7.60.vsix"
+
+for a in "$TARBALL" "$MSI" "$VSIX"; do
+  assert_file_exists "$SB/bucket/releases/$a.sha256" "sidecar published for $a"
+  if [ -f "$SB/bucket/releases/$a.sha256" ]; then
+    want="$(sha_line "$SB/artifacts/$a")"
+    got="$(cat "$SB/bucket/releases/$a.sha256")"
+    assert_eq "$want" "$got" "sidecar for $a holds the sha256sum line for the artifact"
+    assert_contains "$(log_line_for "$SB" "releases/$a.sha256")" "immutable" \
+      "sidecar for $a is cached as immutable"
+    assert_contains "$(log_line_for "$SB" "releases/$a.sha256")" "text/plain" \
+      "sidecar for $a is served as text/plain"
+  fi
+done
+
+# A sidecar for a rolling pointer would itself be rolling, which is exactly the
+# false sense of pinnability this change exists to remove.
+assert_file_absent "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz.sha256" \
+  "no sidecar for the rolling Linux pointer"
+assert_file_absent "$SB/bucket/releases/wfl-latest-windows-x86_64.msi.sha256" \
+  "no sidecar for the rolling Windows pointer"
+assert_file_absent "$SB/bucket/releases/SHA256SUMS.sha256" \
+  "no sidecar for SHA256SUMS itself"
+
+# Backward compatibility: existing consumers read SHA256SUMS, and it must keep
+# describing the current publish exactly as before.
+assert_file_exists "$SB/bucket/releases/SHA256SUMS" "SHA256SUMS is still published"
+sums="$(cat "$SB/bucket/releases/SHA256SUMS" 2>/dev/null)"
+assert_eq "3" "$(printf '%s\n' "$sums" | grep -c .)" "SHA256SUMS still lists all three artifacts"
+assert_contains "$(log_line_for "$SB" "releases/SHA256SUMS")" "max-age=60" \
+  "SHA256SUMS stays a rolling object"
+rm -rf "$SB"
+
+# A publish whose sidecars did not land must not claim success, and must not
+# move the rolling pointers that installers follow.
+echo "publish_spaces.sh: a failed sidecar upload aborts the publish"
+SB="$(new_env)"
+make_artifacts "$SB" "26.7.61" "def5678"
+(
+  export FAKE_FAIL_KEY_GLOB='*.sha256'
+  run_publish "$SB" "26.7.61" "def5678"
+)
+rc=$?
+if [ "$rc" -ne 0 ]; then ok "publish fails when a sidecar upload fails"; else
+  bad "publish fails when a sidecar upload fails"; fi
+assert_file_absent "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz" \
+  "rolling Linux pointer is not moved by a failed publish"
+assert_file_absent "$SB/bucket/status.json" \
+  "status.json is not written by a failed publish"
+rm -rf "$SB"
+
+# ---------------------------------------------------------------------------
+# backfill_spaces_checksums.sh
+# ---------------------------------------------------------------------------
+echo "backfill_spaces_checksums.sh: repairs history without touching it"
+
+SB="$(new_env)"
+put_object "$SB" "releases/wfl-26.7.57-linux-x86_64-2d74737.tar.gz" "old linux bytes"
+put_object "$SB" "releases/wfl-26.7.57.msi"                         "old msi bytes"
+put_object "$SB" "releases/vscode-wfl-26.7.57.vsix"                 "old vsix bytes"
+put_object "$SB" "releases/wfl-26.7.59-linux-x86_64-579eb80.tar.gz" "new linux bytes"
+put_object "$SB" "releases/wfl-26.7.59-linux-x86_64-579eb80.tar.gz.sha256" "pre-existing sidecar"
+put_object "$SB" "releases/wfl-latest-linux-x86_64.tar.gz"          "new linux bytes"
+put_object "$SB" "releases/wfl-latest-windows-x86_64.msi"           "new msi bytes"
+put_object "$SB" "releases/SHA256SUMS"                              "whatever"
+put_object "$SB" "status.json"                                      "{}"
+
+run_backfill "$SB"
+rc=$?
+assert_eq "0" "$rc" "backfill succeeds ($SB/out)"
+
+for k in "wfl-26.7.57-linux-x86_64-2d74737.tar.gz" "wfl-26.7.57.msi" "vscode-wfl-26.7.57.vsix"; do
+  assert_file_exists "$SB/bucket/releases/$k.sha256" "backfilled sidecar for $k"
+  if [ -f "$SB/bucket/releases/$k.sha256" ]; then
+    want="$(sha_line "$SB/bucket/releases/$k")"
+    assert_eq "$want" "$(cat "$SB/bucket/releases/$k.sha256")" \
+      "backfilled sidecar for $k hashes the object's real bytes"
+    assert_contains "$(log_line_for "$SB" "releases/$k.sha256")" "immutable" \
+      "backfilled sidecar for $k is cached as immutable"
+  fi
+done
+
+# Never rewrite what is already published: an existing sidecar is authoritative,
+# and re-uploading it would defeat the immutability the fix depends on.
+assert_eq "pre-existing sidecar" \
+  "$(cat "$SB/bucket/releases/wfl-26.7.59-linux-x86_64-579eb80.tar.gz.sha256")" \
+  "an existing sidecar is left untouched"
+assert_eq "0" "$(put_count "$SB" "releases/wfl-26.7.59-linux-x86_64-579eb80.tar.gz.sha256")" \
+  "an existing sidecar is not re-uploaded"
+
+assert_file_absent "$SB/bucket/releases/wfl-latest-linux-x86_64.tar.gz.sha256" \
+  "rolling Linux pointer gets no sidecar"
+assert_file_absent "$SB/bucket/releases/wfl-latest-windows-x86_64.msi.sha256" \
+  "rolling Windows pointer gets no sidecar"
+assert_file_absent "$SB/bucket/releases/SHA256SUMS.sha256" \
+  "SHA256SUMS gets no sidecar"
+assert_file_absent "$SB/bucket/status.json.sha256" \
+  "status.json gets no sidecar"
+
+# Running it twice is the normal case (it is wired into the nightly publish), so
+# the second run must be a no-op rather than a second round of uploads.
+: > "$SB/log"
+run_backfill "$SB"
+rc=$?
+assert_eq "0" "$rc" "second backfill run succeeds"
+assert_eq "0" "$(grep -c '^PUT' "$SB/log")" "second backfill run uploads nothing"
+rm -rf "$SB"
+
+echo "backfill_spaces_checksums.sh: --dry-run"
+SB="$(new_env)"
+put_object "$SB" "releases/wfl-26.7.57-linux-x86_64-2d74737.tar.gz" "old linux bytes"
+run_backfill "$SB" --dry-run
+rc=$?
+assert_eq "0" "$rc" "dry run succeeds"
+assert_eq "0" "$(grep -c '^PUT' "$SB/log")" "dry run uploads nothing"
+assert_contains "$(cat "$SB/out")" "wfl-26.7.57-linux-x86_64-2d74737.tar.gz.sha256" \
+  "dry run reports the sidecar it would create"
+rm -rf "$SB"
+
+echo
+echo "passed: $PASS   failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test_publish_spaces.sh
+++ b/scripts/test_publish_spaces.sh
@@ -186,7 +186,7 @@ path="${url#*://}"; path="${path#*/}"
 if [ -n "${FAKE_CURL_FLAKY_KEY:-}" ] && [ "$path" = "$FAKE_CURL_FLAKY_KEY" ]; then
   count_file="$(dirname "$FAKE_BUCKET")/flaky.count"
   seen=0
-  [ -f "$count_file" ] && seen="$(cat "$count_file")"
+  [ -s "$count_file" ] && seen="$(cat "$count_file")"
   if [ "$seen" -lt "${FAKE_CURL_FLAKY_TIMES:-1}" ]; then
     echo "$((seen + 1))" > "$count_file"
     [ -n "$wfmt" ] && printf '404'
@@ -356,7 +356,7 @@ assert_eq "2" "$(cat "$SB/flaky.count" 2>/dev/null || echo 0)" \
   "the sidecar fetch was actually retried"
 
 # Tolerating a blip must not mean tolerating an absent object.
-: > "$SB/flaky.count"
+rm -f "$SB/flaky.count"
 rm -rf "$SB/bucket" && mkdir -p "$SB/bucket"
 (
   export FAKE_CURL_FLAKY_KEY="releases/wfl-26.7.62-linux-x86_64-aaa1111.tar.gz.sha256"


### PR DESCRIPTION
## Summary

Fixes #662 by publishing immutable `.sha256` checksum sidecars alongside every versioned artifact, so pinned builds remain verifiable indefinitely. Previously, `SHA256SUMS` was rewritten on every publish and only described the newest build, making pinned verification impossible after the next nightly.

## Changes

**`scripts/publish_spaces.sh`** (modified)
- Refactored to write each versioned artifact with its own immutable `.sha256` sidecar in the same atomic step
- Added `publish_immutable()` helper that uploads artifact + sidecar together under `set -e`, ensuring an artifact never lands without its checksum
- Sidecars use sha256sum's native `<hash>  <name>` line format so consumers can verify with `sha256sum -c <artifact>.sha256` directly
- Rolling keys (`wfl-latest-*`, `SHA256SUMS`, `status.json`) deliberately get no sidecar to avoid the same bug in a new place
- Maintains backward compatibility: `SHA256SUMS` still published with same rolling cache headers

**`scripts/backfill_spaces_checksums.sh`** (new)
- Repairs history by creating missing `.sha256` sidecars for artifacts published before this change
- Idempotent and additive: only creates missing sidecars, never rewrites existing ones, never touches artifacts or rolling keys
- Hashes the bytes the bucket actually serves (not CI's local copy) to attest to what consumers download
- Runs after every nightly publish and on demand via new **Backfill Release Checksums** workflow
- Supports `--dry-run` to inspect missing sidecars without uploading

**`scripts/test_publish_spaces.sh`** (new)
- Comprehensive test suite (43 assertions) for both publish and backfill scripts
- Uses a recording fake of the AWS CLI with a real directory-backed object store, so assertions verify actual bytes and cache headers that moved
- Tests the real scripts, real `sha256sum`, real `jq` — only the Spaces boundary is stubbed
- Validates: sidecars are created and immutable, rolling keys get no sidecar, failed sidecar uploads abort the publish, backfill is idempotent and never rewrites existing checksums
- Runs in CI on every PR as **Release Script Tests** job

**`.github/workflows/backfill-checksums.yml`** (new)
- On-demand workflow to run or dry-run the backfill without forcing a nightly build
- Used for the one-time repair of artifacts published before sidecars existed (26.7.57–26.7.59)

**`.github/workflows/nightly.yml`** (modified)
- Wired in `backfill_spaces_checksums.sh` after every publish with `continue-on-error: true` (a repair gap is not a release failure)

**`.github/workflows/ci.yml`** (modified)
- Added **Release Script Tests** job to run `test_publish_spaces.sh` on every PR

**`Docs/02-getting-started/installation.md`** (modified)
- Added "Verifying a pinned version" section with example showing how to download and verify a specific build using its `.sha256` sidecar
- Clarifies that `SHA256SUMS` describes only the most recent publish and should not be used for pinned versions

**`scripts/README.md`** (modified)
- Documented all three release publishing scripts with usage examples

**`Docs/reference/supported-platforms.md`** (modified)
- Updated to reflect that each artifact now has its own immutable checksum

## Implementation Details

- Sidecars are cached as `public, max-age=31536000, immutable` (same as artifacts) and served as `text/plain`
- The sidecar format is sha256sum's native line: `<40-char-hex>  <basename>`, enabling direct verification with `sha256sum -c`
- Backfill script filters out rolling keys and existing sidecars to avoid rewriting immutable objects
- All three scripts handle the AWS CLI v2.23+ Spaces incompat

https://claude.ai/code/session_01TS59haQMudvaTcCHHimi3E
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable, artifact-specific SHA-256 checksum files for versioned release downloads.
  * Release publishing now verifies checksum files through the CDN and reports mismatches or unavailable files.
  * Existing releases can be safely repaired with checksum backfilling, including a dry-run option.

* **Documentation**
  * Added installation guidance for verifying downloads with `sha256sum`.
  * Documented checksum behavior across supported release artifacts and publishing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->