### PR TITLE
fix(stdlib): use as_chunks in hex_to_bytes to unbreak clippy on Rust 1.98

### DIFF
--- a/src/stdlib/crypto.rs
+++ b/src/stdlib/crypto.rs
@@ -1045,8 +1045,14 @@ fn hex_to_bytes(hex: &str) -> Option<Vec<u8>> {
     if !bytes.len().is_multiple_of(2) {
         return None;
     }
+    // The length guard above makes the remainder half of `as_chunks` always
+    // empty, so discarding it drops nothing. `as_chunks::<2>` is preferred over
+    // `chunks_exact(2)` because the constant chunk size is carried in the type:
+    // each pair arrives as `&[u8; 2]` rather than a runtime-length slice.
     bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|pair| {
             // Rejects any non-ASCII byte: hex is ASCII by definition.
             let text = std::str::from_utf8(pair).ok()?;


### PR DESCRIPTION
## Summary

The nightly build and CI on `main` are both red. This is a one-line fix for a single new clippy lint.

**Root cause: toolchain drift, not a code regression.** Rust **1.98.0** shipped on 2026-08-18 and promoted `clippy::chunks_exact_to_as_chunks` into the default lint set. Both CI lanes pin `dtolnay/rust-toolchain@stable` and run clippy with `-D warnings`, so the single `chunks_exact(2)` call in `src/stdlib/crypto.rs` (`hex_to_bytes`) turned into a hard compile error the moment either lane next ran.

Failing runs:

- Nightly Build [33235732094](https://github.com/WebFirstLanguage/wfl/actions/runs/33235732094) — `Build WFL for Windows` failed at step 8 `Run clippy` after 93s; `Create or Update Nightly Release` skipped, so **no nightly artifacts were published for 2026-08-29**.
- CI [33173832824](https://github.com/WebFirstLanguage/wfl/actions/runs/33173832824) (push to `main`) and [33173861966](https://github.com/WebFirstLanguage/wfl/actions/runs/33173861966) — `Build, Test, Clippy` failed at `Run Clippy`, same lint.

```
error: using `chunks_exact` with a constant chunk size
    --> src/stdlib/crypto.rs:1049:10
     = note: `-D clippy::chunks-exact-to-as-chunks` implied by `-D warnings`
```

### Why it surfaced only now

`main` did not move between 2026-08-14 and 2026-08-28. Every scheduled nightly in that window took the designed `should_build=false` no-change skip, so clippy did not actually execute against the tree after Rust 1.98 landed on 08-18. Merging #718 on 08-28 was simply the first thing to exercise the lint. **The repo read green for ten days while already being broken** — worth a look separately from this PR (see below).

## What changed

`src/stdlib/crypto.rs` only — `chunks_exact(2)` → `as_chunks::<2>().0.iter()`, plus a comment explaining why discarding the remainder half is sound.

**No behaviour change.** The `is_multiple_of(2)` guard directly above already rejects odd-length input, so `as_chunks::<2>()`'s remainder is always empty and discarding it drops nothing. Each pair now arrives as `&[u8; 2]` rather than a runtime-length slice — decoding stays byte-oriented, so the multi-byte-safety property the doc comment describes is untouched.

`slice::as_chunks` is stable since **1.88.0**, comfortably under the crate's `rust-version = "1.94"` MSRV (verified against the 1.98.0 stdlib source, not from memory).

## Verification

Run locally on **rustc 1.98.0 (88d9e12ae 2026-08-18)** — the same toolchain `@stable` resolves to in CI. Reproduced the failure first, then confirmed the fix:

| Check | Result |
|---|---|
| `cargo clippy --lib -- -D warnings` (pre-fix) | reproduced the exact CI error |
| `cargo clippy --all-targets --all-features -- -D warnings` | **exit 0** — matches the `ci.yml` gate verbatim |
| `cargo fmt --all -- --check` | clean |
| `cargo test --lib` | **690 passed**, 0 failed, 6 ignored |

Because `hex_to_bytes` decodes untrusted key material, I also proved the two implementations are observably identical rather than assuming it: a differential harness compared old vs. new over **18,327 inputs** — every valid 1- and 2-byte UTF-8 string, plus multi-byte characters (`é`, `日本`, `a日`), odd lengths, empty input, non-hex bytes, embedded NULs, and 64-byte keys. Zero mismatches.

Per `testing.md` §risk classes this is R0 CI mechanics: the existing clippy gate is the failing-first test, so no manufactured Red→Green test is included. The differential harness was verification scaffolding and is deliberately not committed.

## Not fixed here, worth deciding

A no-change nightly skip means a **toolchain-drift break stays invisible until someone merges**. A cheap mitigation would be having the nightly still run fmt/clippy/test when `should_build=false`, and only skip the expensive packaging and release steps — that would have caught this on 08-19 instead of 08-29. Happy to open that separately if you want it; I did not bundle a workflow change into a lint fix.

---

*Posted by the WFL repo warden (automated triage pass). I do not merge — this needs a human.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of hexadecimal string decoding while preserving existing behavior.
  * Added validation to ensure hexadecimal input has an even number of characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->