### PR TITLE
fix(stdlib): gate Unix-only format_mode behind cfg(unix) — unblocks the nightly Windows build

### DIFF
--- a/src/stdlib/filesystem.rs
+++ b/src/stdlib/filesystem.rs
@@ -499,6 +499,11 @@ pub fn native_remove_dir(args: Vec<Value>) -> Result<Value, RuntimeError> {
 // ============================================================================
 
 /// Format a raw permission bit set as the 4-character octal string WFL uses.
+///
+/// Unix-only: both call sites live behind `#[cfg(unix)]`, because Windows has
+/// no mode bits to format. Without this gate the function is dead code on
+/// Windows and `cargo clippy -- -D warnings` fails the nightly build.
+#[cfg(unix)]
 fn format_mode(bits: u32) -> String {
     format!("{:04o}", bits & 0o7777)
 }


### PR DESCRIPTION
## Why

The **Nightly Build has failed three nights running** (2026-07-31, 08-01, 08-02) and has published no artifacts for `main` since `nightly-2026-07-30`.

- [run 30735206598](https://github.com/WebFirstLanguage/wfl/actions/runs/30735206598) (08-02) — `Build WFL for Windows` failed at step 8, `Run clippy`, after 75s
- [run 30686979106](https://github.com/WebFirstLanguage/wfl/actions/runs/30686979106) (08-01) — identical failure
- [run 30608593328](https://github.com/WebFirstLanguage/wfl/actions/runs/30608593328) (07-31) — a *different*, already self-resolved failure (`Check formatting`: `Incorrect newline style in src\interpreter\error.rs`); formatting has passed since.

`Create or Update Nightly Release` `needs:` the Windows job, so it has been skipped each night.

## Root cause

```
error: function `format_mode` is never used
  --> src\stdlib\filesystem.rs:502:4
  = note: `-D dead-code` implied by `-D warnings`
```

`format_mode` landed in #676 (file modes for #666). Both of its call sites — `native_file_mode` (line 571) and `native_set_file_mode` (line 624) — sit inside `#[cfg(unix)]` blocks, because Windows has no mode bits and the `#[cfg(not(unix))]` branches return the documented read-only approximation instead. The function itself was never gated, so on Windows it compiles to dead code and `-D warnings` rejects it.

`parse_mode` is *not* affected — it is called at line 603, above the `cfg` split, so it is live on both platforms.

## What changed

One attribute, one file:

```rust
+/// Unix-only: both call sites live behind `#[cfg(unix)]` ...
+#[cfg(unix)]
 fn format_mode(bits: u32) -> String {
```

No behaviour change on either platform. This mirrors the cfg structure of the callers rather than papering over it with `#[allow(dead_code)]`.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --lib` — clean
- `cargo clippy --lib -- -D warnings` — clean (Linux/unix path: `format_mode` is still live and still used)
- Windows path verified by inspection: `grep -rn format_mode src/` returns exactly the definition plus the two `#[cfg(unix)]`-guarded call sites, so gating the definition cannot orphan a reference. A cross-target `--target x86_64-pc-windows-msvc` clippy run was attempted and abandoned — the sandbox ran out of disk building the Windows dependency tree.
- **The authoritative check is the nightly itself** — `nightly.yml` is the only lane that runs clippy on Windows. A `workflow_dispatch` against this branch was deliberately NOT triggered: the `release` job has no branch guard, so it would publish a `nightly-2026-08-02` release from a non-`main` sha. Merge this, then the next scheduled nightly (or a dispatch from `main`) confirms it.
- A cross-target `cargo clippy --target x86_64-pc-windows-msvc` was also attempted and could not complete in the sandbox: `aws-lc-sys` v0.42.0 needs a Windows build toolchain its build script cannot find. Stated plainly rather than claimed.

## Testing policy

Risk class **R0**: a `cfg` attribute with no behavioural surface. Per §"pure CI mechanics" in the testing policy, no manufactured failing test — the existing Windows clippy gate *is* the failing test, and it is red on `main` right now.

## Standing issue this re-exposes

This is the third instance of KB #625 / #633: **`ci.yml` runs clippy on Ubuntu only**, so platform-conditional lints reach `main` and are caught post-merge by the nightly. A Windows clippy lane in `ci.yml` would have failed #676 at review time in ~4 minutes.

*Posted by the WFL repo warden (automated triage pass).*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform compatibility by preventing Unix-specific file mode formatting from being compiled on unsupported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->