### PR TITLE
fix(deps): bump js-yaml override to 4.3.1 (clears the last open Dependabot alert, GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/vscode-extension/package-lock.json
+++ b/vscode-extension/package-lock.json
@@ -1907,9 +1907,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -174,7 +174,7 @@
     "@vscode/test-electron": "^2.5.2"
   },
   "overrides": {
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "serialize-javascript": "7.0.6"
   }
 }


### PR DESCRIPTION
## What

Bumps the `js-yaml` override in `vscode-extension/package.json` from **4.3.0 → 4.3.1** and regenerates the lockfile.

## Why

Dependabot alert **#69** (HIGH, [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), *quadratic CPU consumption in `!!omap` resolution*) covers js-yaml 3.x and 4.x below **4.3.1**. The repo already carries a `js-yaml` override — it was pinned at 4.3.0 to clear the *previous* advisory on 2026-07-31 — so the pin exists but is now one patch short of the current one.

This is the **only** open Dependabot alert on the repository. The long-standing structural `rustls-webpki` cluster (8 alerts) and the `brace-expansion` cluster (10) were both resolved on 2026-07-31 and 2026-07-26 respectively, so merging this takes the repo to **zero open alerts**.

## Root cause of the pin still being needed

`js-yaml` is a **dev-only transitive** dependency reached two ways:

```
eslint@8.57.1 → @eslint/eslintrc@2.1.4 → js-yaml
@vscode/test-cli@0.0.10 → mocha@10.8.2 → js-yaml
```

Neither parent has released a version that moves off the affected range, which is why the override exists rather than a straight dependency bump. Both parents accept 4.3.1, so it dedupes to a single copy with no parent bumps required.

## Verification

Run locally against a clean tree:

- `npm install --package-lock-only` regenerated the entry with the registry integrity hash for 4.3.1 (`sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==`).
- `npm ci` succeeds from scratch — 270 packages, exit 0, no peer or range conflicts.
- `npm ls js-yaml` resolves all three consumers to 4.3.1, deduped:
  ```
  ├─┬ @vscode/test-cli@0.0.10 → mocha@10.8.2 → js-yaml@4.3.1 deduped
  └─┬ eslint@8.57.1
    ├─┬ @eslint/eslintrc@2.1.4 → js-yaml@4.3.1 deduped
    └── js-yaml@4.3.1 overridden
  ```

Diff is 4 lines across 2 files — the override value and the lockfile's version/resolved/integrity triple. No shipped Rust code, no workflow, no `TestPrograms/` behaviour is touched.

## Testing policy

**R0** under root `testing.md` — a dependency-pin change with no behavioral surface in shipped code. No red-first test is manufactured; the existing lint and test lanes are the check, per the pure-CI-mechanics carve-out.

## ⚠️ CI cannot verify this right now

GitHub Actions on this repo has been failing at **startup** since ~04:00 UTC today — `CI`, `Nightly Build`, `Auto Format` and `WFL Config Lint` all return `startup_failure` with zero jobs created, because the Actions allowlist was narrowed and now blocks `dtolnay/rust-toolchain` and `Swatinem/rust-cache`. Full diagnosis in **#695**.

So this PR will show no CI signal until #695 is resolved. **Please re-run checks on this branch after fixing the allowlist, before merging.** The change is verified locally as described above, but "green because nothing ran" is not green.

Refs #695

*Opened by the WFL repo warden (automated triage pass). Not merged — merging is a human decision.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the YAML parsing dependency to version 4.3.1 for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->