### PR TITLE
fix(test): gate Value import behind cfg(unix) — unbreaks the nightly Windows job

### DIFF
--- a/tests/filesystem_mode_test.rs
+++ b/tests/filesystem_mode_test.rs
@@ -9,6 +9,9 @@
 // unsupported error — never a silent no-op, which is the failure mode the issue
 // complains about.
 
+// `Value` is only referenced from the `unix` module below; on Windows the import
+// would be dead and `-D warnings` rejects it.
+#[cfg(unix)]
 use wfl::interpreter::value::Value;
 
 mod common;


### PR DESCRIPTION
## What

One line: gate `use wfl::interpreter::value::Value;` in `tests/filesystem_mode_test.rs` behind `#[cfg(unix)]`.

## Why

Nightly run [31795283997](https://github.com/WebFirstLanguage/wfl/actions/runs/31795283997) failed the **Build WFL for Windows** job at the clippy step:

```
error: unused import: `wfl::interpreter::value::Value`
  --> tests\filesystem_mode_test.rs:12:5
   = note: `-D unused-imports` implied by `-D warnings`
error: could not compile `wfl` (test "filesystem_mode_test") due to 1 previous error
```

#694 consolidated the test helpers into `tests/common/mod.rs`, deleting the top-level `get_global(..) -> Value` and `expect_text(&Value)`. Those were the platform-independent uses of `Value`. The only surviving reference is at line 132, inside `#[cfg(unix)] mod unix` — so the import is live on Unix and dead on Windows. Linux passed; Windows failed.

**This reached `main` because #694 merged during the Actions allowlist outage (#695) with zero CI.** Its run was a `startup_failure`, so no clippy job ever ran. This is the concrete cost of that outage rather than just the red X's.

## Risk class

**R0** — test-only, no runtime or public behavior change, no backward-compatibility surface.

## Acceptance criteria → tests

| Criterion | Evidence |
|---|---|
| Windows clippy is clean under `-D warnings` | `cargo clippy --test filesystem_mode_test --all-features -- -D warnings` |
| The file's tests still pass on Windows | `cargo test --test filesystem_mode_test --all-features` — 4 passed, 0 failed |
| Unix coverage is unchanged | `Value` is still imported under `cfg(unix)`; the `unix` module is untouched |
| Formatting | `cargo fmt --all -- --check` clean |

## Red → Green evidence

Reproduced on a real Windows host (win32, MSVC), matching the CI failure exactly.

**Red** — before the change:
```
error: unused import: `wfl::interpreter::value::Value`
  --> tests\filesystem_mode_test.rs:12:5
error: could not compile `wfl` (test "filesystem_mode_test") due to 1 previous error
```

**Green** — after:
```
    Checking wfl v26.8.2 (G:\repos\wfl)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.51s

running 4 tests
test file_mode_on_a_missing_path_errors ... ok
test windows::file_mode_still_returns_an_approximation ... ok
test file_mode_reads_a_four_character_octal_string ... ok
test windows::set_file_mode_reports_that_it_is_unsupported ... ok
test result: ok. 4 passed; 0 failed
```

## Residual risk

None meaningful. If a future change adds a platform-independent use of `Value` to this file, the `cfg(unix)` gate will surface immediately as an unresolved-name compile error on Windows, not a silent gap.

Refs #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->