### PR TITLE
fix(ci): package the Linux tarball reproducibly so a nightly can be re-run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -550,17 +550,39 @@ jobs:
           cp "target/$TARGET/release/wfl-lsp" "dist/$DIR/wfl-lsp"
           strip "dist/$DIR/wfl" "dist/$DIR/wfl-lsp"
           cp README.md LICENSE "dist/$DIR/"
+
+          # publish_spaces.sh treats versioned keys as immutable: identical bytes
+          # are a no-op and different bytes abort the publish, which is what lets
+          # a publish that half-landed be repaired by re-running the nightly.
+          # That contract only holds if the same commit packages to the same
+          # bytes, so everything below that would otherwise vary run to run is
+          # pinned to the commit rather than to the wall clock:
+          #
+          #   - BUILD_INFO's `built:` is the commit's own committer date. It is
+          #     still the moment this artifact corresponds to, and unlike
+          #     `date -u` it does not change when the same commit is rebuilt.
+          #   - --sort=name fixes member order, which otherwise follows
+          #     directory-read order and reshuffles between runs.
+          #   - --mtime pins the header timestamps, which otherwise record when
+          #     `cp` happened.
+          #   - --owner/--group/--numeric-owner drop the runner's uid/gid names.
+          #
+          # gzip already records MTIME=0 here because tar -z compresses a pipe.
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct HEAD)"
           cat > "dist/$DIR/BUILD_INFO" <<EOF
           wfl ${VERSION}
           commit:   ${{ github.sha }}
           branch:   ${{ github.ref_name }}
-          built:    $(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+          built:    $(date -u -d "@$SOURCE_DATE_EPOCH" +%Y-%m-%dT%H:%M:%S+00:00)
           builder:  GitHub Actions / Blacksmith (x86_64-unknown-linux-musl)
           rustc:    $(rustc --version)
           contents: wfl, wfl-lsp
           note:     statically linked against musl - no glibc floor (wfl#616)
           EOF
-          tar czf "dist/${DIR}-${SHORT_SHA}.tar.gz" -C dist "$DIR"
+          tar --sort=name \
+              --mtime="@$SOURCE_DATE_EPOCH" \
+              --owner=0 --group=0 --numeric-owner \
+              -czf "dist/${DIR}-${SHORT_SHA}.tar.gz" -C dist "$DIR"
           ls -la "dist/${DIR}-${SHORT_SHA}.tar.gz"
 
       # The real boundary test, not a proxy for it, and it runs *after* packaging

--- a/Docs/02-getting-started/installation.md
+++ b/Docs/02-getting-started/installation.md
@@ -149,7 +149,7 @@ This creates a `wfl-<version>-linux-x86_64/` directory containing:
 - `wfl` - the WFL compiler and runtime
 - `wfl-lsp` - the Language Server, for editor integration
 - `README.md`, `LICENSE`
-- `BUILD_INFO` - version, commit, build time, and target triple
+- `BUILD_INFO` - version, commit, commit date, and target triple
 
 ### Step 3: Install
 


### PR DESCRIPTION
## What broke

`scripts/publish_spaces.sh` treats versioned release keys as immutable, and says so deliberately (lines ~135-150):

> identical bytes are a no-op, different bytes abort the publish, and only genuinely new keys are written. **A retry after a partial failure therefore completes** rather than trips over the objects the previous attempt already landed.

The Linux tarball could never reach the "identical bytes are a no-op" path. Packaging the same commit twice produced different bytes in three independent ways — none of them the compiled output:

| source of drift | why |
|---|---|
| `BUILD_INFO` `built:` | recorded `date -u`, i.e. the wall clock |
| tar member mtimes | `tar czf` stores each member's mtime, i.e. when `cp` ran |
| tar member order | followed directory-read order, which reshuffles between runs |

So a rebuild of an already-published version+sha aborts the publish — and because `Tag commit for nightly` and `Publish or update nightly release` are later steps in the same job, it takes the tag and the GitHub release with it. Re-running a nightly, which is both the standard remediation for a flaky nightly and the documented way to verify a nightly-only change, was structurally impossible once that version had published.

## How it surfaced

`main` has not moved since 2026-08-14, so the last five scheduled nightlies were all designed no-change skips. I dispatched a full nightly from `main` to confirm the tree still really builds ([run 32235610626](https://github.com/WebFirstLanguage/wfl/actions/runs/32235610626)). Both build jobs went green — Windows fmt/clippy/build/tests/LSP/VSIX/MSI/smoke, and Linux musl including `Assert the binaries are statically linked` and the Debian 12 portability gate. The release job then failed:

```
refusing to overwrite releases/wfl-26.8.8-linux-x86_64-36de4fa.tar.gz:
it is already published with different bytes
(published bfaa9c33..., built 35653452...).
```

It failed **safely** — nothing was overwritten, no tag or release was created.

## Root cause, verified

I pulled both tarballs (the 2026-08-15 publish and today's rebuild of the same commit) and compared them:

- `wfl` — `d8838658aebe59e7...` in **both**
- `wfl-lsp` — `7782faaba7b89972...` in **both**
- the **only** content difference in the entire archive is one line of `BUILD_INFO`:

```diff
-built:    2026-08-15T05:11:32+00:00
+built:    2026-08-19T09:04:43+00:00
```

The build is already reproducible. Only the packaging was not.

## The fix

Derive a `SOURCE_DATE_EPOCH` from the commit's committer date, use it for both `BUILD_INFO`'s `built:` and tar's `--mtime`, and add `--sort=name --owner=0 --group=0 --numeric-owner`. gzip already records `MTIME=0`, because `tar -z` compresses a pipe.

**The one judgement call:** `built:` now means the commit's date rather than the moment the runner happened to package it. It is the field that has to become commit-derived for the artifact to be stable, and `commit:` plus the version already identify the build uniquely. `Docs/02-getting-started/installation.md` is updated to match. Say the word if you'd rather drop the field entirely than change what it means.

## Verification (§15 evidence)

**Risk class R0** — CI mechanics, no runtime behaviour changes, no `TestPrograms/` surface touched.

Red→Green was measured directly rather than asserted: I packaged the identical binaries twice, seconds apart, under each recipe.

```
### current recipe, two runs 3s apart
ead51b15a6e5ca09cc3898b0281d608891a5d300cd0cf691f558209adc62ed30
fc9773cbe3909b7e08d97538f1d60ad0860ec138409896805a45465d290b5def
  => NOT REPRODUCIBLE

### this PR's recipe, two runs 3s apart
3e18d8356d93abf5d7c3cb22053b003bda3479edb96c81a0fb88382e4a0fc631
3e18d8356d93abf5d7c3cb22053b003bda3479edb96c81a0fb88382e4a0fc631
  => REPRODUCIBLE
```

`actionlint` is clean on `nightly.yml`. GNU tar 1.34 accepts every flag used.

The end-to-end proof needs a nightly that publishes, which needs `main` to move — the same verification-gap shape as #683/#717. Once this and #717 are in, the next scheduled nightly exercises both.

## Related

Adjacent to the unguarded-release-job hazard noted on #683 (the `release` job has no `github.ref == 'refs/heads/main'` condition). This PR does not touch that — guarding a publishing job is a policy call, not CI mechanics.

---
*Posted by the WFL repo warden (automated triage pass).*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/718" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Linux release archives are now reproducible, with consistent file ordering, timestamps, and ownership metadata.
  - Build information now reports the commit date consistently.

- **Documentation**
  - Updated Linux installation guidance to clarify that `BUILD_INFO` contains the commit date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->