### PR TITLE
Consolidate test helpers into tests/common/mod.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,11 +137,13 @@ panic = "unwind"
 # (25.1 GB of it test binaries) -- past a 30 GB environment's disk budget and
 # fatal to the link step (`ld ... signal 7 [Bus error]`). `line-tables-only`
 # keeps file/line info for panics and backtraces while dropping variable/type
-# DWARF. Both profiles are needed: integration-test binaries link the library
-# as a *dev*-profile dependency, so `[profile.test]` alone would not shrink
-# them.
-[profile.dev]
-debug = "line-tables-only"
-
+# DWARF, so panic messages and backtraces still name file and line.
+#
+# This is deliberately scoped to `[profile.test]` only. Under `cargo test`
+# the *entire* build graph -- the local library, the `wfl` binary, and every
+# external dependency -- is built with the `test` profile, so this one setting
+# captures the whole saving. `[profile.dev]` is intentionally left at full
+# debug info so ordinary `cargo build` / `cargo run` binaries stay fully
+# inspectable in a debugger.
 [profile.test]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,17 @@ debug = true
 # request-handler fault isolation (Phase 1) stays sound. Enforced by the
 # `#[cfg(panic = "abort")] compile_error!` in src/lib.rs.
 panic = "unwind"
+
+# Test-shrink: the suite's 143 top-level `tests/*.rs` files each statically
+# link the whole compiler, and full debug info pushed `target/` to ~27 GB
+# (25.1 GB of it test binaries) -- past a 30 GB environment's disk budget and
+# fatal to the link step (`ld ... signal 7 [Bus error]`). `line-tables-only`
+# keeps file/line info for panics and backtraces while dropping variable/type
+# DWARF. Both profiles are needed: integration-test binaries link the library
+# as a *dev*-profile dependency, so `[profile.test]` alone would not shrink
+# them.
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"

--- a/History/dev-diary/2026/2026-08-14-test-shrink-pass.md
+++ b/History/dev-diary/2026/2026-08-14-test-shrink-pass.md
@@ -49,9 +49,21 @@ Two things worth recording, because both contradict the skill's own playbook:
   0 = none, 1 = limited, 2 = full; `line-tables-only` is a separate named level,
   lighter than 1. The playbook's inline comment (`debug = 1 # line-tables-only`)
   is wrong and should be corrected.
-- **`[profile.test]` alone would not have worked.** Integration-test binaries
-  link the library as a *dev*-profile dependency, so `[profile.dev]` carries most
-  of the saving.
+- **`[profile.test]` alone is exactly right — and the first version of this
+  change got that wrong.** It originally set `[profile.dev]` *and*
+  `[profile.test]`, on the belief that integration-test binaries link the
+  library as a *dev*-profile dependency. That belief is false, and PR #694
+  review (Codex) caught it. Under `cargo test` the **entire** build graph — the
+  local library, the `wfl` binary, and every external dependency — is built with
+  the `test` profile. Verified with a throwaway crate built with deliberately
+  different values (`[profile.dev] debug = 0`, `[profile.test] debug = 2`): the
+  plain `--crate-type lib` rlib *and* an external path dependency both compiled
+  with `-C debuginfo=2`, i.e. the test profile, never dev's 0. Confirmed against
+  the real repo too — dropping the `[profile.dev]` override left the test binary
+  at 56.1 MB and `libwfl-*.rlib` at 85.5 MB, byte-identical to before. So the
+  dev override bought nothing for tests and only cost contributors variable and
+  type DWARF in ordinary `cargo build` / `cargo run` binaries. It was removed;
+  `[profile.dev]` stays at full debug info.
 
 No `strip` was added — it would remove the very line tables the setting keeps.
 `[profile.release]` was not touched; its `debug = true` stays deliberate.
@@ -115,6 +127,14 @@ full-suite count held at 2096 throughout.
    six tests fail with an opaque
    `Os { code: 2, kind: NotFound }` rather than a clear "run cargo build
    --release first" message.
+   *Partly addressed during PR #694 review:* both Devin and Copilot
+   independently flagged that hoisting `wfl_release_exe()` into the shared
+   harness made this trap easier to reach, since a future author picking
+   `run_file_status` silently gets the release binary. The shared helper now
+   anchors the path to `CARGO_MANIFEST_DIR` (so it no longer depends on the test
+   process's working directory) and asserts the binary exists with an actionable
+   "Run `cargo build --release` first" message. `binary_io_test.rs` still has its
+   own copy of the hardcoded path and is unfixed — see issue #692.
 3. **30 file-I/O tests can drop files into the repo root on failure.**
    `tests/file_io_{performance,concurrent,error_handling,execution}_test.rs` call
    `cleanup_test_files()` as a plain trailing statement with no `Drop` guard, so

--- a/History/dev-diary/2026/2026-08-14-test-shrink-pass.md
+++ b/History/dev-diary/2026/2026-08-14-test-shrink-pass.md
@@ -1,0 +1,181 @@
+# 2026-08-14 — first test-shrink pass
+
+First real run of the `test-shrink` skill. Three candidates landed; the headline
+is that the Rust test suite went from **impossible to build** in a 30 GB
+environment to building and passing in full.
+
+## Metrics — before / after
+
+| Metric | Before | After | Delta |
+|---|---|---|---|
+| `cargo test --all` | **failed to link**, 0 tests ran | 2096 passed, 0 failed | suite is runnable |
+| All test binaries | 25.13 GB (156, incomplete) | **11.22 GB** (180, complete) | −55 % on a larger set |
+| Mean per test binary | 165 MB | **63.9 MB** | −61 % |
+| `target/` | 27 G | 17 G | −37 % |
+| Test source lines | 42,940 | **42,629** | −311 |
+| `tests/common/mod.rs` | 21 lines (1 helper) | 216 lines (14 shared helpers) | shared harness now real |
+| Integration (`TestPrograms/`) | not reachable | 136 passed, 0 failed, 24 skipped | — |
+| Full-suite wall time | n/a | 106–139 s | — |
+
+The binary-size comparison is conservative: the "before" 25.13 GB was an
+*incomplete* set, because the build died partway. The complete 180-target set at
+the old mean would have been ~29.7 GB, against 11.22 GB now.
+
+## The baseline was red, and that was the finding
+
+`cargo test --all` exited 101 without running a single test:
+
+```
+error: linking with `cc` failed: exit status: 1
+  = note: collect2: fatal error: ld terminated with signal 7 [Bus error]
+```
+
+`ld ... signal 7` is the ENOSPC-during-link signature CLAUDE.md already warns
+about. Disk hit 0 G mid-build. 143 top-level `tests/*.rs` files each statically
+link the whole compiler with full debug info; at ~165 MB apiece that is more
+than the entire disk allowance. The base was not broken — the suite simply could
+not be built.
+
+## Candidates accepted
+
+**C1 — `debug = "line-tables-only"` on the dev and test profiles** (`6f4c686`)
+
+Test binary 199.5 MB → 56.1 MB; `libwfl-*.rlib` 291.0 MB → 85.5 MB. This is what
+made every later step possible.
+
+Two things worth recording, because both contradict the skill's own playbook:
+
+- **`debug = 1` is not an alias for `line-tables-only`.** Numeric levels are
+  0 = none, 1 = limited, 2 = full; `line-tables-only` is a separate named level,
+  lighter than 1. The playbook's inline comment (`debug = 1 # line-tables-only`)
+  is wrong and should be corrected.
+- **`[profile.test]` alone would not have worked.** Integration-test binaries
+  link the library as a *dev*-profile dependency, so `[profile.dev]` carries most
+  of the saving.
+
+No `strip` was added — it would remove the very line tables the setting keeps.
+`[profile.release]` was not touched; its `debug = true` stays deliberate.
+
+Readable-panic check (mandatory for a debug-info reduction) passed — a
+deliberately broken assertion still reports its location:
+
+```
+thread 'test_explicit_token_stream_analysis' panicked at
+tests/colon_consumption_test.rs:69:5
+...
+4: colon_consumption_test::test_explicit_token_stream_analysis
+           at ./tests/colon_consumption_test.rs:69:5
+```
+
+**C2 — hoist in-memory WFL drivers into `tests/common/`** (`12f727b`)
+12 files, net −229 lines. Three driver shapes (`run_wfl`, `run_wfl_code`,
+`run_wfl_ok`) plus shared accessors.
+`http_connection_reuse_retry_test.rs` was deliberately left alone: its `get_text`
+matches `Option<Value>` directly instead of routing through a panicking
+`get_var`, so the missing-variable path genuinely differs.
+
+**C3 — hoist the wfl-binary spawn harness into `tests/common/`** (`d1b8aef`)
+13 files, net −82 lines. The real CLI boundary is preserved everywhere.
+
+The trap here: the two original `wfl_exe()` variants resolve to **different
+binaries** — `env!("CARGO_BIN_EXE_wfl")` is the profile-matched test binary,
+while the hardcoded path is the separately built `target/release/wfl`. They were
+kept as two helpers (`wfl_exe` / `wfl_release_exe`) and every call site retained
+the binary it had. Unifying them would have silently changed what several tests
+actually exercise.
+
+For C2 and C3 the coverage evidence was a before/after `--list` test-name
+inventory per target, diffed line by line: byte-identical every time, and the
+full-suite count held at 2096 throughout.
+
+## Rejected / not pursued
+
+- **No test merges.** The redundancy hunt read every same-named family
+  (`concurrent_*`, `crypto_*`/`wflhash_*`, `database_*`, `web_server_tls*`,
+  `*_backcompat_*`, `*return_type*`) and found **no pair** where one file's
+  assertions are provably a subset of another's. The naming discipline tracks
+  real architectural seams — pipeline stage, real-binary vs in-process boundary.
+  Shared test *names* across `web_server_tls_test` and
+  `web_server_tls_parser_test` are deliberate dual-layer coverage, which the
+  testing policy explicitly wants.
+- **Print/noise removal was demoted.** `cargo test` captures stdout and stderr
+  for passing tests and discards them, so `println!` in test bodies costs
+  ~0 bytes on a green run. The suite prints 181 KB total. Not worth a candidate.
+
+## Discovered defects — not fixed here, but real
+
+1. **Flaky test: `interpreter::process_tests::test_capture_process_output`**
+   (`src/interpreter/mod.rs:19109`). Spawns `echo`, sleeps a fixed 200 ms, then
+   asserts the output was captured. It failed once during a loaded full-suite
+   run and passes 5/5 in isolation. Fixed-sleep synchronisation under load. By
+   §8.2 of the testing policy a flaky required test is a failing test. It lives
+   in `src/`, so it was out of scope for this pass.
+2. **`cargo test --all` is not self-sufficient.** `tests/binary_io_test.rs`
+   hardcodes `target/release/wfl`, so without a prior `cargo build --release`
+   six tests fail with an opaque
+   `Os { code: 2, kind: NotFound }` rather than a clear "run cargo build
+   --release first" message.
+3. **30 file-I/O tests can drop files into the repo root on failure.**
+   `tests/file_io_{performance,concurrent,error_handling,execution}_test.rs` call
+   `cleanup_test_files()` as a plain trailing statement with no `Drop` guard, so
+   a failing assertion skips cleanup — turning one red test into a second,
+   confusing hygiene-job failure. One sibling test in the same file already does
+   it correctly with `tempfile::tempdir()`.
+4. **`TestPrograms` leaks.** `error_handling_comprehensive.wfl:249-251` creates
+   `test_error_file.txt` and never deletes it (CI-SKIPped, so manual runs only);
+   five gated programs delete only on the happy path. The fix pattern already
+   exists in `file_io_comprehensive.wfl:10,103,202`.
+5. **Superseded test binaries accumulate without bound.** Cargo never deletes a
+   removed target's old executables. Repeated builds silently grew
+   `target/debug/deps` from 180 to 330 files (11 GB → 22 GB) and exhausted the
+   disk four times this session. Any measurement of `deps/` must prune to the
+   current target graph first or it compares unlike with unlike.
+
+## Proposals for Brad
+
+Maintainer-decision items, deliberately not applied:
+
+- **Binary consolidation (playbook §1) is still the big structural win.** The
+  scouting is done and the pilot is fully specified: group I (crypto + stdlib) —
+  `crypto_test`, `crypto_async_test`, `crypto_kdf_test`, `crypto_seal_test`,
+  `sha256_hmac_test`, `wflhash_hardened_security_test`, `wflhash_security_test`,
+  `password_hashing_test`, `random_functions_test`, `toml_test` (2,973 lines).
+  Verified clean: no `mod common`/`mod test_helpers`/`#[path]`/`include!`/inner
+  attributes/`extern crate`/`fn main`, and — tree-wide, not just in this batch —
+  **zero** `set_var`, `remove_var`, `set_current_dir`, `static mut`,
+  `lazy_static`, `OnceLock`, or `Once`. That last result matters: the usual
+  danger of putting many tests in one process (shared global state) does not
+  exist in this codebase, so consolidation is far safer here than usual.
+- **`test_helpers.rs` is doing double duty** — it is simultaneously a standalone
+  test target with 6 of its own tests and a `mod`-included helper for 9 other
+  files, so it is compiled 10 times. Deserves its own candidate, and it must be
+  resolved before migrating any of its 9 consumers.
+- **`run_src()` has no timeout.** `phase1_correctness_regression_test.rs` has a
+  better `run_files` with a wall-clock kill and pinned `WFL_GLOBAL_CONFIG_PATH`;
+  the other call sites can hang the whole run. Behavioral change, so a separate
+  candidate.
+- **`opt-level` tuning** (`[profile.test] opt-level = 1`,
+  `[profile.dev.package."*"] opt-level = 2`) was deliberately not bundled with
+  C1. Plausible runtime win for interpreter-heavy tests; needs its own
+  measurement.
+- **Fix the playbook's `debug = 1` error** in
+  `.claude/skills/test-shrink/references/rust-test-optimization.md:70`.
+- **Orphaned fixture** `tests/fixtures/tooling/combiner/test_file_list.wfl` — no
+  consumer anywhere. It was moved there by the 2026-07-28 hygiene migration for a
+  test that was never written. "Finish or remove" is the combiner tool owner's
+  call, not a silent deletion.
+- **`constant_error_precedence.wfl` scenario 3** is a coverage *gap* dressed as
+  bloat — the scenario exists but nothing pins its intent. Prefer adding an
+  assertion over trimming it.
+- Larger files worth a future internal-redundancy pass: `overload_test.rs`
+  (2,131 lines), `typechecker_gradual_any_test.rs` (1,262),
+  `write_web_postfix_test.rs` (1,155).
+
+## Gates
+
+Every accepted candidate passed all four, individually, before commit:
+`cargo test --all` (2096 passed / 0 failed / 27 ignored, 159 suites),
+`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features
+-D warnings`, and `./scripts/run_integration_tests.sh` (136 passed / 0 failed /
+24 skipped). `python3 scripts/check_repo_hygiene.py --mode static` exits 0 and
+the working tree is clean.

--- a/tests/cli_help_version_flags_test.rs
+++ b/tests/cli_help_version_flags_test.rs
@@ -11,9 +11,8 @@
 use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
+mod common;
+use common::wfl_exe;
 
 /// Run `wfl <flag>` in an empty temp dir, returning (stdout, stderr, exit code).
 fn run_flag(flag: &str) -> (String, String, Option<i32>) {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,8 +1,11 @@
 //! Shared helpers for integration tests.
 #![allow(dead_code)]
 
+use std::fs;
 use std::net::TcpListener;
+use std::process::Command;
 
+use tempfile::TempDir;
 use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
 use wfl::lexer::lex_wfl_with_positions;
@@ -144,4 +147,70 @@ pub fn get_number(interpreter: &Interpreter, name: &str) -> f64 {
         Value::Number(n) => n,
         other => panic!("Expected '{name}' to be a number, got {other:?}"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Real-binary driver: spawn the actual `wfl` executable and capture its
+// output. Unlike the in-memory shapes above, these tests exercise the real
+// CLI boundary (argument parsing, process exit codes, file I/O), so they
+// spawn a subprocess rather than calling into the interpreter directly.
+// ---------------------------------------------------------------------------
+
+/// Absolute path to the `wfl` binary Cargo built for *this* test run.
+/// `CARGO_BIN_EXE_wfl` is injected by Cargo, so it always points at the
+/// freshly-built binary matching the current test profile (debug under plain
+/// `cargo test`, release under `cargo test --release`) — no stale-binary risk
+/// and no cwd assumption.
+pub fn wfl_exe() -> &'static str {
+    env!("CARGO_BIN_EXE_wfl")
+}
+
+/// Path to the separately-built `target/release/wfl` binary. This is a
+/// *different* binary from [`wfl_exe`] (which may point at a debug build) —
+/// callers that need the release binary specifically (e.g. because a sibling
+/// helper in the same file already assumes it, or the test predates
+/// `CARGO_BIN_EXE_wfl` and was never migrated) use this instead.
+pub fn wfl_release_exe() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "target/release/wfl.exe"
+    } else {
+        "target/release/wfl"
+    }
+}
+
+/// Run inline WFL source (via [`wfl_exe`]) in a fresh temp dir, returning
+/// (combined stdout+stderr, exit code).
+pub fn run_src(src: &str) -> (String, Option<i32>) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("main.wfl");
+    fs::write(&path, src).unwrap();
+    let output = Command::new(wfl_exe())
+        .arg(&path)
+        .output()
+        .expect("failed to execute WFL");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    drop(dir);
+    (combined, output.status.code())
+}
+
+/// Run a WFL file that already lives inside `dir` (via [`wfl_release_exe`]),
+/// so relative paths like `include from`/`load module from` resolve to
+/// sibling files. Returns (combined stdout+stderr, exit code).
+pub fn run_file_status(dir: &TempDir, name: &str, extra_args: &[&str]) -> (String, Option<i32>) {
+    let path = dir.path().join(name);
+    let output = Command::new(wfl_release_exe())
+        .args(extra_args)
+        .arg(&path)
+        .output()
+        .expect("Failed to execute WFL");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (combined, output.status.code())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,7 @@
 
 use std::fs;
 use std::net::TcpListener;
+use std::path::PathBuf;
 use std::process::Command;
 
 use tempfile::TempDir;
@@ -170,12 +171,30 @@ pub fn wfl_exe() -> &'static str {
 /// callers that need the release binary specifically (e.g. because a sibling
 /// helper in the same file already assumes it, or the test predates
 /// `CARGO_BIN_EXE_wfl` and was never migrated) use this instead.
-pub fn wfl_release_exe() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
+///
+/// Unlike [`wfl_exe`], this binary is **not** built by `cargo test`; it has to
+/// exist already. The path is anchored to `CARGO_MANIFEST_DIR` rather than a
+/// bare relative path so it does not depend on the test process's working
+/// directory, and a missing binary fails with an actionable message instead of
+/// a bare `Os { code: 2, kind: NotFound }` from the eventual spawn.
+pub fn wfl_release_exe() -> PathBuf {
+    let name = if cfg!(target_os = "windows") {
+        "wfl.exe"
     } else {
-        "target/release/wfl"
-    }
+        "wfl"
+    };
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("release")
+        .join(name);
+    assert!(
+        path.exists(),
+        "release binary not found at {}\n\
+         This test runs the separately-built release binary; `cargo test` does not build it.\n\
+         Run `cargo build --release` first.",
+        path.display()
+    );
+    path
 }
 
 /// Run inline WFL source (via [`wfl_exe`]) in a fresh temp dir, returning

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,6 +3,11 @@
 
 use std::net::TcpListener;
 
+use wfl::interpreter::Interpreter;
+use wfl::interpreter::value::Value;
+use wfl::lexer::lex_wfl_with_positions;
+use wfl::parser::Parser;
+
 /// Ask the OS for a currently-free TCP port on loopback, then release it so the
 /// caller can bind it via WFL's `listen on port <N>`.
 ///
@@ -18,4 +23,125 @@ pub fn free_tcp_port() -> u16 {
         .local_addr()
         .expect("read the ephemeral local address")
         .port()
+}
+
+// ---------------------------------------------------------------------------
+// Shape A: run WFL source, get back `Result<Interpreter, String>` for
+// inspecting arbitrary globals afterwards.
+// ---------------------------------------------------------------------------
+
+/// Run WFL code and return the interpreter for inspecting globals.
+pub async fn run_wfl(code: &str) -> Result<Interpreter, String> {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
+
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&ast)
+        .await
+        .map_err(|e| format!("Runtime error: {e:?}"))?;
+    Ok(interpreter)
+}
+
+pub fn get_global(interpreter: &Interpreter, name: &str) -> Value {
+    interpreter
+        .global_env()
+        .borrow()
+        .get(name)
+        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
+}
+
+pub fn expect_text(value: &Value) -> String {
+    match value {
+        Value::Text(t) => t.to_string(),
+        other => panic!("Expected text, got {other:?}"),
+    }
+}
+
+pub fn expect_number(value: &Value) -> f64 {
+    match value {
+        Value::Number(n) => *n,
+        other => panic!("Expected number, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape B: run WFL source, get back `Result<Value, String>` read from the
+// `result` global.
+// ---------------------------------------------------------------------------
+
+/// Run WFL code and return the value stored in the `result` global.
+pub async fn run_wfl_code(code: &str) -> Result<Value, String> {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
+
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&ast)
+        .await
+        .map_err(|e| format!("Runtime error: {e:?}"))?;
+
+    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
+        Ok(result_value)
+    } else {
+        Err("Variable 'result' not found after execution".to_string())
+    }
+}
+
+pub fn expect_text_result(result: Result<Value, String>) -> String {
+    match result {
+        Ok(Value::Text(t)) => t.to_string(),
+        other => panic!("Expected text result, got {other:?}"),
+    }
+}
+
+pub fn expect_bool_result(result: Result<Value, String>) -> bool {
+    match result {
+        Ok(Value::Bool(b)) => b,
+        other => panic!("Expected bool result, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shape C: run WFL source, get back a bare `Interpreter` — parse/runtime
+// errors panic immediately instead of being returned.
+// ---------------------------------------------------------------------------
+
+/// Run WFL code and return the interpreter, panicking on parse/runtime errors.
+pub async fn run_wfl_ok(code: &str) -> Interpreter {
+    let tokens = lex_wfl_with_positions(code);
+    let mut parser = Parser::new(&tokens);
+    let program = parser
+        .parse()
+        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
+    let mut interpreter = Interpreter::new();
+    interpreter
+        .interpret(&program)
+        .await
+        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
+    interpreter
+}
+
+pub fn get_var(interpreter: &Interpreter, name: &str) -> Value {
+    interpreter
+        .global_env()
+        .borrow()
+        .get(name)
+        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
+}
+
+pub fn get_text(interpreter: &Interpreter, name: &str) -> String {
+    match get_var(interpreter, name) {
+        Value::Text(t) => t.to_string(),
+        other => panic!("Expected '{name}' to be text, got {other:?}"),
+    }
+}
+
+pub fn get_number(interpreter: &Interpreter, name: &str) -> f64 {
+    match get_var(interpreter, name) {
+        Value::Number(n) => n,
+        other => panic!("Expected '{name}' to be a number, got {other:?}"),
+    }
 }

--- a/tests/crypto_kdf_test.rs
+++ b/tests/crypto_kdf_test.rs
@@ -7,45 +7,8 @@
 // byte generation into native Rust so WFL auth/session code has a correct,
 // non-DoS-prone primitive instead of hand-rolling them in interpreted WFL.
 
-use wfl::interpreter::Interpreter;
-use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
-
-/// Run WFL source and return the value stored in the `result` variable.
-async fn run_wfl_code(code: &str) -> Result<Value, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser
-        .parse()
-        .map_err(|e| format!("Parse error: {:?}", e))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {:?}", e))?;
-
-    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
-        Ok(result_value)
-    } else {
-        Err("Variable 'result' not found after execution".to_string())
-    }
-}
-
-fn expect_text(result: Result<Value, String>) -> String {
-    match result {
-        Ok(Value::Text(t)) => t.to_string(),
-        other => panic!("Expected text result, got {:?}", other),
-    }
-}
-
-fn expect_bool(result: Result<Value, String>) -> bool {
-    match result {
-        Ok(Value::Bool(b)) => b,
-        other => panic!("Expected boolean result, got {:?}", other),
-    }
-}
+mod common;
+use common::{expect_bool_result as expect_bool, expect_text_result as expect_text, run_wfl_code};
 
 // === PBKDF2-HMAC-SHA256 (well-known / RFC-style vectors) ===
 // Vectors: P="password", S="salt". These are the canonical PBKDF2-HMAC-SHA256

--- a/tests/crypto_seal_test.rs
+++ b/tests/crypto_seal_test.rs
@@ -5,38 +5,8 @@
 // blob, or a mismatched context must all be rejected, and rejected the same way,
 // so `unseal` never becomes an oracle that distinguishes one failure from another.
 
-use wfl::interpreter::Interpreter;
-use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
-
-async fn run_wfl(code: &str) -> Result<Interpreter, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {e:?}"))?;
-    Ok(interpreter)
-}
-
-fn get_global(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn expect_text(value: &Value) -> String {
-    match value {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected text, got {other:?}"),
-    }
-}
+mod common;
+use common::{expect_text, get_global, run_wfl};
 
 /// A valid 32-byte key as 64 hex characters — the shape `secure_random_bytes of 32` returns.
 const KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";

--- a/tests/database_test.rs
+++ b/tests/database_test.rs
@@ -5,48 +5,10 @@
 // skip with a notice when unset (same pattern as WFLHASH_HEAVY_TESTS).
 
 use std::path::PathBuf;
-use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
 
-/// Run WFL code and return the interpreter for inspecting globals.
-async fn run_wfl(code: &str) -> Result<Interpreter, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser
-        .parse()
-        .map_err(|e| format!("Parse error: {:?}", e))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {:?}", e))?;
-    Ok(interpreter)
-}
-
-fn get_global(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn expect_number(value: &Value) -> f64 {
-    match value {
-        Value::Number(n) => *n,
-        other => panic!("Expected number, got {other:?}"),
-    }
-}
-
-fn expect_text(value: &Value) -> String {
-    match value {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected text, got {other:?}"),
-    }
-}
+mod common;
+use common::{expect_number, expect_text, get_global, run_wfl};
 
 fn expect_object_key(value: &Value, key: &str) -> Value {
     match value {

--- a/tests/database_transaction_test.rs
+++ b/tests/database_transaction_test.rs
@@ -8,39 +8,10 @@
 // production. Every atomicity assertion here therefore runs against a temp file.
 
 use std::path::{Path, PathBuf};
-use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
 
-/// Run WFL code and return the interpreter for inspecting globals.
-async fn run_wfl(code: &str) -> Result<Interpreter, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {e:?}"))?;
-    Ok(interpreter)
-}
-
-fn get_global(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn expect_number(value: &Value) -> f64 {
-    match value {
-        Value::Number(n) => *n,
-        other => panic!("Expected number, got {other:?}"),
-    }
-}
+mod common;
+use common::{expect_number, get_global, run_wfl};
 
 fn expect_list(value: &Value) -> Vec<Value> {
     match value {

--- a/tests/docs_parser_and_include_fixes_test.rs
+++ b/tests/docs_parser_and_include_fixes_test.rs
@@ -14,13 +14,8 @@ use std::fs;
 use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    }
-}
+mod common;
+use common::wfl_release_exe;
 
 /// Run a single WFL program (written to a temp file) and return combined
 /// stdout + stderr.
@@ -35,7 +30,7 @@ fn run_wfl(code: &str) -> String {
 /// sibling modules), returning combined stdout + stderr.
 fn run_file(dir: &TempDir, name: &str) -> String {
     let path = dir.path().join(name);
-    let output = Command::new(wfl_exe())
+    let output = Command::new(wfl_release_exe())
         .arg(&path)
         .output()
         .expect("Failed to execute WFL");
@@ -49,7 +44,7 @@ fn analyze_wfl(code: &str) -> String {
     let dir = TempDir::new().expect("tempdir");
     let main = dir.path().join("main.wfl");
     fs::write(&main, code).expect("write");
-    let output = Command::new(wfl_exe())
+    let output = Command::new(wfl_release_exe())
         .arg("--analyze")
         .arg(&main)
         .output()
@@ -243,7 +238,7 @@ fn undefined_action_with_include_is_surfaced_as_warning() {
     )
     .unwrap();
 
-    let output = Command::new(wfl_exe())
+    let output = Command::new(wfl_release_exe())
         .arg("--analyze")
         .arg(&main)
         .output()

--- a/tests/filesystem_mode_test.rs
+++ b/tests/filesystem_mode_test.rs
@@ -9,38 +9,10 @@
 // unsupported error — never a silent no-op, which is the failure mode the issue
 // complains about.
 
-use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
 
-async fn run_wfl(code: &str) -> Result<Interpreter, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {e:?}"))?;
-    Ok(interpreter)
-}
-
-fn get_global(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn expect_text(value: &Value) -> String {
-    match value {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected text, got {other:?}"),
-    }
-}
+mod common;
+use common::{expect_text, get_global, run_wfl};
 
 /// Create a temp file with some content and return its WFL-safe path string.
 fn temp_file(name: &str) -> (tempfile::TempDir, String) {

--- a/tests/flush_action_backcompat_test.rs
+++ b/tests/flush_action_backcompat_test.rs
@@ -7,28 +7,12 @@
 //! merged `flush …` tokens to the streaming flush; it must still prefer a defined
 //! action of that full name so an existing program keeps working.
 
-use std::fs;
-use std::process::Command;
-use tempfile::TempDir;
 use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
 use wfl::typechecker::TypeChecker;
 
-fn run_src(src: &str) -> (String, Option<i32>) {
-    let dir = TempDir::new().expect("tempdir");
-    let path = dir.path().join("main.wfl");
-    fs::write(&path, src).unwrap();
-    let output = Command::new(env!("CARGO_BIN_EXE_wfl"))
-        .arg(&path)
-        .output()
-        .expect("failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    (combined, output.status.code())
-}
+mod common;
+use common::run_src;
 
 #[test]
 fn flush_calls_a_matching_zero_arg_action_instead_of_flushing_a_stream() {

--- a/tests/github_issues_batch_test.rs
+++ b/tests/github_issues_batch_test.rs
@@ -22,31 +22,8 @@ use std::fs;
 use std::process::Command;
 use tempfile::TempDir;
 
-/// Absolute path to the `wfl` binary built for this integration-test run.
-/// `CARGO_BIN_EXE_wfl` is injected by Cargo, so it always points at the
-/// freshly-built binary regardless of profile or working directory — no stale
-/// `target/release` build and no cwd assumption.
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
-
-/// Run inline WFL source in a fresh temp dir, returning (stdout+stderr, exit code).
-fn run_src(src: &str) -> (String, Option<i32>) {
-    let dir = TempDir::new().expect("tempdir");
-    let path = dir.path().join("main.wfl");
-    fs::write(&path, src).unwrap();
-    let output = Command::new(wfl_exe())
-        .arg(&path)
-        .output()
-        .expect("failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    drop(dir);
-    (combined, output.status.code())
-}
+mod common;
+use common::{run_src, wfl_exe};
 
 // ---------------------------------------------------------------------------
 // #583 — a quoted "[]" string stays Text

--- a/tests/http_request_runtime_test.rs
+++ b/tests/http_request_runtime_test.rs
@@ -12,6 +12,9 @@ use wfl::interpreter::value::Value;
 use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
 
+mod common;
+use common::{get_text, get_var, run_wfl_ok as run_wfl};
+
 /// Captured request: (request line + headers, body)
 type CapturedRequest = (String, String);
 
@@ -76,36 +79,6 @@ async fn spawn_echo_server() -> (String, tokio::task::JoinHandle<CapturedRequest
     });
 
     (format!("http://{addr}"), handle)
-}
-
-async fn run_wfl(code: &str) -> Interpreter {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let program = parser
-        .parse()
-        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&program)
-        .await
-        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
-    interpreter
-}
-
-fn get_var(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn get_text(interpreter: &Interpreter, name: &str) -> String {
-    match get_var(interpreter, name) {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected '{name}' to be text, got {other:?}"),
-    }
 }
 
 #[tokio::test]

--- a/tests/http_stream_paced_test.rs
+++ b/tests/http_stream_paced_test.rs
@@ -18,10 +18,8 @@ use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 
-use wfl::interpreter::Interpreter;
-use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
+mod common;
+use common::{get_number, get_text, run_wfl_ok as run_wfl};
 
 /// One chunked-encoding frame for `payload` + `\n`.
 fn chunk_frame(payload: &str) -> String {
@@ -31,42 +29,6 @@ fn chunk_frame(payload: &str) -> String {
 
 const CHUNKED_HEAD: &[u8] =
     b"HTTP/1.1 200 OK\r\nContent-Type: application/x-ndjson\r\nTransfer-Encoding: chunked\r\n\r\n";
-
-async fn run_wfl(code: &str) -> Interpreter {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let program = parser
-        .parse()
-        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&program)
-        .await
-        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
-    interpreter
-}
-
-fn get_var(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn get_number(interpreter: &Interpreter, name: &str) -> f64 {
-    match get_var(interpreter, name) {
-        Value::Number(n) => n,
-        other => panic!("Expected '{name}' to be a number, got {other:?}"),
-    }
-}
-
-fn get_text(interpreter: &Interpreter, name: &str) -> String {
-    match get_var(interpreter, name) {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected '{name}' to be text, got {other:?}"),
-    }
-}
 
 /// A chunk that arrives strictly AFTER the program has consumed everything
 /// sent so far must wake the parked read and be delivered.

--- a/tests/http_stream_test.rs
+++ b/tests/http_stream_test.rs
@@ -16,6 +16,9 @@ use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
 use wfl::parser::ast::Statement;
 
+mod common;
+use common::{get_text, get_var, run_wfl_ok as run_wfl};
+
 // ----------------------------- parser tests ------------------------------
 
 fn parse_single_statement(code: &str) -> Statement {
@@ -129,35 +132,6 @@ async fn spawn_body_server(body: &'static str) -> String {
         socket.shutdown().await.ok();
     });
     format!("http://{addr}")
-}
-
-async fn run_wfl(code: &str) -> Interpreter {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let program = parser
-        .parse()
-        .unwrap_or_else(|e| panic!("Parse error: {e:?}"));
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&program)
-        .await
-        .unwrap_or_else(|e| panic!("Runtime error: {e:?}"));
-    interpreter
-}
-
-fn get_var(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn get_text(interpreter: &Interpreter, name: &str) -> String {
-    match get_var(interpreter, name) {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected '{name}' to be text, got {other:?}"),
-    }
 }
 
 #[tokio::test]

--- a/tests/include_of_form_resolution_test.rs
+++ b/tests/include_of_form_resolution_test.rs
@@ -15,33 +15,10 @@
 //! still surfaced (fatal without includes, warning with includes).
 
 use std::fs;
-use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    }
-}
-
-/// Run a WFL file inside `dir` (so `include from` resolves sibling modules),
-/// returning (combined stdout+stderr, exit code).
-fn run_file_status(dir: &TempDir, name: &str, extra_args: &[&str]) -> (String, Option<i32>) {
-    let path = dir.path().join(name);
-    let output = Command::new(wfl_exe())
-        .args(extra_args)
-        .arg(&path)
-        .output()
-        .expect("Failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    (combined, output.status.code())
-}
+mod common;
+use common::run_file_status;
 
 /// Write a `mod.wfl` exposing a one-arg `greet` action next to a `main.wfl`
 /// whose body is `main_body`, then run `main.wfl`.

--- a/tests/load_module_undefined_hint_test.rs
+++ b/tests/load_module_undefined_hint_test.rs
@@ -15,33 +15,10 @@
 //! definitions. This suite pins that behavior and guards the boundaries.
 
 use std::fs;
-use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    }
-}
-
-/// Run a WFL file inside `dir` (so module paths resolve to sibling files),
-/// returning (combined stdout+stderr, exit code).
-fn run_file_status(dir: &TempDir, name: &str, extra_args: &[&str]) -> (String, Option<i32>) {
-    let path = dir.path().join(name);
-    let output = Command::new(wfl_exe())
-        .args(extra_args)
-        .arg(&path)
-        .output()
-        .expect("Failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    (combined, output.status.code())
-}
+mod common;
+use common::run_file_status;
 
 /// Write a `lib_mod.wfl` exposing a one-arg `mod_double` action next to a
 /// `main_mod.wfl` whose body is `main_body`, then run `main_mod.wfl`.

--- a/tests/package_protocol_removed_test.rs
+++ b/tests/package_protocol_removed_test.rs
@@ -20,9 +20,8 @@ use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
+mod common;
+use common::wfl_exe;
 
 /// Run `wfl <args...>` with `dir` as the working directory.
 /// Returns (stdout, stderr, exit code).

--- a/tests/password_hashing_test.rs
+++ b/tests/password_hashing_test.rs
@@ -3,45 +3,8 @@
 // storing passwords. These builtins add slow, salted, memory/CPU-hard password
 // hashes that produce self-describing PHC/MCF strings and verify in constant time.
 
-use wfl::interpreter::Interpreter;
-use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
-
-/// Run WFL code and return the value stored in `result`.
-async fn run_wfl_code(code: &str) -> Result<Value, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser
-        .parse()
-        .map_err(|e| format!("Parse error: {:?}", e))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {:?}", e))?;
-
-    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
-        Ok(result_value)
-    } else {
-        Err("Variable 'result' not found after execution".to_string())
-    }
-}
-
-fn expect_text(result: Result<Value, String>) -> String {
-    match result {
-        Ok(Value::Text(t)) => t.to_string(),
-        other => panic!("Expected text result, got {:?}", other),
-    }
-}
-
-fn expect_bool(result: Result<Value, String>) -> bool {
-    match result {
-        Ok(Value::Bool(b)) => b,
-        other => panic!("Expected bool result, got {:?}", other),
-    }
-}
+mod common;
+use common::{expect_bool_result as expect_bool, expect_text_result as expect_text, run_wfl_code};
 
 // === Generic password hashing (Argon2id default) ===
 

--- a/tests/phase1_correctness_regression_test.rs
+++ b/tests/phase1_correctness_regression_test.rs
@@ -78,16 +78,8 @@ use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 use tempfile::{NamedTempFile, TempDir};
 
-/// Absolute path to the `wfl` binary Cargo built for this test run. It matches
-/// the profile the test itself is compiled with: the **debug** binary under a
-/// plain `cargo test` / `cargo test --workspace` (what CI's test job runs), or
-/// the **release** binary under `cargo test --release`. Either way
-/// `CARGO_BIN_EXE_wfl` points at the freshly-built one, so there is no
-/// stale-binary risk. (These regression programs are tiny, so the debug/release
-/// distinction doesn't affect their outcome.)
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
+mod common;
+use common::wfl_exe;
 
 /// Hard wall-clock cap for a single program run. A regression that loops or
 /// hangs is killed here instead of consuming the whole job timeout.

--- a/tests/property_index_access_test.rs
+++ b/tests/property_index_access_test.rs
@@ -8,38 +8,16 @@
 //! `ct` was bound to the whole `headers` map. This proves both the AST shape
 //! (one `IndexAccess` over the `PropertyAccess`) and the runtime value.
 
-use std::fs;
-use std::process::Command;
-use tempfile::TempDir;
 use wfl::lexer::lex_wfl_with_positions;
 use wfl::parser::Parser;
 use wfl::parser::ast::{Expression, Literal, Statement};
 
+mod common;
+use common::run_src;
+
 fn parse(src: &str) -> wfl::parser::ast::Program {
     let tokens = lex_wfl_with_positions(src);
     Parser::new(&tokens).parse().expect("parse should succeed")
-}
-
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
-
-/// Run inline WFL source, returning (stdout+stderr, exit code).
-fn run_src(src: &str) -> (String, Option<i32>) {
-    let dir = TempDir::new().expect("tempdir");
-    let path = dir.path().join("main.wfl");
-    fs::write(&path, src).unwrap();
-    let output = Command::new(wfl_exe())
-        .arg(&path)
-        .output()
-        .expect("failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    drop(dir);
-    (combined, output.status.code())
 }
 
 #[test]

--- a/tests/sha256_hmac_test.rs
+++ b/tests/sha256_hmac_test.rs
@@ -1,38 +1,8 @@
 // TDD Tests for standard SHA-256 and HMAC-SHA256 builtins (issue #558)
 // Webhook verification (e.g. Stripe) requires standard HMAC-SHA256, not just WFLHASH.
 
-use wfl::interpreter::Interpreter;
-use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
-
-/// Test helper to run WFL code and get the result from a variable
-async fn run_wfl_code(code: &str) -> Result<Value, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser
-        .parse()
-        .map_err(|e| format!("Parse error: {:?}", e))?;
-
-    let mut interpreter = Interpreter::new();
-    let _ = interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {:?}", e))?;
-
-    if let Some(result_value) = interpreter.global_env().borrow().get("result") {
-        Ok(result_value)
-    } else {
-        Err("Variable 'result' not found after execution".to_string())
-    }
-}
-
-fn expect_text(result: Result<Value, String>) -> String {
-    match result {
-        Ok(Value::Text(t)) => t.to_string(),
-        other => panic!("Expected text result, got {:?}", other),
-    }
-}
+mod common;
+use common::{expect_text_result as expect_text, run_wfl_code};
 
 // === SHA-256 (FIPS 180-4 / well-known vectors) ===
 

--- a/tests/subprocess_security_test.rs
+++ b/tests/subprocess_security_test.rs
@@ -4,6 +4,9 @@ use std::thread;
 use std::time::Duration;
 use tempfile::TempDir;
 
+mod common;
+use common::wfl_release_exe;
+
 /// Temp directory holding a `.wfl` program and optional `.wflcfg` so config walk-up works.
 struct TempWflEnv {
     _dir: TempDir,
@@ -53,14 +56,6 @@ allowed_shell_commands = where.exe
 warn_on_shell_execution = false
 "#;
 
-fn wfl_exe() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "target/release/wfl.exe"
-    } else {
-        "target/release/wfl"
-    }
-}
-
 fn run_wfl(code: &str) -> Result<String, String> {
     run_wfl_with_config(code, None)
 }
@@ -68,7 +63,7 @@ fn run_wfl(code: &str) -> Result<String, String> {
 fn run_wfl_with_config(code: &str, config: Option<&str>) -> Result<String, String> {
     let env = TempWflEnv::new(code, config).expect("Failed to create temp WFL env");
 
-    let output = Command::new(wfl_exe())
+    let output = Command::new(wfl_release_exe())
         .arg(env.path())
         .output()
         .expect("Failed to execute WFL");

--- a/tests/toml_test.rs
+++ b/tests/toml_test.rs
@@ -7,45 +7,10 @@
 // R3 (untrusted input): config text is attacker-reachable, so malformed input
 // must produce a clean error rather than a panic.
 
-use wfl::interpreter::Interpreter;
 use wfl::interpreter::value::Value;
-use wfl::lexer::lex_wfl_with_positions;
-use wfl::parser::Parser;
 
-async fn run_wfl(code: &str) -> Result<Interpreter, String> {
-    let tokens = lex_wfl_with_positions(code);
-    let mut parser = Parser::new(&tokens);
-    let ast = parser.parse().map_err(|e| format!("Parse error: {e:?}"))?;
-
-    let mut interpreter = Interpreter::new();
-    interpreter
-        .interpret(&ast)
-        .await
-        .map_err(|e| format!("Runtime error: {e:?}"))?;
-    Ok(interpreter)
-}
-
-fn get_global(interpreter: &Interpreter, name: &str) -> Value {
-    interpreter
-        .global_env()
-        .borrow()
-        .get(name)
-        .unwrap_or_else(|| panic!("Variable '{name}' not found"))
-}
-
-fn expect_text(value: &Value) -> String {
-    match value {
-        Value::Text(t) => t.to_string(),
-        other => panic!("Expected text, got {other:?}"),
-    }
-}
-
-fn expect_number(value: &Value) -> f64 {
-    match value {
-        Value::Number(n) => *n,
-        other => panic!("Expected number, got {other:?}"),
-    }
-}
+mod common;
+use common::{expect_number, expect_text, get_global, run_wfl};
 
 // ---------------------------------------------------------------------------
 // Parsing — the priority half of the issue.

--- a/tests/transpiler_sunset_test.rs
+++ b/tests/transpiler_sunset_test.rs
@@ -13,9 +13,8 @@ use std::fs;
 use std::process::Command;
 use tempfile::TempDir;
 
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
+mod common;
+use common::wfl_exe;
 
 const SAMPLE: &str = "store greeting as \"Hello\"\ndisplay greeting\n";
 

--- a/tests/wfl_version_builtin_test.rs
+++ b/tests/wfl_version_builtin_test.rs
@@ -7,31 +7,8 @@
 //! the bare semver text of `wfl::version::VERSION` (mirroring how `newline` and
 //! `tab` are exposed).
 
-use std::fs;
-use std::process::Command;
-use tempfile::TempDir;
-
-fn wfl_exe() -> &'static str {
-    env!("CARGO_BIN_EXE_wfl")
-}
-
-/// Run inline WFL source in a fresh temp dir, returning (stdout+stderr, exit code).
-fn run_src(src: &str) -> (String, Option<i32>) {
-    let dir = TempDir::new().expect("tempdir");
-    let path = dir.path().join("main.wfl");
-    fs::write(&path, src).unwrap();
-    let output = Command::new(wfl_exe())
-        .arg(&path)
-        .output()
-        .expect("failed to execute WFL");
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    drop(dir);
-    (combined, output.status.code())
-}
+mod common;
+use common::run_src;
 
 /// `wfl_version` resolves to the running interpreter's semver text and matches
 /// the compiled-in constant exactly.


### PR DESCRIPTION
## Summary

Centralizes duplicated Rust test-harness code into `tests/common/mod.rs` and cuts test debug info. The headline outcome is that **`cargo test --all` went from unbuildable to green**: on `main` it exits 101 without running a single test, dying at the link step with `collect2: fatal error: ld terminated with signal 7 [Bus error]` after filling the disk. 143 top-level `tests/*.rs` files each statically link the whole compiler at ~165 MB apiece, which exceeds a 30 GB environment's entire allowance.

Produced by the `test-shrink` skill. Full write-up in `History/dev-diary/2026/2026-08-14-test-shrink-pass.md`.

## Metrics

| Metric | Before | After |
|---|---|---|
| `cargo test --all` | **failed to link**, 0 tests ran | **2096 passed, 0 failed, 27 ignored** |
| All test binaries | 25.13 GB (156, incomplete) | **11.22 GB** (180, complete) |
| Mean per test binary | 165 MB | **63.9 MB** (−61%) |
| `target/` | 27 G | 17 G |
| Test source lines | 42,940 | **42,629** (−311) |
| `tests/common/mod.rs` | 21 lines, 1 helper | 14 shared helpers |
| Integration (`TestPrograms/`) | not reachable | 136 passed, 0 failed, 24 skipped |
| Full-suite wall time | n/a | 106–210 s |

The binary comparison is conservative: the "before" 25.13 GB was an *incomplete* set because the build died partway. The complete 180-target set at the old mean would have been ~29.7 GB.

## Changes

**C1 — `debug = "line-tables-only"` on `[profile.test]`** (`6f4c686`, corrected in `8b03b34`)

Test binary 199.5 MB → 56.1 MB; `libwfl-*.rlib` 291.0 MB → 85.5 MB. This is what makes everything else possible.

Scoped to `[profile.test]` **only**. The first version of this change also set `[profile.dev]`, on the belief that integration-test binaries link the library as a *dev*-profile dependency. That belief is wrong — Codex caught it in review. Under `cargo test` the **entire** build graph (local library, `wfl` binary, and every external dependency) is built with the `test` profile. Verified with a throwaway crate using deliberately different values (`[profile.dev] debug = 0`, `[profile.test] debug = 2`): the plain `--crate-type lib` rlib *and* an external path dependency both compiled at `-C debuginfo=2`, never dev's `0`. Confirmed here too — removing the dev override left the test binary at 56.1 MB and the rlib at 85.5 MB, byte-identical. So `[profile.dev]` stays at full debug info and ordinary `cargo build` / `cargo run` binaries remain fully inspectable in a debugger.

No `strip` was added — it would remove the very line tables this keeps. `[profile.release]` is untouched; its `debug = true` stays deliberate.

Readable-panic check passed — a deliberately broken assertion still reports its location:

```
thread 'test_explicit_token_stream_analysis' panicked at
tests/colon_consumption_test.rs:69:5
```

**C2 — hoist in-memory WFL drivers** (`12f727b`) — 12 files, net −229 lines. Three driver shapes (`run_wfl`, `run_wfl_code`, `run_wfl_ok`) plus shared value accessors. `http_connection_reuse_retry_test.rs` was deliberately left alone: its `get_text` matches `Option<Value>` directly instead of routing through a panicking `get_var`, so the missing-variable path genuinely differs.

**C3 — hoist the real-binary spawn harness** (`d1b8aef`) — 13 files, net −82 lines. The real CLI boundary is preserved everywhere; no test was converted to an in-memory driver.

The trap here: the two original `wfl_exe()` variants resolve to **different binaries** — `env!("CARGO_BIN_EXE_wfl")` is the profile-matched test binary, while the hardcoded path is the separately built `target/release/wfl`. They are kept as two helpers (`wfl_exe` / `wfl_release_exe`) and every call site retains the binary it used before. Unifying them would have silently changed what several tests exercise.

**Review fixes** (`8b03b34`) — the `[profile.dev]` removal above, plus `wfl_release_exe()` hardening flagged independently by Devin and Copilot: it now returns a `PathBuf` anchored to `CARGO_MANIFEST_DIR` (no working-directory dependency) and asserts the binary exists, failing with `Run 'cargo build --release' first` instead of a bare `Os { code: 2, kind: NotFound }`.

## Coverage evidence

For C2 and C3, a before/after `cargo test -- --list` test-name inventory was captured per target and diffed line by line: **byte-identical every time**. The full-suite count held at 2096 throughout.

## Not done deliberately

**No test merges.** Every same-named family (`concurrent_*`, `crypto_*`/`wflhash_*`, `database_*`, `web_server_tls*`, `*_backcompat_*`) was read, and no pair was found where one file's assertions are provably a subset of another's. Shared test names across `web_server_tls_test` and `web_server_tls_parser_test` are deliberate dual-layer coverage, which the testing policy explicitly wants.

**Print/noise removal was demoted.** `cargo test` captures and discards stdout for passing tests, so `println!` in test bodies costs ~0 bytes on a green run.

## Follow-ups filed

- **#692** — three test-harness defects found along the way: a genuinely flaky `test_capture_process_output` (fixed 200 ms sleep), `cargo test --all` silently depending on a prior `cargo build --release`, and 30 file-I/O tests that leak files into the repo root on failure.
- **#693** — binary consolidation, the largest remaining win, with the pilot batch specified and hazard-scanned.

## Gates

Run individually before each commit, and again on `8b03b34`:

- `cargo test --all` — 2096 passed / 0 failed / 27 ignored (159 suites)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `./scripts/run_integration_tests.sh` — 136 passed / 0 failed / 24 skipped
- `python3 scripts/check_repo_hygiene.py --mode static` — exit 0

https://claude.ai/code/session_018znV7g9Wg8hurw1C8kaL8j

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/694" rel="nofollow noreferrer noopener" target="_blank">
  ``&lt;img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review"&gt;``
</a>