### PR TITLE
ci: bump actions/setup-python v4 -> v5 (clears the node16 runner deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Checker unit tests (fixture trees)
@@ -220,7 +220,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # The post-suite working-tree hygiene check needs Python 3.11+ (tomllib);
       # the Windows runner's default python is older, so set it up explicitly.
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -391,7 +391,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # The post-suite working-tree hygiene check needs Python 3.11+ (tomllib);
       # the Windows runner's default python is older, so set it up explicitly.
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
@@ -694,7 +694,7 @@ jobs:
           save-if: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
## What and why

`actionlint` reports exactly five findings on this repository, and all five are the same one:

```
.github/workflows/ci.yml:49:15:  the runner of "actions/setup-python@v4" action is too old
.github/workflows/ci.yml:223:15: ... to run on GitHub Actions. update the action's version
.github/workflows/ci.yml:394:15:
.github/workflows/ci.yml:697:15:
.github/workflows/versioning.yml:28:15:
```

`actions/setup-python@v4` runs on the node16 runner. This is a warning today, not a failure, but it is the kind of deprecation GitHub eventually force-migrates and then drops — at which point it turns into a red `fmt`/`bump-version`/`database-tests` lane rather than a warning. This was flagged as a deferred item during the 2026-08-14 CI outage triage with the explicit condition "worth bumping to @v5 when CI can verify again". CI can verify again, so here it is.

**After this change `actionlint` reports zero findings on the repository.**

## Why v5 and not v7

`actions/setup-python` is currently at v7.0.0, so v5 is not the newest. That is deliberate:

- **v5.0.0** is a runner-only release: node16 → node20, no input changes, no behaviour changes. All five call sites here pass nothing but `python-version`, so this is genuinely mechanical.
- **v6.0.0** moves to node24 and states: *"Make sure your runner is on version v2.327.1 or later to ensure compatibility with this release."* Every job in this repo runs on a **Blacksmith** runner (`blacksmith-*-ubuntu-2404`, `blacksmith-*-windows-2025`), and I cannot verify the Blacksmith agent version from the workflow side.
- **v7.0.0** additionally migrates to ESM and removes the `pip-install` input (unused here).

Jumping three majors to pick up features this repo does not use, while introducing an unverifiable runner-version dependency, is a worse trade than clearing the actual deprecation. **Going to v6/v7 is a reasonable follow-up once someone confirms the Blacksmith agent version** — happy to do that as a separate PR.

## Changes

Five `uses:` lines, two files, nothing else:

| file | lines |
|---|---|
| `.github/workflows/ci.yml` | 49, 223, 394, 697 |
| `.github/workflows/versioning.yml` | 28 |

The two `python-version: '3.12'` pins (ci.yml:225, :396) that exist because the Windows runner's default python predates `tomllib` are untouched and still needed.

## Test evidence

- **Risk class:** R0 — build-infrastructure only. Changes no shipped artifact, no source file, no test. The action version affects only how Python is provisioned on the runner.
- **Acceptance criteria → tests:** all five Python-using jobs still provision Python and pass. Those jobs are the test; per the testing policy, pure CI mechanics do not need a manufactured failing test, and the existing checks *are* the Red→Green evidence here.
- **Red evidence:** `actionlint -no-color` on `main` @ `36de4fa7` → 5 findings (quoted above). Same command on this branch → 0 findings.
- **Unit/component:** n/a — no source change.
- **Integration/contract:** covered by CI on this PR. The five affected jobs are `checker-unit-tests` (ci.yml:43), the two `integration-tests` matrix lanes (ci.yml:211, :386), `bump-version` (ci.yml:666), and `versioning.yml`'s bump job. Note the two integration lanes run the working-tree hygiene check that specifically needs Python 3.11+, so they exercise the pinned-version path, not just the `'3.x'` path.
- **End-to-end:** n/a.
- **Coverage:** unchanged.
- **Platforms:** both — the matrix lanes cover `blacksmith-4vcpu-ubuntu-2404` and `blacksmith-4vcpu-windows-2025`, so the bump is validated on Linux and Windows.
- **Not applicable, with reason:** no security/migration/concurrency/performance surface; this does not touch runtime code.
- **Rollback/recovery:** revert the commit. No state, no artifacts, no migration.
- **Residual risk:** low but not zero, and worth stating plainly — I could not run `scripts/check_repo_hygiene.py` locally because this sandbox has Python 3.10 and the checker requires 3.11+ (`tomllib`). CI runs it on both integration lanes. A workflow `uses:` bump has no path to affect repo-hygiene results, but I did not prove that locally. **Please confirm the hygiene lane is green before merging.**

Not merging — warden branches always go back through review.

*Opened by the WFL repo warden (automated triage pass).*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to use the latest supported Python setup action.
  * Improved reliability and maintenance of repository checks, integration tests, and versioning tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->