### PR TITLE
ci(nightly): drop the musl linker override so rustc keeps the link (#683)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -465,8 +465,19 @@ jobs:
     timeout-minutes: 60
     env:
       TARGET: x86_64-unknown-linux-musl
+      # cc-rs needs this so aws-lc-sys' C and assembly compile for the musl
+      # target. It is deliberately NOT paired with a matching
+      # CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER. That variable would hand
+      # the link to musl-gcc - a spec-file wrapper around the host gcc whose
+      # specs select musl's DYNAMIC loader - so the build silently emits a
+      # binary carrying a PT_INTERP segment, and `-C target-feature=+crt-static`
+      # cannot win the link back once musl-gcc is driving it. Rust's
+      # x86_64-unknown-linux-musl target ships its own self-contained musl and
+      # static-links by default, so the correct move is to leave the link to
+      # rustc rather than take it away. Dropping that override is wfl#683; the
+      # regression it prevents is wfl#616 reappearing. The `Assert the binaries
+      # are statically linked` step below is what proves this held.
       CC_x86_64_unknown_linux_musl: musl-gcc
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
       # Matches the BUILD_INFO the old wflbuild tarballs carried: no debug
       # symbols in the shipped artifact. Also keeps target/ far below the ~30 GB
       # ceiling CLAUDE.md warns about, so no disk-space dance is needed here.


### PR DESCRIPTION
Fixes #683.

`nightly.yml`'s `build-linux` job sets both `CC_x86_64_unknown_linux_musl` and `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER` to `musl-gcc`. The second is unnecessary and actively harmful: `musl-gcc` is a spec-file wrapper around the host `gcc`, and its specs select musl's **dynamic** loader. On an image where that holds, the job silently produces a binary with a `PT_INTERP` segment while still going green — the exact condition #616 was closed to prevent — and `-C target-feature=+crt-static` cannot win the link back once `musl-gcc` is driving it.

Rust's `x86_64-unknown-linux-musl` target ships its own self-contained musl libc and static-links by default, so **removing the override moves the build toward rustc's default rather than away from it.**

## What changed

One deleted line, plus a comment recording why the pairing must not come back.

```diff
       TARGET: x86_64-unknown-linux-musl
       CC_x86_64_unknown_linux_musl: musl-gcc
-      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: musl-gcc
```

`CC_` is kept deliberately — `cc-rs` needs it to compile `aws-lc-sys`' C and assembly for the musl target, and that is the one dependency in the graph with a musl story to get wrong.

## Deliberately *not* included

The issue also floats adding `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUSTFLAGS: "-C target-feature=+crt-static"`. I left it out. It is redundant with the target default, and it introduces a second rustflags source that has to union correctly with the `cfg(target_os = "linux")` block in `.cargo/config.toml` carrying the 8 MB `stack-size` link-arg the parser depends on. The issue author verified that union empirically, but it turns a pure deletion into a change with a non-obvious interaction, and the parser's stack budget is not worth risking for redundancy. The comment states the intent instead. Happy to add it if you'd rather have it explicit.

## Risk and verification

**Risk class R0 — CI mechanics, no behavioural change to the language.** No `src/` change, no `TestPrograms/` exposure, no version touched. Per `testing.md` this needs no manufactured failing test: the existing check *is* the test.

Verified locally:

- `actionlint` 1.7.7 on `nightly.yml`: **zero findings**, identical to `main` before the change.
- YAML parses; `build-linux.env` now resolves to exactly `{TARGET, CC_x86_64_unknown_linux_musl, CARGO_PROFILE_RELEASE_DEBUG}`.
- No `MUSL_LINKER` reference remains anywhere in the tree outside the explanatory comment.

**What I could not verify, stated plainly:** `build-linux` runs **only** in `nightly.yml`, and there is no PR-triggered musl lane — `.github/workflows/verify-linux-musl.yml` is registered but absent from the tree. So PR CI cannot exercise this job, and the authoritative proof is the `Assert the binaries are statically linked` step (`PT_INTERP` absence on both `wfl` and `wfl-lsp`) on the **first full nightly after merge**. That step is unchanged and is the correct detector.

I did *not* try to prove it by dispatching `nightly.yml` from this branch, because the `release` job is guarded only by `should_build == 'true'` with no `github.ref` condition — it holds `contents: write` and read-modify-writes the nightly release plus the Spaces rolling pointers, `SHA256SUMS` and `status.json`. A branch dispatch would have published unmerged artifacts over the real nightly. That gap is written up in #683 and deserves its own fix.

Since the next nightly is the verification, it is worth a glance at tomorrow's `build-linux` log after this merges. If `PT_INTERP` ever *does* appear, the assertion fails loudly and this is trivially revertible.

*Opened by the WFL repo warden (automated maintenance pass). Not merged by me — CI and a human decide.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux musl build configuration for more reliable compilation.
  * Configured the C compiler without overriding Rust’s default musl linker behavior.
  * Reduced the risk of build failures when compiling Linux musl targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->