### PR TITLE
fix: await stream body finish on close; harden execute-file stack (#680, #681)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,6 +276,13 @@ jobs:
       - name: Run Integration Gate (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        # Nested `execute file` (and other deep interpreter futures) need more
+        # than the default ~1 MB Windows test-thread stack; without this the
+        # depth-guard test overflows natively before max_execute_file_depth
+        # can fire (#681). 8 MB matches a typical Linux default and is well
+        # under the CLI's dedicated interpreter stack.
+        env:
+          RUST_MIN_STACK: '8388608'
         run: ./scripts/run_integration_tests.ps1
 
       # Validate that documentation examples still parse/analyze/lint against the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   archive manifest checksums, experiment review expiry, product-version drift,
   and post-suite working-tree cleanliness.
 
+### Fixed
+- **Streaming responses no longer truncate when the program ends right after
+  `close out` (#680).** Close and end-of-handler drain now await the transport
+  finishing the body (not only dropping the chunk sender), so the terminating
+  chunk is delivered before the runtime is torn down.
+- **Windows CI / small-stack hosts no longer overflow before the
+  `execute file` depth guard (#681).** The execute-file pipeline is boxed out of
+  the shared statement state machine; the depth-guard test runs on the large
+  interpreter stack; Windows integration tests default `RUST_MIN_STACK` to 8 MB.
+
 ### Changed
 - **Repository layout migrated to purpose-based top-level homes**: Dev Diary →
   `History/dev-diary/<year>/`, contributor docs `Docs/development/` →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   `close out` (#680).** Close and end-of-handler drain now await the transport
   finishing the body (not only dropping the chunk sender), so the terminating
   chunk is delivered before the runtime is torn down.
-- **Windows CI / small-stack hosts no longer overflow before the
-  `execute file` depth guard (#681).** The execute-file pipeline is boxed out of
-  the shared statement state machine; the depth-guard test runs on the large
-  interpreter stack; Windows integration tests default `RUST_MIN_STACK` to 8 MB.
+- **`execute file` depth guard and Windows integration-test stack (#681).** The
+  execute-file pipeline is boxed out of the shared statement state machine; the
+  depth-guard test runs on the large interpreter stack; Windows integration
+  tests default `RUST_MIN_STACK` to 8 MB.
 
 ### Changed
 - **Repository layout migrated to purpose-based top-level homes**: Dev Diary →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Streaming responses no longer truncate when the program ends right after
   `close out` (#680).** Close and end-of-handler drain now await the transport
   finishing the body (not only dropping the chunk sender), so the terminating
-  chunk is delivered before the runtime is torn down.
+  chunk is delivered before the runtime is torn down. Concurrent
+  (`main loop concurrently:`) handlers that stream without an explicit close
+  and then break/return await the same finish signal before reporting complete.
 - **`execute file` depth guard and Windows integration-test stack (#681).** The
   execute-file pipeline is boxed out of the shared statement state machine; the
   depth-guard test runs on the large interpreter stack; Windows integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Streaming responses no longer truncate when the program ends right after
   `close out` (#680).** Close and end-of-handler drain now await the transport
   finishing the body (not only dropping the chunk sender), so the terminating
-  chunk is delivered before the runtime is torn down. Concurrent
-  (`main loop concurrently:`) handlers that stream without an explicit close
-  and then break/return await the same finish signal before reporting complete.
+  chunk is delivered before the runtime is torn down. The finish wait is a
+  short fixed ceiling independent of `web_server_response_timeout_seconds`, so
+  a client that stops reading cannot pin a serial `main loop` for the full
+  write timeout. Concurrent (`main loop concurrently:`) handlers that stream
+  without an explicit close and then break/return await the same finish signal
+  before reporting complete.
 - **`execute file` depth guard and Windows integration-test stack (#681).** The
   execute-file pipeline is boxed out of the shared statement state machine; the
   depth-guard test runs on the large interpreter stack; Windows integration

--- a/Docs/04-advanced-features/web-servers.md
+++ b/Docs/04-advanced-features/web-servers.md
@@ -545,7 +545,15 @@ close out
   > concatenate keep working.
 - `flush <out>` — advisory: yield so queued bytes are handed to the socket.
   (Chunks are already forwarded as you write them; hyper writes as it receives.)
-- `close <out>` — end the response body. Writing after `close` is an error.
+- `close <out>` — end the response body. Signals end-of-stream immediately
+  (stops accepting further chunks), then briefly waits for the transport to
+  finish delivering the body so a program that exits right after `close` does
+  not truncate the response. That finish wait is short and independent of
+  `web_server_response_timeout_seconds` (which bounds **writes** and request
+  admission, not close). If the client has stopped reading, `close` returns
+  when the short ceiling elapses rather than parking for the full write
+  timeout — important for a serial `main loop`, where one stalled close would
+  otherwise block every other request. Writing after `close` is an error.
 
 **Ownership:** a response stream belongs to the handler that started it. Under
 `main loop concurrently:`, `write`, `flush`, and `close` on a **live** stream
@@ -557,20 +565,24 @@ closed-stream error, while `close` is an idempotent no-op for any handler
 holding the stale handle.
 
 **Lifecycle & backpressure:** the body channel is bounded, so a slow client
-slows your `write` calls (backpressure) instead of buffering without bound. If
-the client disconnects, hyper drops the response body and your next `write` to
+slows your `write` calls (backpressure) instead of buffering without bound.
+Each `write` is also bounded by `web_server_response_timeout_seconds` so a
+connected client that stops reading cannot pin the handler forever. If the
+client disconnects, hyper drops the response body and your next `write` to
 that stream fails with a catchable error — use `try`/`catch` to detect it and
 stop producing (and `close` any upstream you are proxying).
 
 **Prefer an explicit `close out`** to finalize the response promptly — that is
-what signals the end of the body to the client, and doing it as soon as you are
-done frees the connection without waiting. As a safety net, the stream is also
-**closed automatically when the handler ends on any path** (normal return, a
-caught error, or a panic contained by `main loop concurrently:`), so a handler
-that forgets `close out` still finalizes the client's body rather than leaving
-it hanging. For long-lived handlers, still `close` as soon as you are finished —
-and put it in a `finally:` block if the handler can error partway through — so
-the client is not left waiting until the handler happens to return.
+what signals the end of the body to the client and briefly confirms delivery
+so exiting the program immediately afterwards does not lose the tail of the
+response. As a safety net, the stream is also **closed automatically when the
+handler ends on any path** (normal return, a caught error, or a panic
+contained by `main loop concurrently:`), with the same short finish wait, so a
+handler that forgets `close out` still finalizes the client's body rather than
+leaving it hanging. For long-lived handlers, still `close` as soon as you are
+finished — and put it in a `finally:` block if the handler can error partway
+through — so the client is not left waiting until the handler happens to
+return.
 
 **Proxying an upstream to the browser** — combine with the outbound streaming
 client ([Interoperability → Streaming a response

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -652,7 +652,7 @@ Maximum nesting depth of `load module` / `include from`. Circular imports are al
 
 #### `max_execute_file_depth`
 
-Maximum nesting depth of `execute file` runs. Kept small because each level re-enters the whole interpreter recursively.
+Maximum nesting depth of `execute file` runs. Kept small because each level re-enters the whole interpreter pipeline (lex → parse → analyze → interpret). The CLI runs the interpreter on a dedicated large stack so the depth guard can fire as a clean error before a native stack overflow; library embedders should use `wfl::run_with_interpreter_stack` (or an equivalent large stack) for the same guarantee.
 
 - **Type:** Integer (at least 1)
 - **Default:** `4`

--- a/Docs/reference/configuration-reference.md
+++ b/Docs/reference/configuration-reference.md
@@ -565,7 +565,7 @@ Maximum time, in seconds, the transport waits for a handler to answer an accepte
 - **Default:** `300`
 - **Example:** `web_server_response_timeout_seconds = 30`
 
-A value of `0` disables the timeout (including the streaming-write bound above). The in-flight request cap (`web_server_request_queue_bound`) is enforced globally across every `listen` server via one shared budget, and a request's slot is held from the moment its body starts streaming until the handler responds, this timeout fires, or the client disconnects.
+A value of `0` disables the timeout (including the streaming-write bound above). It does **not** control how long `close out` (or the automatic end-of-handler stream drain) waits for the transport to finish the body: that finish wait is a short, fixed runtime ceiling independent of this setting, so a non-reading client cannot hold a serial `main loop` for the full write-timeout duration just by stalling at close. The in-flight request cap (`web_server_request_queue_bound`) is enforced globally across every `listen` server via one shared budget, and a request's slot is held from the moment its body starts streaming until the handler responds, this timeout fires, or the client disconnects.
 
 #### `outbound_stream_max_seconds`
 

--- a/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
+++ b/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
@@ -1,0 +1,69 @@
+# 2026-07-31 — Stream close finish wait (#680) and execute-file stack (#681)
+
+## Why
+
+Two intermittent CI failures, both filed after they proved not job-specific and
+not caused by in-flight feature work:
+
+- **#680** — `test_early_chunk_is_visible_before_the_body_completes` failed with
+  `error decoding response body` in both `Build, Test, Clippy` and
+  `Integration Tests`, after also passing in those same jobs. Same commit, both
+  outcomes → teardown race under load.
+- **#681** — Windows integration jobs aborted with `STATUS_STACK_OVERFLOW`. The
+  binary name varied until a later run named
+  `test_execute_file_depth_limit_prevents_infinite_recursion`. Four nested
+  `execute file` levels (the default `max_execute_file_depth`) exhaust a ~1 MB
+  Windows test-thread stack *before* the depth guard can fire.
+
+## #680 — close out must mean the body finished
+
+`close out` (and end-of-handler auto-close) only dropped the body-chunk sender.
+That signals end-of-stream to hyper; it does not wait for the terminating chunk
+to leave the process. When the program then returns and the host drops the
+tokio `Runtime`, the warp connection task can be aborted mid-flush — the client
+sees a truncated chunked body.
+
+Fix:
+
+1. Pair each streaming body with a oneshot fired from
+   `NotifyingChunkStream::Drop` (hyper drops the body when it is done writing
+   or when the client disconnects).
+2. `close out` and async end-of-handler / end-of-run drains drop the sender,
+   then await that signal (bounded by the response-write timeout, or 30s when
+   the timeout is disabled).
+3. Sync `Drop` paths (`IsolatedHandler`, `OutboundStreamCleanup`) still only
+   drop senders — they cannot await; serial programs that finish right after
+   `close out` take the async path.
+
+Regression: `test_body_is_complete_when_program_ends_immediately_after_close`
+streams one chunk, closes, breaks, and asserts the client reads a complete body
+with no transport decode error.
+
+## #681 — depth guard must win over the native stack
+
+The CLI already runs on `wfl::run_with_interpreter_stack` (1 GiB reserved). The
+overflow was the **test harness**: default Windows test threads are ~1 MB, and
+nested `execute file` multiplies poll frames of large interpreter futures.
+
+Fix:
+
+1. Move the `execute file` pipeline into its own `execute_wfl_file` async method
+   and only `Box::pin` it from `_execute_statement`, so the full
+   lex→parse→analyze→interpret locals are not part of the shared statement
+   state machine (smaller futures for every other statement; less stack cost
+   per nested execute-file level).
+2. Run the depth-guard test under `run_with_interpreter_stack` so it asserts the
+   promised depth error, not a native overflow.
+3. Default `RUST_MIN_STACK=8388608` for Windows in
+   `scripts/run_integration_tests.ps1` and the Windows Integration Tests CI
+   job, matching a typical Linux default and leaving headroom for other deep
+   futures in the suite.
+
+Embedders that drive `Interpreter` without a large stack remain at risk for
+deep recursion of any kind; the existing `run_with_interpreter_stack` docs and
+the configuration note for `max_execute_file_depth` call that out.
+
+## Verification
+
+- `cargo test --test response_stream_backpressure_test --test execute_file_test`
+  — all green, including the new #680 regression and the rewritten depth guard.

--- a/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
+++ b/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
@@ -75,6 +75,18 @@ still nowait-closes on cancellation mid-flight.
 Regression:
 `test_concurrent_handler_body_is_complete_without_explicit_close_on_break`.
 
+## Finish-wait ceiling (not the write timeout)
+
+An early version of the close-await used `web_server_response_timeout_seconds`
+(default 300s, or 30s when `0`) as the finish ceiling. That fixed the
+truncation race but let a client that stops reading pin a serial `main loop`
+at `close out` / end-of-iteration drain for minutes — and the docs still said
+close returned immediately / that `0` disabled all waiting.
+
+Fix: finish wait is a short fixed `RESPONSE_STREAM_FINISH_WAIT` (2s),
+independent of the write-path timeout. Docs for streaming close and
+`web_server_response_timeout_seconds` now describe that split accurately.
+
 ## Verification
 
 - `cargo test --test response_stream_backpressure_test --test execute_file_test`

--- a/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
+++ b/History/dev-diary/2026/2026-07-31-stream-close-finish-and-execute-file-stack.md
@@ -63,6 +63,18 @@ Embedders that drive `Interpreter` without a large stack remain at risk for
 deep recursion of any kind; the existing `run_with_interpreter_stack` docs and
 the configuration note for `max_execute_file_depth` call that out.
 
+## Concurrent path follow-up
+
+A review found the same race on `main loop concurrently:`: stream ids live on
+the handler's isolated `RunState`, so the top-level serial drain never sees them.
+`IsolatedHandler` Drop only nowait-closed. Fix: after the handler future
+completes, take any still-open response-stream ids and await
+`close_response_streams` **before** reporting `Ready` (Break/Exit/Return). Drop
+still nowait-closes on cancellation mid-flight.
+
+Regression:
+`test_concurrent_handler_body_is_complete_without_explicit_close_on_break`.
+
 ## Verification
 
 - `cargo test --test response_stream_backpressure_test --test execute_file_test`

--- a/scripts/run_integration_tests.ps1
+++ b/scripts/run_integration_tests.ps1
@@ -130,6 +130,17 @@ if ($TestOnly) {
 # Run integration tests
 Write-Host "[INFO] Running integration tests..." -ForegroundColor Blue
 
+# Nested `execute file` multiplies interpreter futures on the native stack.
+# Windows defaults test threads to ~1 MB, which overflows before the depth
+# guard (max_execute_file_depth = 4) can fire (#681). Prefer an explicit
+# caller-set value; otherwise give Windows 8 MB (typical Linux default).
+if (-not $env:RUST_MIN_STACK) {
+    if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+        $env:RUST_MIN_STACK = "8388608"
+        Write-Host "[INFO] RUST_MIN_STACK defaulted to 8388608 for Windows test threads (#681)" -ForegroundColor Blue
+    }
+}
+
 Write-Host "[INFO] Running split functionality tests..." -ForegroundColor Blue
 & cargo test --test split_functionality --verbose
 if ($LASTEXITCODE -ne 0) {

--- a/scripts/run_integration_tests.ps1
+++ b/scripts/run_integration_tests.ps1
@@ -1,4 +1,4 @@
-# WFL Integration Test Runner (PowerShell)
+﻿# WFL Integration Test Runner (PowerShell)
 # Ensures release binary is built before running integration tests
 
 param(

--- a/src/exec/budget.rs
+++ b/src/exec/budget.rs
@@ -86,8 +86,10 @@ pub struct BudgetLimits {
     /// `max_import_depth`.
     pub max_import_depth: usize,
     /// Maximum `execute file` nesting depth. Kept small because each level
-    /// re-enters the whole interpreter recursively. Mapped from `.wflcfg`
-    /// `max_execute_file_depth`.
+    /// re-enters the whole interpreter pipeline. The CLI (and
+    /// `run_with_interpreter_stack`) give the run enough native stack for the
+    /// guard to fire as a clean error; bare embedders on a ~1 MB stack can
+    /// overflow first (#681). Mapped from `.wflcfg` `max_execute_file_depth`.
     pub max_execute_file_depth: usize,
     /// Maximum pattern-VM transitions per match attempt (ReDoS guard). Mapped
     /// from `.wflcfg` `max_pattern_steps`.

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -996,6 +996,14 @@ impl Drop for InstalledRunState<'_> {
 /// panic therefore surfaces as `Poll::Ready` and the swap-back still runs,
 /// leaving the interpreter's scratch fields restored for the next sibling.
 ///
+/// After the handler future completes, any still-open server response streams
+/// are drained **asynchronously** (drop sender + await transport finish) before
+/// this wrapper reports `Ready`. Without that step, a concurrent handler that
+/// streams without an explicit `close out` and then `break`s / `return`s would
+/// only nowait-close in [`Drop`], racing runtime teardown the same way the
+/// serial path did before #680. Cancellation (dropping this wrapper mid-flight)
+/// still falls back to sync nowait close.
+///
 /// The wrapper's output is `(inner_output, accepted_request)` so the concurrent
 /// loop can classify request-local vs structural failures after the handler's
 /// run state has been swapped out (and its pending list drained by `Drop`).
@@ -1006,6 +1014,15 @@ struct IsolatedHandler<'a, T> {
     /// future while this handler's state is installed. Any RAII guards inside
     /// the future then unwind against their own call/static-context stacks.
     inner: Option<std::pin::Pin<Box<dyn std::future::Future<Output = T> + 'a>>>,
+    /// After `inner` completes: await body finish for streams the handler left
+    /// open. Polled without installing `RunState` (ids are already taken).
+    drain: Option<std::pin::Pin<Box<dyn std::future::Future<Output = ()> + 'a>>>,
+    /// Output of `inner`, held until `drain` completes. Boxed so this wrapper
+    /// stays `Unpin` regardless of `T` (required for `Pin::get_mut` in `poll`).
+    pending_output: Option<Box<(T, bool)>>,
+    /// Stream ids currently being drained (or waiting to start). Drop falls
+    /// back to nowait-close for these if the wrapper is cancelled mid-drain.
+    pending_finish_ids: Vec<String>,
 }
 
 impl<'a, T> std::future::Future for IsolatedHandler<'a, T> {
@@ -1018,17 +1035,90 @@ impl<'a, T> std::future::Future for IsolatedHandler<'a, T> {
         // Every field is `Unpin` (`&`, `RunState`, and `Pin<Box<..>>`), so the
         // wrapper itself is `Unpin` and `get_mut` is sound.
         let this = self.get_mut();
-        let result = {
-            let _installed = InstalledRunState::new(this.interp, &mut this.state);
-            this.inner
+
+        // Phase 2: finish any open response bodies before reporting Ready so a
+        // concurrent Break/Exit/Return cannot tear down the runtime mid-flush.
+        if this.drain.is_some() {
+            match this
+                .drain
                 .as_mut()
-                .expect("isolated handler must not be polled after its inner future is dropped")
+                .expect("drain present")
                 .as_mut()
                 .poll(cx)
+            {
+                std::task::Poll::Ready(()) => {
+                    this.drain = None;
+                    this.pending_finish_ids.clear();
+                    return std::task::Poll::Ready(
+                        *this
+                            .pending_output
+                            .take()
+                            .expect("drained handler must retain its output"),
+                    );
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+            }
+        }
+
+        // Phase 1: run the handler body with its RunState installed.
+        let completed = {
+            let _installed = InstalledRunState::new(this.interp, &mut this.state);
+            let inner = this
+                .inner
+                .as_mut()
+                .expect("isolated handler must not be polled after its inner future is dropped");
+            match inner.as_mut().poll(cx) {
+                std::task::Poll::Pending => None,
+                std::task::Poll::Ready(value) => {
+                    // Capture while installed: `accepted_request` and open stream
+                    // ids live on the interpreter for this poll. Taking the ids
+                    // clears the list so swap-out parks an empty vec (Drop will
+                    // not double-close them via `state.open_response_streams`).
+                    let accepted = this.interp.accepted_request.get();
+                    let stream_ids =
+                        std::mem::take(&mut *this.interp.open_response_streams.borrow_mut());
+                    Some((value, accepted, stream_ids))
+                }
+            }
         };
-        match result {
-            std::task::Poll::Ready(value) => {
-                std::task::Poll::Ready((value, this.state.accepted_request))
+
+        let Some((value, accepted, stream_ids)) = completed else {
+            return std::task::Poll::Pending;
+        };
+
+        // Drop the completed inner future with RunState installed so any RAII
+        // guards still live at the top frame unwind against this handler.
+        if let Some(inner) = this.inner.take() {
+            let _installed = InstalledRunState::new(this.interp, &mut this.state);
+            drop(inner);
+        }
+
+        if stream_ids.is_empty() {
+            return std::task::Poll::Ready((value, accepted));
+        }
+
+        this.pending_output = Some(Box::new((value, accepted)));
+        this.pending_finish_ids = stream_ids.clone();
+        let interp = this.interp;
+        this.drain = Some(Box::pin(async move {
+            interp.close_response_streams(&stream_ids).await;
+        }));
+        match this
+            .drain
+            .as_mut()
+            .expect("drain just set")
+            .as_mut()
+            .poll(cx)
+        {
+            std::task::Poll::Ready(()) => {
+                this.drain = None;
+                this.pending_finish_ids.clear();
+                std::task::Poll::Ready(
+                    *this
+                        .pending_output
+                        .take()
+                        .expect("drained handler must retain its output"),
+                )
             }
             std::task::Poll::Pending => std::task::Poll::Pending,
         }
@@ -1048,6 +1138,8 @@ impl<'a, T> Drop for IsolatedHandler<'a, T> {
             let _installed = InstalledRunState::new(self.interp, &mut self.state);
             drop(inner);
         }
+        // Abandon an in-flight finish wait (cancellation path).
+        self.drain.take();
 
         // The handler is finished (normal return, error, panic contained by
         // `catch_unwind`, or cancellation as the loop tears down). After the
@@ -1055,12 +1147,14 @@ impl<'a, T> Drop for IsolatedHandler<'a, T> {
         // closed and any requests it dequeued but never answered. Close the
         // streams (finalizing the client's body) and 500 the unanswered requests,
         // so every exit path resolves the client instead of leaving it hanging.
-        // Sync path: Drop cannot await the transport finish signal. Ending the
-        // body by dropping the sender is still correct; a concurrent main loop
-        // that exits immediately after the last handler may still race under
-        // load (serial `close out` / end-of-iteration drain await instead).
-        self.interp
-            .close_response_streams_nowait(&self.state.open_response_streams);
+        //
+        // Sync nowait: Drop cannot await. Normal completion already awaited
+        // finish via `drain` and cleared these lists; this path covers
+        // cancellation and any streams still open when the wrapper is dropped
+        // mid-drain (senders not yet removed) or never drained.
+        let mut ids = std::mem::take(&mut self.state.open_response_streams);
+        ids.append(&mut self.pending_finish_ids);
+        self.interp.close_response_streams_nowait(&ids);
         self.interp
             .fail_unanswered_requests(&self.state.open_pending_requests);
         // Drop any outbound streams this handler still owns, cancelling their
@@ -5999,6 +6093,9 @@ impl Interpreter {
                     interp: self,
                     state: self.fresh_handler_run_state(),
                     inner: Some(Box::pin(handler)),
+                    drain: None,
+                    pending_output: None,
+                    pending_finish_ids: Vec::new(),
                 });
             }
 
@@ -15724,6 +15821,9 @@ mod concurrent_handler_classification_tests {
             interp: interpreter,
             state: RunState::fresh(interpreter.base_call_depth),
             inner: Some(Box::pin(one_yield_static_scope(interpreter, context))),
+            drain: None,
+            pending_output: None,
+            pending_finish_ids: Vec::new(),
         })
     }
 

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -151,11 +151,17 @@ const COOP_YIELD_STRIDE: u64 = 1024;
 /// free slot) rather than letting queued chunks grow without bound.
 const RESPONSE_STREAM_BUFFER: usize = 64;
 
-/// Fallback ceiling for awaiting transport body finish after `close out` when
-/// `web_server_response_timeout_seconds` is `0` (disabled / unbounded on the
-/// write path). Close still needs a finite wait so a stuck connection cannot
-/// pin the handler forever; this is independent of the write-path sentinel.
-const RESPONSE_STREAM_FINISH_FALLBACK_SECS: u64 = 30;
+/// How long `close out` / end-of-handler drain wait for the transport to finish
+/// the body after the sender is dropped (#680).
+///
+/// Short on purpose and **independent** of `web_server_response_timeout_seconds`
+/// (the write-path / admission bound, default 300s, with `0` = unbounded). Close
+/// only needs enough time for hyper to flush the terminating chunk under load;
+/// tying it to the write timeout would let a client that stops reading pin a
+/// serial `main loop` for up to five minutes. After this ceiling, close returns
+/// anyway — the sender is already dropped so the body will still end when the
+/// transport can flush or the connection is later torn down.
+const RESPONSE_STREAM_FINISH_WAIT: Duration = Duration::from_secs(2);
 
 /// Maximum number of `main loop concurrently:` iterations in flight at once. The
 /// transport already bounds the request *queue*; this bounds concurrent *handler*
@@ -5304,18 +5310,11 @@ impl Interpreter {
     }
 
     /// How long `close out` / end-of-handler drain will wait for the transport
-    /// to finish the body after the sender is dropped. Uses the configured
-    /// response-write timeout when set; otherwise
-    /// [`RESPONSE_STREAM_FINISH_FALLBACK_SECS`] — a fixed safety ceiling, not
-    /// the write-path's "0 = unbounded" meaning, so a stuck connection cannot
-    /// pin the handler forever.
+    /// to finish the body after the sender is dropped. See
+    /// [`RESPONSE_STREAM_FINISH_WAIT`] — a short fixed ceiling, not the write-
+    /// path timeout (so a non-reading client cannot pin a serial main loop).
     fn response_stream_finish_timeout(&self) -> Duration {
-        let secs = self.config.web_server_response_timeout_seconds;
-        if secs == 0 {
-            Duration::from_secs(RESPONSE_STREAM_FINISH_FALLBACK_SECS)
-        } else {
-            Duration::from_secs(secs)
-        }
+        RESPONSE_STREAM_FINISH_WAIT
     }
 
     /// Drop the body sender for each id (ending the stream) without waiting for

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -151,6 +151,12 @@ const COOP_YIELD_STRIDE: u64 = 1024;
 /// free slot) rather than letting queued chunks grow without bound.
 const RESPONSE_STREAM_BUFFER: usize = 64;
 
+/// Fallback ceiling for awaiting transport body finish after `close out` when
+/// `web_server_response_timeout_seconds` is `0` (disabled / unbounded on the
+/// write path). Close still needs a finite wait so a stuck connection cannot
+/// pin the handler forever; this is independent of the write-path sentinel.
+const RESPONSE_STREAM_FINISH_FALLBACK_SECS: u64 = 30;
+
 /// Maximum number of `main loop concurrently:` iterations in flight at once. The
 /// transport already bounds the request *queue*; this bounds concurrent *handler*
 /// execution so a burst cannot spawn unbounded cooperative tasks. Requests
@@ -5205,12 +5211,14 @@ impl Interpreter {
 
     /// How long `close out` / end-of-handler drain will wait for the transport
     /// to finish the body after the sender is dropped. Uses the configured
-    /// response-write timeout when set; otherwise a fixed safety ceiling so a
-    /// stuck connection cannot pin the handler forever.
+    /// response-write timeout when set; otherwise
+    /// [`RESPONSE_STREAM_FINISH_FALLBACK_SECS`] — a fixed safety ceiling, not
+    /// the write-path's "0 = unbounded" meaning, so a stuck connection cannot
+    /// pin the handler forever.
     fn response_stream_finish_timeout(&self) -> Duration {
         let secs = self.config.web_server_response_timeout_seconds;
         if secs == 0 {
-            Duration::from_secs(30)
+            Duration::from_secs(RESPONSE_STREAM_FINISH_FALLBACK_SECS)
         } else {
             Duration::from_secs(secs)
         }
@@ -5260,12 +5268,13 @@ impl Interpreter {
         let timeout = self.response_stream_finish_timeout();
         // Wait for every body in parallel so multi-stream handlers don't pay
         // sequential timeouts, then bound the whole set.
-        let wait_all = async {
-            for rx in finished {
+        let _ = tokio::time::timeout(
+            timeout,
+            futures_util::future::join_all(finished.into_iter().map(|rx| async move {
                 let _ = rx.await;
-            }
-        };
-        let _ = tokio::time::timeout(timeout, wait_all).await;
+            })),
+        )
+        .await;
     }
 
     /// Drain and close every server response stream the current (serial) handler

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -70,9 +70,57 @@ use tokio::sync::{mpsc, oneshot};
 // Type alias for complex pending response type
 type PendingResponseSender = Arc<tokio::sync::Mutex<Option<oneshot::Sender<HandlerReply>>>>;
 
-/// An open server response stream: the bounded body-chunk sender plus the
-/// running total of body bytes written (enforced against `max_response_bytes`).
-type ServerResponseStream = (mpsc::Sender<Vec<u8>>, usize);
+/// An open server response stream: the bounded body-chunk sender, the running
+/// total of body bytes written (enforced against `max_response_bytes`), and an
+/// optional oneshot that the transport fires when it has finished with the body.
+///
+/// The finished signal is how `close out` (and end-of-handler drain) wait for the
+/// terminating chunk to actually leave the process — dropping the sender only
+/// *signals* end-of-body; under load the warp/hyper connection task can still be
+/// flushing when the program returns and the runtime is dropped, which surfaces
+/// as a truncated chunked body on the client (#680).
+struct ServerResponseStream {
+    tx: mpsc::Sender<Vec<u8>>,
+    bytes_written: usize,
+    /// Taken and awaited by close/drain. `None` once already consumed, or when
+    /// the stream was closed via a sync Drop path that cannot await.
+    finished: Option<oneshot::Receiver<()>>,
+}
+
+/// Chunk body stream that notifies when hyper is done with it.
+///
+/// Dropped by the connection task after the response is fully written (or the
+/// client disconnects). That Drop is the acknowledgement `close out` awaits so
+/// the program does not finish before the terminating chunk is delivered.
+/// Public only because it appears on [`HandlerReply::Streaming`]; fields are
+/// private and construction stays inside the interpreter.
+pub struct NotifyingChunkStream {
+    rx: mpsc::Receiver<Vec<u8>>,
+    done: Option<oneshot::Sender<()>>,
+}
+
+impl futures_util::Stream for NotifyingChunkStream {
+    type Item = Result<Vec<u8>, std::io::Error>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        match self.rx.poll_recv(cx) {
+            std::task::Poll::Ready(Some(chunk)) => std::task::Poll::Ready(Some(Ok(chunk))),
+            std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
+            std::task::Poll::Pending => std::task::Poll::Pending,
+        }
+    }
+}
+
+impl Drop for NotifyingChunkStream {
+    fn drop(&mut self) {
+        if let Some(done) = self.done.take() {
+            let _ = done.send(());
+        }
+    }
+}
 
 /// A dequeued HTTP request parked in `pending_responses` awaiting a `respond`.
 ///
@@ -169,16 +217,37 @@ pub struct WflHttpResponse {
 /// and whose body is fed chunk-by-chunk over a bounded channel by `write
 /// line|chunk`. A bounded channel gives backpressure: a slow client slows the
 /// handler's writes. Dropping the sender (handler end, `close`, or a caught
-/// error) closes the body stream and finalizes the response.
-#[derive(Debug)]
+/// error) closes the body stream and finalizes the response. The body stream
+/// notifies when the transport is finished with it so `close out` can await
+/// delivery (#680).
 pub enum HandlerReply {
     Buffered(WflHttpResponse),
     Streaming {
         status: u16,
         content_type: String,
         headers: HashMap<String, String>,
-        body: mpsc::Receiver<Vec<u8>>,
+        body: NotifyingChunkStream,
     },
+}
+
+impl std::fmt::Debug for HandlerReply {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HandlerReply::Buffered(response) => f.debug_tuple("Buffered").field(response).finish(),
+            HandlerReply::Streaming {
+                status,
+                content_type,
+                headers,
+                body: _,
+            } => f
+                .debug_struct("Streaming")
+                .field("status", status)
+                .field("content_type", content_type)
+                .field("headers", headers)
+                .field("body", &"<stream>")
+                .finish(),
+        }
+    }
 }
 
 /// Ensures an HTTP `respond` always resolves its request after the commit point.
@@ -980,8 +1049,12 @@ impl<'a, T> Drop for IsolatedHandler<'a, T> {
         // closed and any requests it dequeued but never answered. Close the
         // streams (finalizing the client's body) and 500 the unanswered requests,
         // so every exit path resolves the client instead of leaving it hanging.
+        // Sync path: Drop cannot await the transport finish signal. Ending the
+        // body by dropping the sender is still correct; a concurrent main loop
+        // that exits immediately after the last handler may still race under
+        // load (serial `close out` / end-of-iteration drain await instead).
         self.interp
-            .close_response_streams(&self.state.open_response_streams);
+            .close_response_streams_nowait(&self.state.open_response_streams);
         self.interp
             .fail_unanswered_requests(&self.state.open_pending_requests);
         // Drop any outbound streams this handler still owns, cancelling their
@@ -1449,10 +1522,11 @@ pub struct Interpreter {
     ws_connections: WsConnectionRegistry, // Outbound senders for all live WebSocket connections
     pending_responses: Rc<RefCell<HashMap<String, PendingResponse>>>, // Pending responses (channel + admission slot) by request ID
     /// Open server response streams (`start streaming response`), keyed by
-    /// handle id ("respstream1", ...). Each holds the bounded body-chunk sender
-    /// plus the running total of body bytes written, enforced against
-    /// `max_response_bytes` so a stream cannot bypass the buffered response
-    /// ceiling. `write line|chunk`/`flush` push to it, `close` drops it.
+    /// handle id ("respstream1", ...). Each holds the bounded body-chunk sender,
+    /// the running total of body bytes written (enforced against
+    /// `max_response_bytes`), and a oneshot the transport fires when it has
+    /// finished the body. `write line|chunk`/`flush` push chunks; `close`
+    /// drops the sender and awaits that finish signal (#680).
     server_response_streams: Rc<RefCell<HashMap<String, ServerResponseStream>>>,
     next_response_stream_id: std::cell::Cell<usize>,
     /// Handle ids of server response streams opened by the currently executing
@@ -5048,7 +5122,7 @@ impl Interpreter {
         }
         let map = self.server_response_streams.borrow();
         open.iter()
-            .filter_map(|id| map.get(id).map(|(tx, _)| tx.clone()))
+            .filter_map(|id| map.get(id).map(|stream| stream.tx.clone()))
             .collect()
     }
 
@@ -5129,11 +5203,24 @@ impl Interpreter {
         }
     }
 
-    /// Close (drop the sender for) each server response stream whose handle id is
-    /// in `ids`, ending its body so the client stops waiting. Idempotent — an id
-    /// already closed by an explicit `close out` (or a disconnect) is a no-op —
-    /// so it is safe to call over a handler's full opened-stream list on exit.
-    fn close_response_streams(&self, ids: &[String]) {
+    /// How long `close out` / end-of-handler drain will wait for the transport
+    /// to finish the body after the sender is dropped. Uses the configured
+    /// response-write timeout when set; otherwise a fixed safety ceiling so a
+    /// stuck connection cannot pin the handler forever.
+    fn response_stream_finish_timeout(&self) -> Duration {
+        let secs = self.config.web_server_response_timeout_seconds;
+        if secs == 0 {
+            Duration::from_secs(30)
+        } else {
+            Duration::from_secs(secs)
+        }
+    }
+
+    /// Drop the body sender for each id (ending the stream) without waiting for
+    /// the transport to finish. Used only from `Drop` impls that cannot await.
+    /// Prefer [`Self::close_response_streams`] on every async path so the
+    /// terminating chunk is delivered before the program returns (#680).
+    fn close_response_streams_nowait(&self, ids: &[String]) {
         if ids.is_empty() {
             return;
         }
@@ -5143,12 +5230,313 @@ impl Interpreter {
         }
     }
 
+    /// Close each server response stream whose handle id is in `ids`: drop the
+    /// sender (ending the body) and await the transport's finished signal so the
+    /// terminating chunk has left the process before we return. Idempotent — an
+    /// id already closed by an explicit `close out` (or a disconnect) is a
+    /// no-op — so it is safe to call over a handler's full opened-stream list on
+    /// exit.
+    async fn close_response_streams(&self, ids: &[String]) {
+        if ids.is_empty() {
+            return;
+        }
+        let mut finished = Vec::new();
+        {
+            let mut map = self.server_response_streams.borrow_mut();
+            for id in ids {
+                if let Some(stream) = map.remove(id)
+                    && let Some(rx) = stream.finished
+                {
+                    finished.push(rx);
+                }
+                // Dropping `stream.tx` (via `stream` going out of scope) ends
+                // the body; the transport then fires `finished` on Drop of the
+                // body stream.
+            }
+        }
+        if finished.is_empty() {
+            return;
+        }
+        let timeout = self.response_stream_finish_timeout();
+        // Wait for every body in parallel so multi-stream handlers don't pay
+        // sequential timeouts, then bound the whole set.
+        let wait_all = async {
+            for rx in finished {
+                let _ = rx.await;
+            }
+        };
+        let _ = tokio::time::timeout(timeout, wait_all).await;
+    }
+
     /// Drain and close every server response stream the current (serial) handler
     /// left open. Called at the end of each serial `main loop` iteration and at
-    /// program exit, mirroring the concurrent path's per-handler `Drop`.
-    fn close_open_response_streams(&self) {
+    /// program exit, mirroring the concurrent path's per-handler `Drop` — but
+    /// awaits body completion so a `break` right after the last chunk still
+    /// delivers a clean end-of-stream (#680).
+    async fn close_open_response_streams(&self) {
         let ids = std::mem::take(&mut *self.open_response_streams.borrow_mut());
-        self.close_response_streams(&ids);
+        self.close_response_streams(&ids).await;
+    }
+
+    /// `execute [wfl] file at <path> [with <request>] [and read output as <var>]`.
+    ///
+    /// Kept as its own async fn (and only `Box::pin`ned from
+    /// `_execute_statement`) so the nested lex→parse→analyze→interpret pipeline
+    /// is not part of the giant shared statement state machine. Nesting this
+    /// statement multiplies only this smaller future on the poll stack (#681).
+    async fn execute_wfl_file(
+        &self,
+        path: &Expression,
+        request: Option<&Expression>,
+        variable_name: Option<&str>,
+        line: usize,
+        column: usize,
+        env: Rc<RefCell<Environment>>,
+    ) -> Result<(Value, ControlFlow), RuntimeError> {
+        // Guard against a file that (directly or indirectly) executes itself,
+        // using the shared budget's execute-file depth ceiling.
+        if let Err(exceeded) = self.budget.check_execute_file_depth(self.execute_depth) {
+            return Err(self.budget_error(exceeded, line, column));
+        }
+
+        // Evaluate path expression to string
+        let path_value = self.evaluate_expression(path, Rc::clone(&env)).await?;
+        let path_str: String = match &path_value {
+            Value::Text(s) => s.to_string(),
+            _ => {
+                return Err(RuntimeError::new(
+                    format!(
+                        "Execute file path must be text, got {}",
+                        path_value.type_name()
+                    ),
+                    line,
+                    column,
+                ));
+            }
+        };
+
+        // Resolve relative to the current script's directory (like load module),
+        // mapping a missing file to FileNotFound so `when file not found` works
+        let opt_source = self.current_source_file.borrow().as_ref().cloned();
+        let joined = if let Some(source_path) = opt_source {
+            source_path
+                .parent()
+                .map(|dir| dir.join(&path_str))
+                .unwrap_or_else(|| PathBuf::from(&path_str))
+        } else {
+            let cwd = std::env::current_dir().map_err(|e| {
+                RuntimeError::new(
+                    format!("Cannot determine current directory: {e}"),
+                    line,
+                    column,
+                )
+            })?;
+            cwd.join(&path_str)
+        };
+        let map_io_error = |e: std::io::Error| {
+            let kind = match e.kind() {
+                std::io::ErrorKind::NotFound => ErrorKind::FileNotFound,
+                std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
+                _ => ErrorKind::General,
+            };
+            RuntimeError::with_kind(
+                format!("Cannot execute wfl file '{path_str}': {e}"),
+                line,
+                column,
+                kind,
+            )
+        };
+        let resolved_path = tokio::fs::canonicalize(&joined)
+            .await
+            .map_err(map_io_error)?;
+        // Read under the shared source-size ceiling (bounded read).
+        let content = self
+            .read_source_bounded(&resolved_path, line, column)
+            .await?;
+
+        // Evaluate the optional request context and extract the variables that
+        // `wait for request` defines, so the executed file sees the same names.
+        // Validate the shape upfront so a wrong object fails here with a clear
+        // message instead of as confusing undefined variable errors inside the
+        // executed file.
+        let request_vars: Vec<(String, Value)> = if let Some(request_expr) = request {
+            let request_value = self
+                .evaluate_expression(request_expr, Rc::clone(&env))
+                .await?;
+            match &request_value {
+                Value::Object(props) => {
+                    let props = props.borrow();
+                    let mut vars = Vec::new();
+                    for key in ["method", "path", "query", "client_ip", "body", "headers"] {
+                        let value = props.get(key).ok_or_else(|| {
+                            RuntimeError::new(
+                                format!(
+                                    "Execute file request context is missing '{key}' - pass the request object from 'wait for request'"
+                                ),
+                                line,
+                                column,
+                            )
+                        })?;
+                        let type_ok = match key {
+                            "headers" => matches!(value, Value::Object(_)),
+                            _ => matches!(value, Value::Text(_)),
+                        };
+                        if !type_ok {
+                            return Err(RuntimeError::new(
+                                format!(
+                                    "Execute file request context field '{key}' must be {}, got {}",
+                                    if key == "headers" {
+                                        "an object"
+                                    } else {
+                                        "text"
+                                    },
+                                    value.type_name()
+                                ),
+                                line,
+                                column,
+                            ));
+                        }
+                        // Deep clone so the executed file cannot mutate the
+                        // parent's request data (e.g. the headers object)
+                        vars.push((key.to_string(), value.deep_clone()));
+                    }
+                    vars
+                }
+                _ => {
+                    return Err(RuntimeError::new(
+                        format!(
+                            "Execute file request context must be a request object, got {}",
+                            request_value.type_name()
+                        ),
+                        line,
+                        column,
+                    ));
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        // Parse the file; errors are catchable in the parent
+        use crate::lexer::lex_wfl_with_positions_checked;
+        use crate::parser::Parser;
+
+        // Lex under the shared run budget: a deadline / cancellation /
+        // operation breach during nested source loading surfaces as a
+        // typed, catchable runtime error instead of a truncated token
+        // stream that could execute as if it were the whole file.
+        let tokens = lex_wfl_with_positions_checked(&content)
+            .map_err(|exceeded| self.budget_error(exceeded, line, column))?;
+        let mut parser = Parser::new(&tokens);
+        let program = parser.parse().map_err(|errors| {
+            let first_error = errors.first();
+            RuntimeError::new(
+                format!(
+                    "Parse error in executed file '{}' (line {}, column {}): {}",
+                    resolved_path.display(),
+                    first_error.map(|e| e.line).unwrap_or(1),
+                    first_error.map(|e| e.column).unwrap_or(1),
+                    first_error.map(|e| e.message.as_str()).unwrap_or("unknown")
+                ),
+                line,
+                column,
+            )
+        })?;
+
+        // Analyze semantics, seeding the injected request variable names.
+        // The type checker is intentionally skipped: main.rs treats type
+        // errors as warnings only, so a hard gate here would reject files
+        // that run fine standalone.
+        use crate::analyzer::Analyzer;
+
+        let mut seeded_vars: HashMap<String, (crate::parser::ast::Type, bool)> = HashMap::new();
+        for (name, value) in &request_vars {
+            seeded_vars.insert(name.clone(), (Self::infer_type_from_value(value), true));
+        }
+        let mut analyzer = Analyzer::with_parent_variables(seeded_vars);
+        if let Err(errors) = analyzer.analyze(&program) {
+            let first_error = errors.first();
+            return Err(RuntimeError::new(
+                format!(
+                    "Semantic error in executed file '{}': {}",
+                    resolved_path.display(),
+                    first_error.map(|e| e.to_string()).unwrap_or_default()
+                ),
+                line,
+                column,
+            ));
+        }
+
+        // Run the file in a fresh nested interpreter (own global env and
+        // stdlib, inherits the parent's config) with request context injected
+        let mut child = Interpreter::with_config(Arc::clone(&self.config));
+        child.set_source_file(resolved_path.clone());
+        child.execute_depth = self.execute_depth + 1;
+        // Share the parent's budget so the deadline, operation ceiling,
+        // and cancellation span the whole run — otherwise splitting work
+        // across `execute file` calls would reset them and evade the cap.
+        child.budget = Arc::clone(&self.budget);
+        // Seed the child's recursion accounting with the parent's live
+        // depth so the combined WFL call depth across nested `execute
+        // file` runs is bounded by `max_call_depth` (not multiplied per
+        // level), preventing native-stack overflow before the guard fires.
+        child.base_call_depth = self.call_depth.get();
+
+        {
+            let mut child_env = child.global_env().borrow_mut();
+            for (name, value) in request_vars {
+                if let Err(msg) = child_env.define(&name, value) {
+                    return Err(RuntimeError::new(msg, line, column));
+                }
+            }
+        }
+
+        // With an output clause, capture the child's display/print output;
+        // without one, child output flows to the current sink (stdout, or
+        // the parent's own capture buffer if the parent is being captured)
+        let capture_buffer = variable_name.map(|_| Rc::new(RefCell::new(String::new())));
+        // The child shares this budget, so the parent's active main-loop
+        // exemption (a depth counter, not a flag) naturally covers the
+        // child and the nested front end — `execute file` from inside a
+        // server's `main loop` handler inherits the exemption instead of
+        // spuriously timing out, and the RAII guard needs no save/restore.
+        let run_result = {
+            let _guard = capture_buffer
+                .as_ref()
+                .map(|buffer| io_capture::push_capture(Rc::clone(buffer)));
+            // Box::pin breaks the recursive future (this method awaits a full
+            // nested interpret), keeping the future finitely sized
+            Box::pin(child.interpret(&program)).await
+        };
+
+        if let Err(errors) = run_result {
+            let first = errors
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| RuntimeError::new("unknown error".to_string(), line, column));
+            // Position the error at the parent's execute statement, keep the
+            // child's error kind so typed `when` clauses still match
+            return Err(RuntimeError::with_kind(
+                format!(
+                    "Error in executed file '{}' (line {}): {}",
+                    resolved_path.display(),
+                    first.line,
+                    first.message
+                ),
+                line,
+                column,
+                first.kind,
+            ));
+        }
+
+        if let (Some(var_name), Some(buffer)) = (variable_name, capture_buffer) {
+            let output = buffer.borrow();
+            env.borrow_mut()
+                .define_direct(var_name, Value::Text(Arc::from(output.as_str())))
+                .map_err(|e| RuntimeError::new(e, line, column))?;
+        }
+
+        Ok((Value::Null, ControlFlow::None))
     }
 
     fn pending_response_disconnected_now(&self, request_id: &str) -> bool {
@@ -5274,7 +5662,10 @@ impl Interpreter {
             .filter(|id| !snapshot.response_streams.contains(*id))
             .cloned()
             .collect();
-        self.close_response_streams(&new_response_streams);
+        // Cancel path: drop senders immediately (client is already gone or the
+        // pre-commit work is abandoned). No finish wait — there is no successful
+        // body left to deliver.
+        self.close_response_streams_nowait(&new_response_streams);
         self.open_response_streams
             .borrow_mut()
             .retain(|id| snapshot.response_streams.contains(id));
@@ -5911,7 +6302,7 @@ impl Interpreter {
         // than only clearing the id lists — clearing alone would strand the
         // still-open sender/receiver in `server_response_streams` /
         // `pending_responses`, hanging the client and leaking the entry.
-        self.close_open_response_streams();
+        self.close_open_response_streams().await;
         self.fail_open_pending_requests();
         self.close_open_http_streams();
         // RAII: if THIS run's future is dropped/cancelled before its normal exit
@@ -6099,7 +6490,7 @@ impl Interpreter {
                 errors.push(err);
                 // A mid-run timeout is still an exit path: finalize any open
                 // top-level streams and unanswered requests before returning.
-                self.close_open_response_streams();
+                self.close_open_response_streams().await;
                 self.fail_open_pending_requests();
                 self.close_open_http_streams();
                 return Err(errors);
@@ -6184,7 +6575,7 @@ impl Interpreter {
         // never answered — on EVERY exit path (normal end, statement error, or a
         // failing `main`), so a script that exits without `close` still finalizes
         // the client's body rather than leaving it hanging until process death.
-        self.close_open_response_streams();
+        self.close_open_response_streams().await;
         self.fail_open_pending_requests();
         self.close_open_http_streams();
 
@@ -6988,8 +7379,10 @@ impl Interpreter {
                     // server response streams this iteration left open, and 500
                     // any request it dequeued but never answered — so a handler
                     // that forgets `close out`/`respond` never leaves the client
-                    // hanging or waiting out the request timeout.
-                    self.close_open_response_streams();
+                    // hanging or waiting out the request timeout. Awaits body
+                    // finish so a `break` right after the last chunk still
+                    // delivers a clean end-of-stream (#680).
+                    self.close_open_response_streams().await;
                     self.fail_open_pending_requests();
                     self.close_open_http_streams();
                     let result = result?;
@@ -7322,11 +7715,15 @@ impl Interpreter {
                                     "close", &id, *line, *column,
                                 ));
                             }
-                            // Dropping the sender ends the response body stream.
-                            self.server_response_streams.borrow_mut().remove(&id);
                             // Drop it from the handler's auto-close tracking so
-                            // the list stays bounded to actually-open streams.
+                            // the list stays bounded to actually-open streams
+                            // *before* awaiting finish (so a concurrent drain
+                            // cannot double-close).
                             self.open_response_streams.borrow_mut().retain(|s| s != &id);
+                            // Drop the sender (ends the body) and await the
+                            // transport finishing the body so the terminating
+                            // chunk is on the wire before we return (#680).
+                            self.close_response_streams(std::slice::from_ref(&id)).await;
                             Ok((Value::Null, ControlFlow::None))
                         } else {
                             Err(RuntimeError::new(
@@ -9991,22 +10388,15 @@ impl Interpreter {
                                             reply_builder = reply_builder.header(name, value);
                                         }
 
-                                        // Turn the chunk receiver into a body stream.
-                                        // When the client disconnects, hyper drops this
-                                        // body, dropping `body`, which makes the
-                                        // handler's next `write` fail (the interpreter
-                                        // observes the closed channel) — that is how a
-                                        // browser disconnect cancels the handler.
-                                        let stream = futures_util::stream::unfold(
-                                            body,
-                                            |mut rx| async move {
-                                                rx.recv()
-                                                    .await
-                                                    .map(|chunk| (Ok::<Vec<u8>, std::io::Error>(chunk), rx))
-                                            },
-                                        );
+                                        // `body` is a `NotifyingChunkStream`: when the
+                                        // client disconnects, hyper drops it (firing
+                                        // the finish oneshot and making the handler's
+                                        // next `write` fail); when the sender is
+                                        // closed cleanly, the stream ends and Drop
+                                        // still fires so `close out` can await
+                                        // delivery of the terminating chunk (#680).
                                         match reply_builder
-                                            .body(warp::hyper::Body::wrap_stream(stream))
+                                            .body(warp::hyper::Body::wrap_stream(body))
                                         {
                                             Ok(response) => Ok(response),
                                             Err(_) => Err(warp::reject::custom(ServerError(
@@ -11013,7 +11403,14 @@ impl Interpreter {
                     .await?;
 
                 // Commit: take the sender and hand the streaming head to the transport.
+                // The oneshot pairs `close out` with the transport finishing the
+                // body so the program does not return mid-flush (#680).
                 let (tx, rx) = mpsc::channel::<Vec<u8>>(RESPONSE_STREAM_BUFFER);
+                let (done_tx, done_rx) = oneshot::channel::<()>();
+                let body = NotifyingChunkStream {
+                    rx,
+                    done: Some(done_tx),
+                };
                 let mut completion = match self
                     .take_pending_response_completion(&request_id, *line, *column)
                     .await
@@ -11033,7 +11430,7 @@ impl Interpreter {
                                 status: status_code,
                                 content_type: content_type_str,
                                 headers: custom_headers,
-                                body: rx,
+                                body,
                             })
                             .is_err()
                         {
@@ -11065,9 +11462,14 @@ impl Interpreter {
                     self.next_response_stream_id.set(n + 1);
                     format!("respstream{n}")
                 };
-                self.server_response_streams
-                    .borrow_mut()
-                    .insert(handle_id.clone(), (tx, 0));
+                self.server_response_streams.borrow_mut().insert(
+                    handle_id.clone(),
+                    ServerResponseStream {
+                        tx,
+                        bytes_written: 0,
+                        finished: Some(done_rx),
+                    },
+                );
                 // Track it against the current handler so it is auto-closed if
                 // the handler ends without an explicit `close out`.
                 self.open_response_streams
@@ -11179,8 +11581,8 @@ impl Interpreter {
                 let sender = {
                     let mut map = self.server_response_streams.borrow_mut();
                     match map.get_mut(&handle_id) {
-                        Some((tx, bytes_written)) => {
-                            let new_total = bytes_written.saturating_add(incoming_len);
+                        Some(stream) => {
+                            let new_total = stream.bytes_written.saturating_add(incoming_len);
                             if new_total > max_response_bytes {
                                 let actual = new_total;
                                 // Drop the stream so the body ends rather than
@@ -11199,8 +11601,8 @@ impl Interpreter {
                                     *column,
                                 ));
                             }
-                            *bytes_written = new_total;
-                            Some(tx.clone())
+                            stream.bytes_written = new_total;
+                            Some(stream.tx.clone())
                         }
                         None => None,
                     }
@@ -11929,252 +12331,19 @@ impl Interpreter {
                 line,
                 column,
             } => {
-                // Guard against a file that (directly or indirectly) executes
-                // itself, using the shared budget's execute-file depth ceiling.
-                if let Err(exceeded) = self.budget.check_execute_file_depth(self.execute_depth) {
-                    return Err(self.budget_error(exceeded, *line, *column));
-                }
-
-                // Evaluate path expression to string
-                let path_value = self.evaluate_expression(path, Rc::clone(&env)).await?;
-                let path_str: String = match &path_value {
-                    Value::Text(s) => s.to_string(),
-                    _ => {
-                        return Err(RuntimeError::new(
-                            format!(
-                                "Execute file path must be text, got {}",
-                                path_value.type_name()
-                            ),
-                            *line,
-                            *column,
-                        ));
-                    }
-                };
-
-                // Resolve relative to the current script's directory (like load module),
-                // mapping a missing file to FileNotFound so `when file not found` works
-                let opt_source = self.current_source_file.borrow().as_ref().cloned();
-                let joined = if let Some(source_path) = opt_source {
-                    source_path
-                        .parent()
-                        .map(|dir| dir.join(&path_str))
-                        .unwrap_or_else(|| PathBuf::from(&path_str))
-                } else {
-                    let cwd = std::env::current_dir().map_err(|e| {
-                        RuntimeError::new(
-                            format!("Cannot determine current directory: {e}"),
-                            *line,
-                            *column,
-                        )
-                    })?;
-                    cwd.join(&path_str)
-                };
-                let map_io_error = |e: std::io::Error| {
-                    let kind = match e.kind() {
-                        std::io::ErrorKind::NotFound => ErrorKind::FileNotFound,
-                        std::io::ErrorKind::PermissionDenied => ErrorKind::PermissionDenied,
-                        _ => ErrorKind::General,
-                    };
-                    RuntimeError::with_kind(
-                        format!("Cannot execute wfl file '{path_str}': {e}"),
-                        *line,
-                        *column,
-                        kind,
-                    )
-                };
-                let resolved_path = tokio::fs::canonicalize(&joined)
-                    .await
-                    .map_err(map_io_error)?;
-                // Read under the shared source-size ceiling (bounded read).
-                let content = self
-                    .read_source_bounded(&resolved_path, *line, *column)
-                    .await?;
-
-                // Evaluate the optional request context and extract the variables
-                // that `wait for request` defines, so the executed file sees the
-                // same names. Validate the shape upfront so a wrong object fails
-                // here with a clear message instead of as confusing undefined
-                // variable errors inside the executed file.
-                let request_vars: Vec<(String, Value)> = if let Some(request_expr) = request {
-                    let request_value = self
-                        .evaluate_expression(request_expr, Rc::clone(&env))
-                        .await?;
-                    match &request_value {
-                        Value::Object(props) => {
-                            let props = props.borrow();
-                            let mut vars = Vec::new();
-                            for key in ["method", "path", "query", "client_ip", "body", "headers"] {
-                                let value = props.get(key).ok_or_else(|| {
-                                    RuntimeError::new(
-                                        format!(
-                                            "Execute file request context is missing '{key}' - pass the request object from 'wait for request'"
-                                        ),
-                                        *line,
-                                        *column,
-                                    )
-                                })?;
-                                let type_ok = match key {
-                                    "headers" => matches!(value, Value::Object(_)),
-                                    _ => matches!(value, Value::Text(_)),
-                                };
-                                if !type_ok {
-                                    return Err(RuntimeError::new(
-                                        format!(
-                                            "Execute file request context field '{key}' must be {}, got {}",
-                                            if key == "headers" {
-                                                "an object"
-                                            } else {
-                                                "text"
-                                            },
-                                            value.type_name()
-                                        ),
-                                        *line,
-                                        *column,
-                                    ));
-                                }
-                                // Deep clone so the executed file cannot mutate the
-                                // parent's request data (e.g. the headers object)
-                                vars.push((key.to_string(), value.deep_clone()));
-                            }
-                            vars
-                        }
-                        _ => {
-                            return Err(RuntimeError::new(
-                                format!(
-                                    "Execute file request context must be a request object, got {}",
-                                    request_value.type_name()
-                                ),
-                                *line,
-                                *column,
-                            ));
-                        }
-                    }
-                } else {
-                    Vec::new()
-                };
-
-                // Parse the file; errors are catchable in the parent
-                use crate::lexer::lex_wfl_with_positions_checked;
-                use crate::parser::Parser;
-
-                // Lex under the shared run budget: a deadline / cancellation /
-                // operation breach during nested source loading surfaces as a
-                // typed, catchable runtime error instead of a truncated token
-                // stream that could execute as if it were the whole file.
-                let tokens = lex_wfl_with_positions_checked(&content)
-                    .map_err(|exceeded| self.budget_error(exceeded, *line, *column))?;
-                let mut parser = Parser::new(&tokens);
-                let program = parser.parse().map_err(|errors| {
-                    let first_error = errors.first();
-                    RuntimeError::new(
-                        format!(
-                            "Parse error in executed file '{}' (line {}, column {}): {}",
-                            resolved_path.display(),
-                            first_error.map(|e| e.line).unwrap_or(1),
-                            first_error.map(|e| e.column).unwrap_or(1),
-                            first_error.map(|e| e.message.as_str()).unwrap_or("unknown")
-                        ),
-                        *line,
-                        *column,
-                    )
-                })?;
-
-                // Analyze semantics, seeding the injected request variable names.
-                // The type checker is intentionally skipped: main.rs treats type
-                // errors as warnings only, so a hard gate here would reject files
-                // that run fine standalone.
-                use crate::analyzer::Analyzer;
-
-                let mut seeded_vars: HashMap<String, (crate::parser::ast::Type, bool)> =
-                    HashMap::new();
-                for (name, value) in &request_vars {
-                    seeded_vars.insert(name.clone(), (Self::infer_type_from_value(value), true));
-                }
-                let mut analyzer = Analyzer::with_parent_variables(seeded_vars);
-                if let Err(errors) = analyzer.analyze(&program) {
-                    let first_error = errors.first();
-                    return Err(RuntimeError::new(
-                        format!(
-                            "Semantic error in executed file '{}': {}",
-                            resolved_path.display(),
-                            first_error.map(|e| e.to_string()).unwrap_or_default()
-                        ),
-                        *line,
-                        *column,
-                    ));
-                }
-
-                // Run the file in a fresh nested interpreter (own global env and
-                // stdlib, inherits the parent's config) with request context injected
-                let mut child = Interpreter::with_config(Arc::clone(&self.config));
-                child.set_source_file(resolved_path.clone());
-                child.execute_depth = self.execute_depth + 1;
-                // Share the parent's budget so the deadline, operation ceiling,
-                // and cancellation span the whole run — otherwise splitting work
-                // across `execute file` calls would reset them and evade the cap.
-                child.budget = Arc::clone(&self.budget);
-                // Seed the child's recursion accounting with the parent's live
-                // depth so the combined WFL call depth across nested `execute
-                // file` runs is bounded by `max_call_depth` (not multiplied per
-                // level), preventing native-stack overflow before the guard fires.
-                child.base_call_depth = self.call_depth.get();
-
-                {
-                    let mut child_env = child.global_env().borrow_mut();
-                    for (name, value) in request_vars {
-                        if let Err(msg) = child_env.define(&name, value) {
-                            return Err(RuntimeError::new(msg, *line, *column));
-                        }
-                    }
-                }
-
-                // With an output clause, capture the child's display/print output;
-                // without one, child output flows to the current sink (stdout, or
-                // the parent's own capture buffer if the parent is being captured)
-                let capture_buffer = variable_name
-                    .as_ref()
-                    .map(|_| Rc::new(RefCell::new(String::new())));
-                // The child shares this budget, so the parent's active main-loop
-                // exemption (a depth counter, not a flag) naturally covers the
-                // child and the nested front end — `execute file` from inside a
-                // server's `main loop` handler inherits the exemption instead of
-                // spuriously timing out, and the RAII guard needs no save/restore.
-                let run_result = {
-                    let _guard = capture_buffer
-                        .as_ref()
-                        .map(|buffer| io_capture::push_capture(Rc::clone(buffer)));
-                    // Box::pin breaks the recursive future (this statement awaits a
-                    // full nested interpret), keeping the future finitely sized
-                    Box::pin(child.interpret(&program)).await
-                };
-
-                if let Err(errors) = run_result {
-                    let first = errors.into_iter().next().unwrap_or_else(|| {
-                        RuntimeError::new("unknown error".to_string(), *line, *column)
-                    });
-                    // Position the error at the parent's execute statement, keep the
-                    // child's error kind so typed `when` clauses still match
-                    return Err(RuntimeError::with_kind(
-                        format!(
-                            "Error in executed file '{}' (line {}): {}",
-                            resolved_path.display(),
-                            first.line,
-                            first.message
-                        ),
-                        *line,
-                        *column,
-                        first.kind,
-                    ));
-                }
-
-                if let (Some(var_name), Some(buffer)) = (variable_name, capture_buffer) {
-                    let output = buffer.borrow();
-                    env.borrow_mut()
-                        .define_direct(var_name, Value::Text(Arc::from(output.as_str())))
-                        .map_err(|e| RuntimeError::new(e, *line, *column))?;
-                }
-
-                Ok((Value::Null, ControlFlow::None))
+                // Boxed out of `_execute_statement`'s shared state machine so the
+                // full lex→parse→analyze→interpret pipeline does not inflate every
+                // other statement's future (and so nested `execute file` depth is
+                // not multiplied by that giant enum on the native stack — #681).
+                Box::pin(self.execute_wfl_file(
+                    path,
+                    request.as_ref(),
+                    variable_name.as_deref(),
+                    *line,
+                    *column,
+                    env,
+                ))
+                .await
             }
             Statement::SpawnProcessStatement {
                 command,
@@ -16461,10 +16630,15 @@ mod response_disconnect_result_tests {
                 .try_send(vec![0])
                 .expect("fill response stream buffer");
         }
-        interpreter
-            .server_response_streams
-            .borrow_mut()
-            .insert(handle_id.to_string(), (sender, 0));
+        let (_done_tx, done_rx) = oneshot::channel();
+        interpreter.server_response_streams.borrow_mut().insert(
+            handle_id.to_string(),
+            ServerResponseStream {
+                tx: sender,
+                bytes_written: 0,
+                finished: Some(done_rx),
+            },
+        );
         interpreter
             .open_response_streams
             .borrow_mut()

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -395,24 +395,38 @@ async fn test_execute_file_child_error_mentions_child_path() {
     );
 }
 
-#[tokio::test]
-async fn test_execute_file_depth_limit_prevents_infinite_recursion() {
-    let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    // self_exec.wfl executes itself forever; the depth guard must stop it
-    fs::write(
-        temp_dir.path().join("self_exec.wfl"),
-        "execute wfl file at \"self_exec.wfl\" and read output as nested_output\n",
-    )
-    .expect("Failed to write self-executing file");
+/// Depth-guard regression (#681). Nested `execute file` re-enters the full
+/// pipeline; on a default ~1 MB Windows test-thread stack that can overflow
+/// *before* `max_execute_file_depth` (4) fires. Run under the same large
+/// interpreter stack the CLI uses so the test asserts the promised depth error
+/// rather than a native stack overflow.
+#[test]
+fn test_execute_file_depth_limit_prevents_infinite_recursion() {
+    wfl::run_with_interpreter_stack(|| {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime for depth-limit test");
+        rt.block_on(async {
+            let temp_dir = TempDir::new().expect("Failed to create temp directory");
+            // self_exec.wfl executes itself forever; the depth guard must stop it
+            fs::write(
+                temp_dir.path().join("self_exec.wfl"),
+                "execute wfl file at \"self_exec.wfl\" and read output as nested_output\n",
+            )
+            .expect("Failed to write self-executing file");
 
-    let source = r#"execute wfl file at "self_exec.wfl" and read output as page_output"#;
-    let (result, _interpreter) = run_program_in_dir(&temp_dir, source).await;
-    let errors = result.expect_err("Expected depth limit error");
-    let message = &errors.first().expect("Expected at least one error").message;
-    assert!(
-        message.contains("depth"),
-        "Error should mention nesting depth, got: {message}"
-    );
+            let source = r#"execute wfl file at "self_exec.wfl" and read output as page_output"#;
+            let (result, _interpreter) = run_program_in_dir(&temp_dir, source).await;
+            let errors = result.expect_err("Expected depth limit error");
+            let message = &errors.first().expect("Expected at least one error").message;
+            assert!(
+                message.contains("depth"),
+                "Error should mention nesting depth, got: {message}"
+            );
+        });
+    })
+    .expect("reserve interpreter stack for depth-limit test");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/execute_file_test.rs
+++ b/tests/execute_file_test.rs
@@ -421,8 +421,8 @@ fn test_execute_file_depth_limit_prevents_infinite_recursion() {
             let errors = result.expect_err("Expected depth limit error");
             let message = &errors.first().expect("Expected at least one error").message;
             assert!(
-                message.contains("depth"),
-                "Error should mention nesting depth, got: {message}"
+                message.contains("Maximum execute file nesting depth"),
+                "Error should report the execute-file nesting guard, got: {message}"
             );
         });
     })

--- a/tests/response_stream_backpressure_test.rs
+++ b/tests/response_stream_backpressure_test.rs
@@ -382,3 +382,82 @@ async fn test_body_is_complete_when_program_ends_immediately_after_close() {
     });
     join_server(server).await;
 }
+
+/// Concurrent counterpart to #680: a `main loop concurrently:` handler that
+/// streams without an explicit `close out` and then `break`s must still deliver
+/// a complete body. Stream ids live on the handler's isolated RunState, so the
+/// top-level serial drain never sees them — finish must be awaited before the
+/// IsolatedHandler reports Ready, not only fire-and-forget in Drop.
+#[tokio::test]
+async fn test_concurrent_handler_body_is_complete_without_explicit_close_on_break() {
+    let port = common::free_tcp_port();
+
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop concurrently:
+            wait for request comes in on srv as req with timeout 30000
+            start streaming response to req with status 200 and content type "text/plain" as out
+            write chunk "COMPLETE" to out
+            break
+        end loop
+    "#
+    );
+
+    let (done_tx, done_rx) =
+        tokio::sync::oneshot::channel::<Result<(), Vec<(ErrorKind, String)>>>();
+    let server = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("server runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let program = Parser::new(&tokens).parse().expect("parse");
+            let mut interp = Interpreter::new();
+            let result = match interp.interpret(&program).await {
+                Ok(_) => Ok(()),
+                Err(errors) => Err(errors
+                    .into_iter()
+                    .map(|error| (error.kind, error.message))
+                    .collect()),
+            };
+            let _ = done_tx.send(result);
+        });
+    });
+
+    wait_for_server(port).await;
+
+    let mut resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/"))
+        .send()
+        .await
+        .expect("request send");
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let mut body = String::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match resp.chunk().await {
+                Ok(Some(bytes)) => body.push_str(&String::from_utf8_lossy(&bytes)),
+                Ok(None) => break,
+                Err(error) => {
+                    panic!("concurrent stream transport failed instead of ending cleanly: {error}")
+                }
+            }
+        }
+    })
+    .await
+    .expect("concurrent streaming body stalled");
+
+    assert_eq!(
+        body, "COMPLETE",
+        "concurrent handler must deliver the full body when it breaks without close out"
+    );
+
+    let interpreter_result = tokio::time::timeout(Duration::from_secs(3), done_rx)
+        .await
+        .expect("interpreter did not finish after concurrent break")
+        .expect("interpreter result sender dropped");
+    interpreter_result.unwrap_or_else(|errors| {
+        panic!("concurrent stream-break program must finish successfully, got {errors:?}")
+    });
+    join_server(server).await;
+}

--- a/tests/response_stream_backpressure_test.rs
+++ b/tests/response_stream_backpressure_test.rs
@@ -296,3 +296,89 @@ async fn test_early_chunk_is_visible_before_the_body_completes() {
     });
     join_server(server).await;
 }
+
+/// #680: when a program's last act is `close out` then exit, the client must
+/// still receive a complete body (including the terminating chunk). Dropping the
+/// sender alone is not enough — the interpreter must wait for the transport to
+/// finish the body before returning, otherwise runtime teardown aborts the
+/// connection mid-flush and the client reports a decode/truncation error.
+#[tokio::test]
+async fn test_body_is_complete_when_program_ends_immediately_after_close() {
+    let port = common::free_tcp_port();
+
+    // No post-close wait, no `close server` — the program finishes the moment
+    // the handler breaks. This is the product path that used to race: close
+    // drops the sender, interpret returns, the host drops the Runtime, and the
+    // in-flight connection task is aborted before the terminating chunk lands.
+    let code = format!(
+        r#"
+        listen on port {port} as srv
+        main loop:
+            wait for request comes in on srv as req with timeout 30000
+            start streaming response to req with status 200 and content type "text/plain" as out
+            write chunk "COMPLETE" to out
+            close out
+            break
+        end loop
+    "#
+    );
+
+    let (done_tx, done_rx) =
+        tokio::sync::oneshot::channel::<Result<(), Vec<(ErrorKind, String)>>>();
+    let server = std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().expect("server runtime");
+        rt.block_on(async {
+            let tokens = lex_wfl_with_positions(&code);
+            let program = Parser::new(&tokens).parse().expect("parse");
+            let mut interp = Interpreter::new();
+            let result = match interp.interpret(&program).await {
+                Ok(_) => Ok(()),
+                Err(errors) => Err(errors
+                    .into_iter()
+                    .map(|error| (error.kind, error.message))
+                    .collect()),
+            };
+            let _ = done_tx.send(result);
+        });
+    });
+
+    wait_for_server(port).await;
+
+    let mut resp = reqwest::Client::new()
+        .get(format!("http://127.0.0.1:{port}/"))
+        .send()
+        .await
+        .expect("request send");
+    assert_eq!(resp.status().as_u16(), 200);
+
+    let mut body = String::new();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match resp.chunk().await {
+                Ok(Some(bytes)) => body.push_str(&String::from_utf8_lossy(&bytes)),
+                Ok(None) => break,
+                Err(error) => {
+                    panic!(
+                        "stream transport failed instead of ending cleanly after close out: {error}"
+                    )
+                }
+            }
+        }
+    })
+    .await
+    .expect("streaming body stalled after close out");
+
+    assert_eq!(
+        body, "COMPLETE",
+        "client must receive the full body when the program ends immediately after close out"
+    );
+
+    let interpreter_result = tokio::time::timeout(Duration::from_secs(3), done_rx)
+        .await
+        .expect("interpreter did not finish after close out")
+        .expect("interpreter result sender dropped");
+    interpreter_result.unwrap_or_else(|errors| {
+        panic!("close-out exit program must finish successfully, got {errors:?}")
+    });
+    join_server(server).await;
+}


### PR DESCRIPTION
## Summary

- **#680:** `close out` and async end-of-handler/end-of-run drains now drop the body-chunk sender *and* await a transport finish signal (`NotifyingChunkStream` Drop), so programs that end immediately after streaming no longer race runtime teardown and truncate the chunked body under load.
- **#681:** Box the `execute file` pipeline out of the shared `_execute_statement` state machine; run the depth-guard test under `run_with_interpreter_stack`; default `RUST_MIN_STACK=8MB` for Windows integration tests so `max_execute_file_depth` fires as a clean error instead of `STATUS_STACK_OVERFLOW`.

## Test plan

- [x] `cargo test --test response_stream_backpressure_test --test execute_file_test`
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] CI: Build, Test, Clippy (includes the formerly flaky streaming visibility test)
- [ ] CI: Integration Tests on Windows (depth guard + suite under larger stack)

Closes #680
Closes #681
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/682" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now reliably deliver all output when a program exits immediately after closing the output stream.
  * Deeply nested `execute file` operations now reach the configured depth limit without premature native stack overflows, including on Windows.

* **Documentation**
  * Clarified stack requirements and recommended configuration for applications embedding the interpreter.
  * Added release notes describing the streaming and nested execution fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->