### PR TITLE
fix(ci): allow the cursor bot to trigger Claude Code Review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,10 +36,14 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Allow review of PRs opened by github-actions[bot], such as the
-          # monthly SECURITY.md rotation. Without this the job fails with
-          # "Workflow initiated by non-human actor".
-          allowed_bots: 'github-actions'
+          # Allow review of PRs opened or pushed by trusted bot actors.
+          # Without this the job fails with "Workflow initiated by non-human
+          # actor". github-actions covers the monthly SECURITY.md rotation;
+          # cursor covers the Cursor cloud agent, which pushes to cursor/*
+          # branches on our own PRs. The review prompt below is fixed by this
+          # workflow, so an allowed bot cannot influence what Claude is asked
+          # to do -- it only gets the same code review a human push would.
+          allowed_bots: 'github-actions,cursor'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## What was broken

Every push to a PR made by the **Cursor cloud agent** fails the `claude-review` job.

Most recent instance: [run 33315392206](https://github.com/WebFirstLanguage/wfl/actions/runs/33315392206) on `cursor/setup-cloud-agent-env-2b67` (PR #720), which failed in 1.6s with:

```
##[error]Action failed with error: Workflow initiated by non-human actor: cursor (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

This is not a flake and not a missing secret. The same branch went **green** at 13:15 and 13:36 and **red** at 13:53 — the only difference is the triggering actor:

| Run | Time (UTC) | `triggering_actor` | Result |
|---|---|---|---|
| 33313705518 | 13:15 | `logbie` | success |
| 33314646506 | 13:36 | `logbie` | success |
| 33315392206 | 13:53 | `cursor[bot]` | **failure** |
| 33316533966 | 14:19 | `logbie` | success |

So the job fails precisely when the Cursor agent itself pushes, and passes when a human pushes the same branch. As we use Cursor cloud agents more, this becomes a permanent red X on our own PRs — noise that trains us to ignore a review check.

## Root cause

`anthropics/claude-code-action@v1` refuses non-`User` actors unless they are named in `allowed_bots` (`src/github/validation/actor.ts` → `checkHumanActor` / `isAllowedBot`). Our workflow sets `allowed_bots: 'github-actions'`, which was added for exactly this failure mode when the monthly SECURITY.md rotation PR hit it. `cursor[bot]` was never added.

## The fix

One-line list extension: `allowed_bots: 'github-actions'` → `'github-actions,cursor'`.

The action lowercases each entry and strips a trailing `[bot]` on both sides before comparing, so the bare `cursor` form is correct and matches the existing `github-actions` style. This is the same remedy, from the same list, that already fixed the same error for `github-actions`.

## Security note — please make this call deliberately, it is not routine plumbing

`allowed_bots` is a security control, so I want to be explicit rather than slip this through as CI cleanup:

- This adds **one named bot**, not `'*'`. The action's own docs warn that `'*'` on a public repo can let external Apps invoke the action with prompts they control; that risk is not taken here.
- Our `prompt:` is **fixed by the workflow** (`/code-review:code-review ${{ github.repository }}/pull/...`), so an allowed bot cannot steer what Claude is asked to do. It gets the same code review a human push would.
- Job permissions are unchanged and read-only apart from `id-token: write`.
- The residual exposure is that a PR whose head branch is pushed by `cursor[bot]` now gets reviewed rather than refused. That is the intended behaviour, but it is your integration and your judgement call — if you would rather gate the job off bot actors entirely (`if: github.actor != 'cursor[bot]'`), say so and I will send that instead.

## Verification

- `allowed_bots` semantics confirmed by reading `action.yml` (`"Comma-separated list of allowed bot usernames"`) and the matching logic in `src/github/validation/actor.ts` and `permissions.ts` in `anthropics/claude-code-action`.
- Failure signature and per-run `triggering_actor` values read from the Actions REST API (table above).
- Workflow file re-parsed with `yaml.safe_load` after the edit; `runs-on: blacksmith-4vcpu-ubuntu-2404` unchanged and still present in `.github/actionlint.yaml`.
- No Rust source touched, so the presubmit build/test block is not implicated. I could not run `cargo` in this sandbox; nothing in this change requires it.

## Test evidence

- **Risk class:** R3. This is a workflow change to a security allow-list governing an untrusted-input boundary, and the conventions say ambiguous classification takes the higher class. R3's independent-review requirement is satisfied by this PR being human-reviewed and human-merged.
- **Acceptance criteria → tests:** a `claude-review` run whose `triggering_actor` is `cursor[bot]` completes instead of exiting 1 at the actor gate. The check is only observable in CI on a Cursor-pushed PR — there is no local harness for it.
- **Red evidence:** [run 33315392206](https://github.com/WebFirstLanguage/wfl/actions/runs/33315392206), a real timestamped CI failure on current `main`'s workflow, with the exact error above. Not manufactured.
- **Unit/component:** n/a — no repo code changed.
- **Integration/contract:** n/a.
- **End-to-end:** deferred to the next Cursor-authored push after merge. Please watch the first one.
- **Security:** analysed above — single named bot, fixed prompt, unchanged permissions, `'*'` deliberately avoided.
- **Coverage / platforms:** n/a; GitHub-hosted workflow config.
- **Not applicable, with reason:** no `TestPrograms/` or language-behaviour surface is touched, so backward compatibility is not in play.
- **Rollback/recovery:** revert this one-line commit; behaviour returns to today's (Cursor pushes fail the review job).
- **Residual risk:** low but non-zero, and it is a posture choice rather than a defect fix — see the security note.

---

*Opened by the WFL repo warden (automated triage pass). I do not merge — this is for a human to review and decide.*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/webfirstlanguage/wfl/pull/722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated pull request review coverage for changes created by supported automation tools.
  - Clarified the review workflow documentation while preserving the existing review criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->