### PR TITLE
fix(ci): repair post-merge gate failures on main (follow-up to #672)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # The post-suite working-tree hygiene check needs Python 3.11+ (tomllib);
+      # the Windows runner's default python is older, so set it up explicitly.
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       # Reclaim runner disk before building: this job builds the (debuginfo-heavy)
       # release tree AND every integration test binary (`cargo test --test '*'`),
@@ -372,6 +377,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      # The post-suite working-tree hygiene check needs Python 3.11+ (tomllib);
+      # the Windows runner's default python is older, so set it up explicitly.
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       # Cache Cargo registry and target directory for faster builds
       - name: Cache Cargo registry and target directory

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,8 @@
 edition = "2024"
 max_width = 100
-newline_style = "Unix"
+# Auto (the default) accepts each file's existing, consistent line-ending
+# style. "Unix" breaks `cargo fmt --check` on Windows runners, where git's
+# autocrlf checkout materializes every file with CRLF endings — this was the
+# effective behavior all along via the now-removed duplicate .rustfmt.toml,
+# which carried no newline_style and shadowed this file.
+newline_style = "Auto"

--- a/scripts/check_repo_hygiene.py
+++ b/scripts/check_repo_hygiene.py
@@ -295,7 +295,12 @@ def check_archive(report, root, files, profile):
             report.add("archive-manifest", path,
                        "manifest entry points at a file that does not exist")
             continue
-        digest = hashlib.sha256(target.read_bytes()).hexdigest()
+        # Hash the staged blob, not the working-tree bytes: on Windows an
+        # autocrlf checkout materializes text files with CRLF endings, which
+        # would make every archived text file's checksum drift. The index
+        # content is canonical (LF, as committed) on every platform.
+        blob = git(root, "show", f":{path}")
+        digest = hashlib.sha256(blob).hexdigest()
         if digest != entry["sha256"]:
             report.add("archive-manifest", path,
                        f"sha256 drift: manifest {entry['sha256'][:12]}… vs "

--- a/tests/tooling/test_check_repo_hygiene.py
+++ b/tests/tooling/test_check_repo_hygiene.py
@@ -108,7 +108,10 @@ class FixtureTree:
         if isinstance(content, bytes):
             path.write_bytes(content)
         else:
-            path.write_text(content)
+            # newline="\n" keeps fixture bytes identical across platforms —
+            # Windows text-mode writes would otherwise turn \n into \r\n and
+            # break checksum-sensitive tests.
+            path.write_text(content, newline="\n")
         return path
 
     def commit_all(self):

--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-wfl",
-  "version": "26.7.59",
+  "version": "26.7.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-wfl",
-      "version": "26.7.59",
+      "version": "26.7.60",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.4",


### PR DESCRIPTION
First-contact fixes from the initial run of #672's hygiene gates on main. All three underlying test suites passed everywhere (Windows ran 140/140 WFL programs, 3/3 web tests); the failures were in the gates themselves plus one nightly regression.

## What failed and why

- **CI `repo-hygiene` + Auto Format pre-push check — version drift.** `Bump version to 26.7.60` (5b2fa98) landed on main between #672's base and its merge, made with the pre-#672 bump script that skipped `vscode-extension/package-lock.json`; the merged tree had Cargo.toml 26.7.60 vs lock 26.7.59. **Fix:** sync both lock version fields to 26.7.60. Future bumps stay in sync via the fixed `scripts/bump_version.py` already on main; the drift rule remains as the backstop.
- **CI `integration-tests` / `run-wfl-programs` (Windows) — `HYGIENE-ERROR: Python 3.11+ with tomllib is required`.** The new post-suite working-tree checks ran on the Windows runner's default (older) python. **Fix:** `actions/setup-python@v4` with 3.12 in both jobs.
- **Nightly Build (Windows) — `Incorrect newline style` in `cargo fmt --check`.** #672 removed the duplicate `.rustfmt.toml`, which carried no `newline_style` and was rustfmt's effective config; with it gone, `rustfmt.toml`'s `newline_style = "Unix"` rejected the autocrlf CRLF checkout. (Verified against history: the last pre-merge nightly's Windows build passed; its failure was the separate release-tag issue.) **Fix:** `newline_style = "Auto"`, restoring the long-standing effective behavior.

## Test evidence (testing.md §15)

- **Risk class:** R2 (CI-config and metadata repair; no runtime code paths changed).
- **Red evidence:** the failing CI runs on main themselves — CI run 30607638911 (repo-hygiene drift + two Windows tomllib failures), Auto Format run 30607638916, Nightly run 30608593328 — each failing for the reason its fix addresses.
- **Green evidence:** locally `cargo fmt --all -- --check` clean with `newline_style = Auto`; `python3 scripts/check_repo_hygiene.py --mode static` exit 0 (drift resolved); tooling suite 32/32; ci.yml parses. The Windows tomllib and nightly CRLF fixes are runner-environment-specific — this PR's own CI (and tonight's nightly) is the executable verification.
- **Residual risk:** none beyond CI-lane coverage; no Rust/WFL behavior touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVvQraMbMgEWU9dPSTaqqJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVvQraMbMgEWU9dPSTaqqJ)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->